### PR TITLE
Add LDAP module to build_ehr tests on TeamCity

### DIFF
--- a/gradle/settings/ehr.gradle
+++ b/gradle/settings/ehr.gradle
@@ -42,6 +42,7 @@ include ":server:modules:tnprc_ehr"
 include ":server:modules:tnprc_billing"
 include ":server:modules:dataintegration"
 include ":server:modules:premium"
+include ":server:modules:ldap"
 
 // include the test distribution, which is used to create an artifact for TeamCity to pass around to the agents
 include "${BuildUtils.getTestProjectPath(this.settings.gradle)}:distributions:teamcity"


### PR DESCRIPTION
#### Rationale
We want EHR developers to have Artifactory-based access to the LDAP module, and TeamCity to use the same set of modules.

#### Related Pull Requests
* https://github.com/LabKey/onprcEHRModules/pull/59

#### Changes
* Include LDAP module