### PR TITLE
20.11 fb bump version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,7 @@ buildFromSource=true
 
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
-labkeyVersion=20.11.4
+labkeyVersion=20.11.5
 labkeyClientApiVersion=1.3.1
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,7 @@ buildFromSource=true
 
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
-labkeyVersion=20.11.2
+labkeyVersion=20.11.3
 labkeyClientApiVersion=1.3.1
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,7 @@ buildFromSource=true
 
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
-labkeyVersion=20.11.3
+labkeyVersion=20.11.4
 labkeyClientApiVersion=1.3.1
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.


### PR DESCRIPTION
#### Rationale
Bump LabKey version number for the 20.11.5 maintenance release.