### PR TITLE
Use Gradle Plugin DSL for applying plugins and specifying versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ plugins {
     id "com.github.node-gradle.node" version "${gradleNodePluginVersion}" apply false
     id "org.owasp.dependencycheck" version "${owaspDependencyCheckPluginVersion}" apply false
 //    id "com.github.ben-manes.versions" version "0.33.0"
+    id "org.labkey.build.multiGit"
 }
 
 allprojects {
@@ -60,7 +61,6 @@ String tomcatDirProp = System.getenv('CATALINA_HOME') != null ? System.getenv('C
 if (tomcatDirProp != null && !new File(tomcatDirProp).exists())
     throw new GradleException("Tomcat home directory ${tomcatDirProp} does not exist.")
 
-apply plugin: 'org.labkey.multiGit'
 allprojects {
     // this configuration is needed only in server and testAutomation, but we leave it here (for now) to avoid duplication
     configurations
@@ -83,14 +83,17 @@ allprojects {
                 }
             }
 
+    // TODO move to base or FileModule?
     if (project.hasProperty('includeVcs'))
     {
         apply plugin: 'org.labkey.versioning'
     }
 
-    apply plugin: 'org.labkey.base'
-    group  'org.labkey'
-    version BuildUtils.getVersionNumber(project)
+    // We apply the base module here so we get the configurations (in particular external and modules)
+    // that can be used for the allDepInsight task below.  I would really prefer not to do this here, but
+    // we'll need to find another solution for allDepInsight (perhaps enumerate projects?)
+    apply plugin: 'org.labkey.build.base'
+
 
     tasks.withType(JavaCompile)
             {
@@ -284,7 +287,7 @@ if (BuildUtils.shouldPublish(project) || BuildUtils.shouldPublishDistribution(pr
 
 subprojects {
     task("showRepos", group: "Help", description: "Show the list of repositories currently in use.").doLast({
-        repositories.each{
+        repositories.each {
             println "repository: ${it.name} (${it.hasProperty("url") ? it.url : it.getDirs()})"
         }
     })

--- a/build.gradle
+++ b/build.gradle
@@ -95,12 +95,6 @@ allprojects {
                 targetCompatibility = project.ext.targetCompatibility
             }
 
-    ext
-            {
-                vcsRevision = BuildUtils.getStandardVCSProperties(project).getProperty("VcsRevision")
-                installerVersion = "${project.version}-${vcsRevision}"
-            }
-
     repositories
             {
                 // this if statement is necessary because the TeamCity artifactory plugin overrides

--- a/build.gradle
+++ b/build.gradle
@@ -83,12 +83,6 @@ allprojects {
                 }
             }
 
-    // TODO move to base or FileModule?
-    if (project.hasProperty('includeVcs'))
-    {
-        apply plugin: 'org.labkey.versioning'
-    }
-
     // We apply the base module here so we get the configurations (in particular external and modules)
     // that can be used for the allDepInsight task below.  I would really prefer not to do this here, but
     // we'll need to find another solution for allDepInsight (perhaps enumerate projects?)
@@ -106,6 +100,7 @@ allprojects {
                 vcsRevision = BuildUtils.getStandardVCSProperties(project).getProperty("VcsRevision")
                 installerVersion = "${project.version}-${vcsRevision}"
             }
+
     repositories
             {
                 // this if statement is necessary because the TeamCity artifactory plugin overrides

--- a/gradle.properties
+++ b/gradle.properties
@@ -50,7 +50,7 @@ windowsProteomicsBinariesVersion=1.0
 bintrayPluginVersion=1.8.4
 artifactoryPluginVersion=4.13.0
 gradleNodePluginVersion=2.2.4
-gradlePluginsVersion=1.21.1
+gradlePluginsVersion=1.22.0-modernizePublishing-SNAPSHOT
 owaspDependencyCheckPluginVersion=5.2.1
 versioningPluginVersion=1.1.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -50,7 +50,7 @@ windowsProteomicsBinariesVersion=1.0
 bintrayPluginVersion=1.8.4
 artifactoryPluginVersion=4.13.0
 gradleNodePluginVersion=2.2.4
-gradlePluginsVersion=1.22.0-modernizePublishing-SNAPSHOT
+gradlePluginsVersion=1.22.0
 owaspDependencyCheckPluginVersion=5.2.1
 versioningPluginVersion=1.1.0
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -6,6 +6,16 @@ import org.labkey.gradle.plugin.XsdDoc
 import org.labkey.gradle.plugin.JsDoc
 import org.apache.commons.lang3.SystemUtils
 
+plugins {
+    id 'maven-publish'
+    id 'org.labkey.build.jsdoc'
+    id 'org.labkey.build.xsddoc'
+    id 'org.labkey.build.npmRun'
+    id 'org.labkey.build.tomcat'
+    id 'org.labkey.build.serverDeploy'
+    id 'org.labkey.build.database'
+}
+
 BuildUtils.addLabKeyDependency(project: project, config: 'tomcatJars', depProjectPath: BuildUtils.getBootstrapProjectPath(gradle))
 dependencies
         {
@@ -14,11 +24,6 @@ dependencies
 
             remotePipelineJars "javax.servlet:servlet-api:${servletApiVersion}"
         }
-
-apply plugin: 'maven-publish'
-apply plugin: 'org.labkey.jsdoc'
-apply plugin: 'org.labkey.xsddoc'
-apply plugin: 'org.labkey.npmRun'
 
 dependencies
 {
@@ -49,10 +54,6 @@ if (!project.hasProperty('excludeProteomicsBinaries'))
         }
     }
 }
-
-apply plugin: 'org.labkey.tomcat'
-apply plugin: 'org.labkey.serverDeploy'
-apply plugin: 'org.labkey.database'
 
 // This a subset of the XSDs because dependencies get pulled in.
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,34 @@
 
+pluginManagement {
+    repositories {
+        maven {
+            url "${artifactory_contextUrl}/plugins-release"
+        }
+        if (gradlePluginsVersion.contains("SNAPSHOT") || versioningPluginVersion.contains("SNAPSHOT")) {
+            maven {
+                url "${artifactory_contextUrl}/plugins-snapshot-local"
+            }
+        }
+    }
+    plugins {
+        id 'org.labkey.build.antlr' version "${gradlePluginsVersion}" apply false
+        id 'org.labkey.build.api' version "${gradlePluginsVersion}" apply false
+        id 'org.labkey.build.base' version "${gradlePluginsVersion}" apply false
+        id 'org.labkey.build.distribution' version "${gradlePluginsVersion}" apply false
+        id 'org.labkey.build.fileModule' version "${gradlePluginsVersion}" apply false
+        id 'org.labkey.build.javaModule' version "${gradlePluginsVersion}" apply false
+        id 'org.labkey.build.jsdoc' version "${gradlePluginsVersion}" apply false
+        id 'org.labkey.build.module' version "${gradlePluginsVersion}" apply false
+        id 'org.labkey.build.multiGit' version "${gradlePluginsVersion}" apply false
+        id 'org.labkey.build.npmRun' version "${gradlePluginsVersion}" apply false
+        id 'org.labkey.build.serverDeploy' version "${gradlePluginsVersion}" apply false
+        id 'org.labkey.build.teamCity' version "${gradlePluginsVersion}" apply false
+        id 'org.labkey.build.testRunner' version "${gradlePluginsVersion}" apply false
+        id 'org.labkey.build.tomcat' version "${gradlePluginsVersion}" apply false
+        id 'org.labkey.build.xsddoc' version "${gradlePluginsVersion}" apply false
+    }
+}
+
 buildscript {
     repositories {
         maven {

--- a/settings.gradle
+++ b/settings.gradle
@@ -26,6 +26,7 @@ pluginManagement {
         id 'org.labkey.build.testRunner' version "${gradlePluginsVersion}" apply false
         id 'org.labkey.build.tomcat' version "${gradlePluginsVersion}" apply false
         id 'org.labkey.build.xsddoc' version "${gradlePluginsVersion}" apply false
+        id 'org.labkey.versioning' version "${versioningPluginVersion}" apply false
     }
 }
 


### PR DESCRIPTION
#### Rationale
We're updating how we publish our plugins to move away from the older method and streamlining how the plugins get applied so we can avoid some duplication.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/105

#### Changes
* add pluginManagement section to settings.gradle file
* use plugin DSL for applying various
* move application of versioning plugin into base plugin
