### PR TITLE
Update version for 21.1.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -37,7 +37,7 @@ buildFromSource=true
 
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
-labkeyVersion=21.1-SNAPSHOT
+labkeyVersion=21.1.0
 labkeyClientApiVersion=1.3.2
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.


### PR DESCRIPTION
#### Rationale
This change should have been included when the 'release21.1' branch was created. I didn't notice that my local pre-commit hook prevented the commit. Oops.

#### Changes
* Update `labkeyVersion` to 21.1.0
