### PR TITLE
Support to run embedded tomcat with java 16

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -92,7 +92,7 @@ activationVersion=1.2.1
 
 annotationsVersion=15.0
 
-apacheTomcatVersion=9.0.34
+apacheTomcatVersion=8.5.51
 
 #Unifying version used by DISCVR and Premium
 apacheDirectoryVersion=1.0.3
@@ -243,6 +243,8 @@ slf4jLog4jApiVersion=1.7.30
 
 
 springBootVersion=2.2.13.RELEASE
+# Keep building the core server with 8.5.x, but use 9.0.x within the Embedded code until support for 8.5.x is dropped
+springBootTomcatVersion=9.0.34
 
 # N.B. Spring version 5+ brings in a change to form handling such that GET and POST parameters are both used when
 # posting a form. For some of our forms this causes heartache.

--- a/gradle.properties
+++ b/gradle.properties
@@ -92,7 +92,7 @@ activationVersion=1.2.1
 
 annotationsVersion=15.0
 
-apacheTomcatVersion=8.5.51
+apacheTomcatVersion=9.0.34
 
 #Unifying version used by DISCVR and Premium
 apacheDirectoryVersion=1.0.3
@@ -242,7 +242,7 @@ slf4jLog4j12Version=1.7.5
 slf4jLog4jApiVersion=1.7.30
 
 
-springBootVersion=2.0.9.RELEASE
+springBootVersion=2.2.13.RELEASE
 
 # N.B. Spring version 5+ brings in a change to form handling such that GET and POST parameters are both used when
 # posting a form. For some of our forms this causes heartache.

--- a/server/bootstrap/build.gradle
+++ b/server/bootstrap/build.gradle
@@ -16,10 +16,12 @@ sourceSets {
 
 dependencies
         {
-            implementation "org.apache.tomcat:tomcat-api:${project.apacheTomcatVersion}"
-            implementation "org.apache.tomcat:tomcat-catalina:${project.apacheTomcatVersion}"
-            implementation "org.apache.tomcat:tomcat-juli:${project.apacheTomcatVersion}"
-            implementation "org.apache.tomcat:tomcat-util:${project.apacheTomcatVersion}"
+            def tomcatVersion = BuildUtils.useEmbeddedTomcat(project) ? project.springBootTomcatVersion : project.apacheTomcatVersion
+
+            implementation "org.apache.tomcat:tomcat-api:${tomcatVersion}"
+            implementation "org.apache.tomcat:tomcat-catalina:${tomcatVersion}"
+            implementation "org.apache.tomcat:tomcat-juli:${tomcatVersion}"
+            implementation "org.apache.tomcat:tomcat-util:${tomcatVersion}"
         }
 
 def JAR_BASE_NAME = "labkeyBootstrap"

--- a/server/embedded/build.gradle
+++ b/server/embedded/build.gradle
@@ -24,14 +24,14 @@ configurations {
 
 dependencies {
     implementation "org.springframework.boot:spring-boot-starter-web:${springBootVersion}"
-    implementation "org.apache.tomcat.embed:tomcat-embed-core:${apacheTomcatVersion}"
+    implementation "org.apache.tomcat.embed:tomcat-embed-core:${springBootTomcatVersion}"
     implementation "org.springframework.boot:spring-boot-starter-actuator:${springBootVersion}"
     implementation "org.springframework.boot:spring-boot-starter-validation:${springBootVersion}"
 
     runtimeOnly "org.apache.tomcat.embed:tomcat-embed-jasper:${apacheTomcatVersion}"
     runtimeOnly "javax.mail:javax.mail-api:1.6.2"
     runtimeOnly group: "com.sun.mail", name: "javax.mail", version: "1.6.0"
-    runtimeOnly group: "org.apache.tomcat", name: "tomcat-dbcp", version: "${apacheTomcatVersion}"
+    runtimeOnly group: "org.apache.tomcat", name: "tomcat-dbcp", version: "${springBootTomcatVersion}"
     runtimeOnly "org.postgresql:postgresql:${postgresqlDriverVersion}"
 
     developmentOnly("org.springframework.boot:spring-boot-devtools")

--- a/server/embedded/build.gradle
+++ b/server/embedded/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-actuator:${springBootVersion}"
     implementation "org.springframework.boot:spring-boot-starter-validation:${springBootVersion}"
 
-    runtimeOnly "org.apache.tomcat.embed:tomcat-embed-jasper:${apacheTomcatVersion}"
+    runtimeOnly "org.apache.tomcat.embed:tomcat-embed-jasper:${springBootTomcatVersion}"
     runtimeOnly "javax.mail:javax.mail-api:1.6.2"
     runtimeOnly group: "com.sun.mail", name: "javax.mail", version: "1.6.0"
     runtimeOnly group: "org.apache.tomcat", name: "tomcat-dbcp", version: "${springBootTomcatVersion}"


### PR DESCRIPTION
#### Rationale
With introduction of java 16, we'd like to support running embedded tomcat with jdk 16. 

#### Changes
* upgrade springboot and apache tomcat versions 
