### PR TITLE
Correct commented out custom modules reference

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -143,7 +143,7 @@ else
     //BuildUtils.includeModules(this.settings, rootDir, [BuildUtils.SERVER_MODULES_DIR], excludedModules, true)
 
     // The line below includes all modules in the server/modules/customModules directory
-    //BuildUtils.includeModules(this.settings, rootDir, [BuildUtils.CUSTOM_MODULES_GIT_DIR], excludedModules)
+    //BuildUtils.includeModules(this.settings, rootDir, [BuildUtils.CUSTOM_MODULES_DIR], excludedModules)
 
     // The line below includes all modules in the server/modules, server/modules/platform, server/modules/commonAssays, and server/modules/customModules directories
     //BuildUtils.includeModules(this.settings, rootDir, BuildUtils.SERVER_MODULE_DIRS, excludedModules)


### PR DESCRIPTION
#### Rationale
`BuildUtils.CUSTOM_MODULES_GIT_DIR` is not a thing
