### PR TITLE
bump LabKey version number

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -37,7 +37,7 @@ buildFromSource=true
 
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
-labkeyVersion=21.1-SNAPSHOT
+labkeyVersion=21.2-SNAPSHOT
 labkeyClientApiVersion=1.3.2
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.


### PR DESCRIPTION
#### Rationale
As part of the release process for 21.1, we will bump the LabKey version number on the develop branch to : 21.2