### PR TITLE
Use consistent versions for Commons Collections 4 and Google Protocol Buffers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -182,6 +182,8 @@ allprojects {
                     force "commons-collections:commons-collections:${commonsCollectionsVersion}"
                     // force version for ms2, saml, fileTransfer, harvest, scrumtime, api, accounts, docker
                     force "commons-codec:commons-codec:${commonsCodecVersion}"
+                    // force version consistency in OmeroIntegration, API, probably many more
+                    force "org.apache.commons:commons-collections4:${commonsCollections4Version}"
                     // force version consistency in TCRdb, SequenceAnalysis, API
                     force "org.apache.commons:commons-math3:${commonsMath3Version}"
                     // force version for api, accounts, fileTransfer, harvest, scrumtime, docker
@@ -206,6 +208,8 @@ allprojects {
                         force "xml-apis:xml-apis:${xmlApisVersion}"
                     // cloud and SequenceAnalysis bring this in as a transitive dependency.  We resolve to the later version here to keep things consistent
                     force "com.google.code.gson:gson:${gsonVersion}"
+                    // TargetedMS uses this directly, and OmeroIntegration brings this in as a transitive dependency
+                    force "com.google.protobuf:protobuf-java:${googleProtocolBufVersion}"
                     // workflow (Activiti) brings in older versions of these libraries, so we need to force these versions
                     force "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
                     force "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -134,6 +134,7 @@ googleApiServicesCalendarVersion=v3-rev255-1.23.0
 googleApiClientVersion=1.23.0
 googleHttpClientVersion=1.23.0
 googleOauthClientVersion=1.23.0
+googleProtocolBufVersion=3.12.2
 
 graalVersion=20.0.0
 


### PR DESCRIPTION
#### Rationale
We don't want conflicting versions of libraries across modules.

https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Premium_VerifyDependencies/1145949?

#### Related Pull Requests
* https://github.com/LabKey/DiscvrLabKeyModules/pull/65

#### Changes
* Consolidate on Commons Collections 4.2 and Google Protocol Buffers 3.12.2