### PR TITLE
Gradle 6.7 and gradlePluginsVersion 1.21.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -45,7 +45,7 @@ windowsProteomicsBinariesVersion=1.0
 bintrayPluginVersion=1.8.4
 artifactoryPluginVersion=4.13.0
 gradleNodePluginVersion=2.2.4
-gradlePluginsVersion=1.20.0
+gradlePluginsVersion=1.21.1
 owaspDependencyCheckPluginVersion=5.2.1
 versioningPluginVersion=1.0.2
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
#### Rationale
Gradle 6.7 officially supports Java 15.  Gradle 6.7 seems to have introduced a timing bug having to do with the resolution of configurations within an ant copy task.  This manifests only on TeamCity, but causes the pickMssql task to fail there almost always, so we need a gradle plugins update to address this 

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/100


