### PR TITLE
Add server/modules/README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,8 @@ server/testAutomation/
 # Include the remoteapi README -- this line will override previous exclusion
 !remoteapi/README.md
 
-# Include the modules build.gradle file -- this line will override previous exclusion
-!server/modules/build.gradle
+# Include the modules README.md file -- this line will override previous exclusion
+!server/modules/README.md
 
 # Ignore parts of the .idea dir
 .idea/libraries/

--- a/server/modules/README.md
+++ b/server/modules/README.md
@@ -1,0 +1,2 @@
+Place modules' source in this directory. \
+See [LabKey documentation](https://www.labkey.org/Documentation/wiki-page.view?name=devMachine) for more information on configuring your development environment.

--- a/server/modules/README.md
+++ b/server/modules/README.md
@@ -1,2 +1,4 @@
-Place modules' source in this directory. \
+### Module Checkout Directory
+
+Clone module source into this directory. Gradle will look for modules here when building. \
 See [LabKey documentation](https://www.labkey.org/Documentation/wiki-page.view?name=devMachine) for more information on configuring your development environment.


### PR DESCRIPTION
#### Rationale
Git doesn't allow empty directories so `server/modules` won't exist in a fresh enlistment. Adding a placeholder, similar to the one in `remoteapi/README.md`

#### Changes
* Add 'server/modules/README.md'
