### PR TITLE
Update gradle versioning plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,11 +86,6 @@ allprojects {
     if (project.hasProperty('includeVcs'))
     {
         apply plugin: 'org.labkey.versioning'
-        versioning
-                {
-                    user = project.hasProperty('svn_user') ? project.property('svn_user') : 'cpas'
-                    password = project.hasProperty('svn_password') ? project.property('svn_password') : 'cpas'
-                }
     }
 
     apply plugin: 'org.labkey.base'

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         maven {
             url "${artifactory_contextUrl}/plugins-release"
         }
-        if (gradlePluginsVersion.contains("SNAPSHOT"))
+        if (gradlePluginsVersion.contains("SNAPSHOT") || versioningPluginVersion.contains("SNAPSHOT"))
         {
             maven {
                 url "${artifactory_contextUrl}/plugins-snapshot-local"

--- a/gradle.properties
+++ b/gradle.properties
@@ -47,7 +47,7 @@ artifactoryPluginVersion=4.13.0
 gradleNodePluginVersion=2.2.4
 gradlePluginsVersion=1.21.1
 owaspDependencyCheckPluginVersion=5.2.1
-versioningPluginVersion=1.0.3-SNAPSHOT
+versioningPluginVersion=1.1.0
 
 # Versions of node and npm to use during the build. If set, these versions
 # will be downloaded and used. If not set, the existing local installations will be use

--- a/gradle.properties
+++ b/gradle.properties
@@ -47,7 +47,7 @@ artifactoryPluginVersion=4.13.0
 gradleNodePluginVersion=2.2.4
 gradlePluginsVersion=1.21.1
 owaspDependencyCheckPluginVersion=5.2.1
-versioningPluginVersion=1.0.2
+versioningPluginVersion=1.0.3-SNAPSHOT
 
 # Versions of node and npm to use during the build. If set, these versions
 # will be downloaded and used. If not set, the existing local installations will be use


### PR DESCRIPTION
#### Rationale
Since migrating fully to git, VCS information is not getting populated in many modules' `module.xml` files. I've updated the versioning plugin to work properly with our new structure.

#### Related Pull Requests
* https://github.com/LabKey/versioning/pull/2

#### Changes
* Use updated versioning plugin
* Support using SNAPSHOT releases of versioning plugin
