### PR TITLE
Add extra data source to configuration templates

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -59,7 +59,7 @@ windowsProteomicsBinariesVersion=1.0
 bintrayPluginVersion=1.8.4
 artifactoryPluginVersion=4.13.0
 gradleNodePluginVersion=2.2.4
-gradlePluginsVersion=1.24.0_extraDataSource-SNAPSHOT
+gradlePluginsVersion=1.24.0-SNAPSHOT
 owaspDependencyCheckPluginVersion=5.2.1
 versioningPluginVersion=1.1.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -59,7 +59,7 @@ windowsProteomicsBinariesVersion=1.0
 bintrayPluginVersion=1.8.4
 artifactoryPluginVersion=4.13.0
 gradleNodePluginVersion=2.2.4
-gradlePluginsVersion=1.23.0
+gradlePluginsVersion=1.24.0_extraDataSource-SNAPSHOT
 owaspDependencyCheckPluginVersion=5.2.1
 versioningPluginVersion=1.1.0
 

--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -16,11 +16,11 @@ context.url[0]=@@jdbcURL@@
 context.username[0]=@@jdbcUser@@
 context.password[0]=@@jdbcPassword@@
 
-#@@extraJdbcDataSource@@.context.dataSourceName[1]=jdbc/@@extraJdbcDataSource@@
-#@@extraJdbcDataSource@@.context.driverClassName[1]=@@extraJdbcDriverClassName@@
-#@@extraJdbcDataSource@@.context.url[1]=@@extraJdbcURL@@
-#@@extraJdbcDataSource@@.context.username[1]=@@extraJdbcUser@@
-#@@extraJdbcDataSource@@.context.password[1]=@@extraJdbcPassword@@
+#context.dataSourceName[1]=jdbc/@@extraJdbcDataSource@@
+#context.driverClassName[1]=@@extraJdbcDriverClassName@@
+#context.url[1]=@@extraJdbcURL@@
+#context.username[1]=@@extraJdbcUser@@
+#context.password[1]=@@extraJdbcPassword@@
 
 #context.webAppLocation=@@pathToServer@@/build/deploy/labkeyWebapp
 context.masterEncryptionKey=@@masterEncryptionKey@@

--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -16,6 +16,12 @@ context.url[0]=@@jdbcURL@@
 context.username[0]=@@jdbcUser@@
 context.password[0]=@@jdbcPassword@@
 
+#@@extraJdbcDataSource@@.context.dataSourceName[1]=jdbc/@@extraJdbcDataSource@@
+#@@extraJdbcDataSource@@.context.driverClassName[1]=@@extraJdbcDriverClassName@@
+#@@extraJdbcDataSource@@.context.url[1]=@@extraJdbcURL@@
+#@@extraJdbcDataSource@@.context.username[1]=@@extraJdbcUser@@
+#@@extraJdbcDataSource@@.context.password[1]=@@extraJdbcPassword@@
+
 #context.webAppLocation=@@pathToServer@@/build/deploy/labkeyWebapp
 context.masterEncryptionKey=@@masterEncryptionKey@@
 

--- a/webapps/labkey.xml
+++ b/webapps/labkey.xml
@@ -48,7 +48,6 @@
     <!-- Pipeline configuration -->
     <!--@@pipeline@@    <Parameter name="org.labkey.api.pipeline.config" value="@@pipelineConfigPath@@"/> @@pipeline@@-->
 
-    <!--        brokerURL="tcp://localhost:61616" userName="username" password="password" -->
     <!--@@jmsConfig@@ <Resource name="jms/ConnectionFactory" auth="Container"
         type="org.apache.activemq.ActiveMQConnectionFactory"
         factory="org.apache.activemq.jndi.JNDIReferenceFactory"

--- a/webapps/labkey.xml
+++ b/webapps/labkey.xml
@@ -27,13 +27,23 @@
     <!-- Encryption key for encrypted property store -->
     <Parameter name="MasterEncryptionKey" value="@@masterEncryptionKey@@" />
 
+    <!--@@extraJdbcDataSource@@
+    <Resource name="jdbc/@@extraJdbcDataSource@@" auth="Container"
+              type="javax.sql.DataSource"
+              username="@@extraJdbcUsername@@"
+              password="@@extraJdbcPassword@@"
+              driverClassName="@@extraJdbcDriverClassName@@"
+              url="@@extraJdbcUrl@@"
+              maxTotal="20"
+              maxIdle="10"
+              accessToUnderlyingConnectionAllowed="true"
+              validationQuery="SELECT 1"/>
+    @@extraJdbcDataSource@@-->
+
     <!-- mzML support via JNI -->
     <!-- 
-	<Parameter name="org.labkey.api.ms2.mzmlLibrary" value="pwiz_swigbindings"></Parameter>    
-	 -->
-
-    <!-- Track installations from Windows Installer -->
-    <!--@@installer@@ <Parameter name="org.labkey.api.util.mothershipreport.usedInstaller" value="true"/> @@installer@@-->
+    <Parameter name="org.labkey.api.ms2.mzmlLibrary" value="pwiz_swigbindings"></Parameter>
+    -->
 
     <!-- Pipeline configuration -->
     <!--@@pipeline@@    <Parameter name="org.labkey.api.pipeline.config" value="@@pipelineConfigPath@@"/> @@pipeline@@-->


### PR DESCRIPTION
#### Rationale
We need a non-manual method to define a second data source in order to test Redshift on TeamCity.

#### Related Pull Requests
* LabKey/gradlePlugin#112

#### Changes
* Add template placeholders to `labkey.xml` and `application.properties` for extra data source
* Clean up some cruft from `labkey.xml` (No need to track Windows installer ghosts)
