### PR TITLE
Update Gradle plugins for Gradle 7 support and a few other dependencies

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 # Uncomment the following line to turn on Gradle's file watching, which may improve efficiency
 # https://blog.gradle.org/introducing-file-system-watching
 #org.gradle.vfs.watch=true
-# Uncomment the following line to turn on Gradle's build cache, which will improve efficiency
+# This controls Gradle's build cache, which improves efficiency.
 # https://docs.gradle.org/current/userguide/build_cache.html
 org.gradle.caching=true
 # comment out or use --no-parallel to turn off parallel execution

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@
 #org.gradle.vfs.watch=true
 # Uncomment the following line to turn on Gradle's build cache, which will improve efficiency
 # https://docs.gradle.org/current/userguide/build_cache.html
-#org.gradle.caching=true
+org.gradle.caching=true
 # comment out or use --no-parallel to turn off parallel execution
 org.gradle.parallel=true
 # comment out and Gradle will attempt to determine the optimal number of executor threads to use
@@ -55,10 +55,9 @@ osxProteomicsBinariesVersion=1.0
 windowsProteomicsBinariesVersion=1.0
 
 # The current version numbers for the gradle plugins.
-bintrayPluginVersion=1.8.4
-artifactoryPluginVersion=4.13.0
-gradleNodePluginVersion=2.2.4
-gradlePluginsVersion=1.25.1
+artifactoryPluginVersion=4.21.0
+gradleNodePluginVersion=3.0.1
+gradlePluginsVersion=1.26.0-gradle7Updates-SNAPSHOT
 owaspDependencyCheckPluginVersion=5.2.1
 versioningPluginVersion=1.1.0
 
@@ -125,9 +124,9 @@ commonsDbcpVersion=1.4
 commonsDiscoveryVersion=0.2
 commonsDigesterVersion=1.8.1
 commonsFileuploadVersion=1.3.1
-commonsIoVersion=2.6
+commonsIoVersion=2.8.0
 commonsLangVersion=2.6
-commonsLang3Version=3.8
+commonsLang3Version=3.12.0
 commonsLoggingVersion=1.2
 commonsMath3Version=3.6.1
 commonsNetVersion=3.5
@@ -167,11 +166,11 @@ hamcrestCoreVersion=1.3
 # It is also necessary to update SequenceAnalysisManager.htsjdkVersion
 htsjdkVersion=2.21.3
 
-httpclientVersion=4.5.3
-httpcoreVersion=4.4.6
+httpclientVersion=4.5.13
+httpcoreVersion=4.4.14
 httpmimeVersion=4.5.3
 
-jacksonVersion=2.9.5
+jacksonVersion=2.12.2
 jacksonAnnotationsVersion=2.9.5
 jacksonJaxrsBaseVersion=2.9.5
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -170,7 +170,7 @@ httpclientVersion=4.5.13
 httpcoreVersion=4.4.14
 httpmimeVersion=4.5.3
 
-jacksonVersion=2.12.2
+jacksonVersion=2.9.5
 jacksonAnnotationsVersion=2.9.5
 jacksonJaxrsBaseVersion=2.9.5
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -57,7 +57,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.21.0
 gradleNodePluginVersion=3.0.1
-gradlePluginsVersion=1.26.0-gradle7Updates-SNAPSHOT
+gradlePluginsVersion=1.26.0
 owaspDependencyCheckPluginVersion=5.2.1
 versioningPluginVersion=1.1.0
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -47,14 +47,14 @@ buildscript {
     // depending on where you've enlisted in the gradlePlugins repository.  You will need to manually rebuild the jar file
     // to pick up these changes.
 //    dependencies {
-//        classpath files("../gradlePlugin/build/libs/gradlePlugin-1.22.0-SNAPSHOT.jar")
+//        classpath files("../gradlePlugin/build/libs/gradlePlugin-1.26.0-gradle7Updates-SNAPSHOT.jar")
 //        classpath "org.apache.commons:commons-lang3:${commonsLang3Version}"
 //        classpath "commons-io:commons-io:${commonsIoVersion}"
 //        classpath "com.yahoo.platform.yui:yuicompressor:2.4.8a"
 //        classpath "org.apache.httpcomponents:httpclient:${httpclientVersion}"
-//        classpath "org.json:json:20180130"
-//        classpath "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
-//        classpath "org.ajoberstar.grgit:grgit-gradle:3.1.1"
+//        classpath "org.json:json:20210307"
+//        classpath "com.fasterxml.jackson.core:jackson-databind:2.12.2"
+//        classpath "org.ajoberstar.grgit:grgit-gradle:4.1.0"
 //    }
     dependencies {
         classpath "org.labkey.build:gradlePlugins:${gradlePluginsVersion}"


### PR DESCRIPTION
#### Rationale
Gradle 7 is on its way and we want to use it when it comes out so we can start building with Java 16.  We've had to make a few minor changes to our gradle plugins to work with the latest Gradle 7 release candidate.  We also take this opportunity to update some dependency versions.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/122
* https://github.com/LabKey/platform/pull/2169

#### Changes
* Turn on build caching by default
* Update some dependency versions
