### PR TITLE
Issue42107: Module Import Permit Mixed-Case

### DIFF
--- a/server/bootstrap/src/org/labkey/bootstrap/LabKeyBootstrapClassLoader.java
+++ b/server/bootstrap/src/org/labkey/bootstrap/LabKeyBootstrapClassLoader.java
@@ -211,7 +211,7 @@ public class LabKeyBootstrapClassLoader extends WebappClassLoader implements Exp
         File existingTarget = existingModuleArchive.getDefaultExplodedLocation();
         File updatedTarget = updatedModuleArchive.getDefaultExplodedLocation();
 
-        if (!updatedTarget.getName().equals(existingTarget.getName()))
+        if (!updatedTarget.getName().equalsIgnoreCase(existingTarget.getName()))
             throw new IllegalArgumentException("Target directories for new and existing archive don't match");
         if (!explodedModuleDirectory.equals(existingTarget))
             throw new IllegalArgumentException("Module archive and exploded directory don't match");

--- a/server/bootstrap/src/org/labkey/bootstrap/LabKeyBootstrapClassLoader.java
+++ b/server/bootstrap/src/org/labkey/bootstrap/LabKeyBootstrapClassLoader.java
@@ -205,7 +205,7 @@ public class LabKeyBootstrapClassLoader extends WebappClassLoader implements Exp
 
         ModuleArchive existingModuleArchive = new ModuleArchive(existingArchive, _log);
         ModuleArchive updatedModuleArchive = new ModuleArchive(updatedArchive, _log);
-        if (!existingModuleArchive.getModuleName().equals(updatedModuleArchive.getModuleName()))
+        if (!existingModuleArchive.getModuleName().equalsIgnoreCase(updatedModuleArchive.getModuleName()))
             throw new IllegalArgumentException("Module name doesn't match, expected " + existingModuleArchive.getModuleName());
 
         File existingTarget = existingModuleArchive.getDefaultExplodedLocation();


### PR DESCRIPTION
#### Rationale
Upload of new module archive rejects with a "Module name doesn't match" message if a .module file's name is not undercase-only, to match with the exploded directory name.

#### Related Pull Requests
* n/a

#### Changes
* Permit .module upload if file name matches exploded directory name irrespective of casing.
