### PR TITLE
Issue 42452: Incessant per-request logging spam from WsRemoteEndpointImplServer.doClose()

### DIFF
--- a/server/bootstrap/src/org/labkey/bootstrap/LabKeyBootstrapClassLoader.java
+++ b/server/bootstrap/src/org/labkey/bootstrap/LabKeyBootstrapClassLoader.java
@@ -60,11 +60,6 @@ public class LabKeyBootstrapClassLoader extends WebappClassLoader implements Exp
         // to have multiple instances share the Tomcat binaries but have their own ./logs, ./conf, etc directories
         // Thus, we want to use catalina.base for our place to find log files. http://www.jguru.com/faq/view.jsp?EID=1121565
         PipelineBootstrapConfig.ensureLogHomeSet(System.getProperty("catalina.base") + "/logs");
-
-        // Suppress overly verbose logging from Tomcat about WebSocket connections not closing in the ideal pattern
-        // https://bz.apache.org/bugzilla/show_bug.cgi?id=59062
-        java.util.logging.Logger logger = java.util.logging.Logger.getLogger("org.apache.tomcat.websocket.server.WsRemoteEndpointImplServer");
-        logger.setLevel(Level.WARNING);
     }
 
     private ModuleExtractor _moduleExtractor;


### PR DESCRIPTION
#### Rationale
Some dev machines (like mine) see lots of logging from Tomcat complaining that WebSockets aren't being closed appropriately. This is from a combination of java.util.logging and Tomcat's JULI configuration that is getting reset by some third-party library during initialization. I've failed to isolate the exact cause, but it seems like moving the logging level reset to later in the codepath has the intended result.

#### Changes
* Set the log level when we're starting to wire up WebSocket code