### PR TITLE
bump LabKey version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -45,7 +45,7 @@ buildFromSource=true
 
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
-labkeyVersion=21.3-SNAPSHOT
+labkeyVersion=21.4-SNAPSHOT
 labkeyClientApiVersion=1.3.2
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.


### PR DESCRIPTION
#### Rationale
Once we create the 21.3 SNAPSHOT branches, we will need to bump the version on develop.