### PR TITLE
Add new applyLicenses plugin from new gradlePlugins version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -58,7 +58,7 @@ windowsProteomicsBinariesVersion=1.0
 bintrayPluginVersion=1.8.4
 artifactoryPluginVersion=4.13.0
 gradleNodePluginVersion=2.2.4
-gradlePluginsVersion=1.24.1
+gradlePluginsVersion=1.24.2-patchApiModuleDep-SNAPSHOT
 owaspDependencyCheckPluginVersion=5.2.1
 versioningPluginVersion=1.1.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -58,7 +58,7 @@ windowsProteomicsBinariesVersion=1.0
 bintrayPluginVersion=1.8.4
 artifactoryPluginVersion=4.13.0
 gradleNodePluginVersion=2.2.4
-gradlePluginsVersion=1.24.2-patchApiModuleDep-SNAPSHOT
+gradlePluginsVersion=1.24.2
 owaspDependencyCheckPluginVersion=5.2.1
 versioningPluginVersion=1.1.0
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -13,6 +13,7 @@ pluginManagement {
     plugins {
         id 'org.labkey.build.antlr' version "${gradlePluginsVersion}" apply false
         id 'org.labkey.build.api' version "${gradlePluginsVersion}" apply false
+        id 'org.labkey.build.applyLicenses' version "${gradlePluginsVersion}" apply false
         id 'org.labkey.build.base' version "${gradlePluginsVersion}" apply false
         id 'org.labkey.build.distribution' version "${gradlePluginsVersion}" apply false
         id 'org.labkey.build.fileModule' version "${gradlePluginsVersion}" apply false


### PR DESCRIPTION
#### Rationale
It seems that when each module declares a dependency on its own `patchApiModule` task, the patched module gets created multiple times.  Since the patch is being put into the same output directory for each distribution this can cause race conditions with distributions ending up with partial api modules.  Moving this `patchApiModule` task into its own plugin means we can apply the plugin only once at the root of the distributions repository, build it only once and avoid overlapping output from the `patchApiModule` tasks when more than one distribution is being built.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/117
* https://github.com/LabKey/testAutomation/pull/620
* https://github.com/LabKey/distributions/pull/148

#### Changes
* Add new plugin id in pluginManagment block
