### PR TITLE
Add config directory to restart.additional-paths

### DIFF
--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -28,7 +28,7 @@ mail.smtpUser=@@smtpUser@@
 # mail.smtpSocketFactoryClass=@@smtpSocketFactoryClass@@
 # mail.smtpAuth=@@smtpAuth@@
 
-#spring.devtools.restart.additional-paths=@@pathToServer@@/build/deploy/modules
+#spring.devtools.restart.additional-paths=@@pathToServer@@/build/deploy/modules,@@pathToServer@@/build/deploy/embedded/config
 
 #Enable shutdown endpoint
 management.endpoint.shutdown.enabled=true


### PR DESCRIPTION
#### Rationale
After a `pickDb` task has run (or generally, after the `application.properties` file has been changed), we want the server to restart.


#### Changes
* Add `build/deploy/embedded/config` as additional additional-path