### PR TITLE
bump LabKey version number to 20.12-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,7 @@ buildFromSource=true
 
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
-labkeyVersion=20.11-SNAPSHOT
+labkeyVersion=20.12-SNAPSHOT
 labkeyClientApiVersion=1.3.1
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.


### PR DESCRIPTION
#### Rationale
To prepare for the 20.11 release we are creating the 20.11-SNAPSHOT branch and will be bumping develop to 20.12-SNAPSHOT.