### PR TITLE
21.3 fb bump version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -45,7 +45,7 @@ buildFromSource=true
 
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
-labkeyVersion=21.3.2
+labkeyVersion=21.3.3
 labkeyClientApiVersion=1.3.2
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.

--- a/gradle.properties
+++ b/gradle.properties
@@ -45,7 +45,7 @@ buildFromSource=true
 
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
-labkeyVersion=21.3.1
+labkeyVersion=21.3.2
 labkeyClientApiVersion=1.3.2
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.


### PR DESCRIPTION
#### Rationale
Increment the LabKey version number to 21.3.3 for the upcoming maintenance release.