### PR TITLE
Issue 42487: Default embedded tomcat to the "ROOT" context path

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -244,7 +244,7 @@ slf4jLog4jApiVersion=1.7.30
 
 springBootVersion=2.2.13.RELEASE
 # Keep building the core server with 8.5.x, but use 9.0.x within the Embedded code until support for 8.5.x is dropped
-springBootTomcatVersion=9.0.34
+springBootTomcatVersion=9.0.41
 
 # N.B. Spring version 5+ brings in a change to form handling such that GET and POST parameters are both used when
 # posting a form. For some of our forms this causes heartache.

--- a/server/embedded/build.gradle
+++ b/server/embedded/build.gradle
@@ -24,7 +24,6 @@ configurations {
 
 dependencies {
     implementation "org.springframework.boot:spring-boot-starter-web:${springBootVersion}"
-    implementation "org.apache.tomcat.embed:tomcat-embed-core:${springBootTomcatVersion}"
     implementation "org.springframework.boot:spring-boot-starter-actuator:${springBootVersion}"
     implementation "org.springframework.boot:spring-boot-starter-validation:${springBootVersion}"
 

--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -89,8 +89,11 @@ public class LabKeyServer
                         webAppLocation = contextProperties.getWebAppLocation();
                     }
 
-                    // TODO : 8021 :fix context path - put app at root by default
+                    // tomcat requires a unique context path other than root here
+                    // can not set context path as "" because em tomcat complains "Child name [] is not unique"
                     StandardContext context = (StandardContext) tomcat.addWebapp("/labkey", webAppLocation);
+                    // set the root path to the context explicitly
+                    context.setPath("");
 
                     // Push the JDBC connection for the primary DB into the context so that the LabKey webapp finds them
                     getDataSourceResources(contextProperties).forEach(contextResource -> context.getNamingResources().addResource(contextResource));


### PR DESCRIPTION
#### Rationale
Put LabKey webapp at the root context by default for embedded tomcat.


