### PR TITLE
Replace jcenter with mavenCentral

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -144,7 +144,7 @@ allprojects {
                         }
                     }
                 }
-                jcenter()
+                mavenCentral()
             }
     configurations.all
             {


### PR DESCRIPTION
#### Rationale
Jcenter is being sunsetted in May, and while the jcenter convenience method will probably continue to work and jcenter itself will continue to serve artifacts for quite a while, we might as well go ahead and transition to mavenCentral instead.

I consider simply removing the use of another repository altogether since it's included in the virtual repositories we reference from our Artifactory instance, but this serves as something of a backup mechanism in case our Artifactory instance is down.

#### Changes
* replace jcenter convenience method with mavenCentral.