### PR TITLE
Facilitate standalone module build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -298,25 +298,6 @@ subprojects {
             description: "Displays the dependencies for all projects")
 }
 
-// We copy the resource files to a separate directory so they can be copied to jsptmp directory
-// for use in compiling JSPs.  Copying directly from the project.sourceSets.webapp.output for the JSP
-// task for api does not work when modules may be evaluated before the api module is evaluated.  Attempts to
-// declare evaluationDependsOn(:server:api) for each of these projects did not work.
-// This task is defined at the root to eliminate problems with evaluation order
-if (project.findProject(BuildUtils.getApiProjectPath(gradle)) != null)
-{
-    project.task("copyTagLibsBase",
-            type: Copy,
-            { CopySpec copy ->
-                copy.from "${BuildUtils.getApiProjectPath(gradle).replace(":", "/").substring(1)}/webapp"
-                copy.into "${project.buildDir}/webapp"
-                copy.include 'WEB-INF/web.xml'
-                copy.include 'WEB-INF/*.tld'
-                copy.include 'WEB-INF/*.jspf'
-            }
-    )
-}
-
 project.task("showDiscrepancies",
         group: "Help",
         type: ShowDiscrepancies,

--- a/build.gradle
+++ b/build.gradle
@@ -303,16 +303,19 @@ subprojects {
 // task for api does not work when modules may be evaluated before the api module is evaluated.  Attempts to
 // declare evaluationDependsOn(:server:api) for each of these projects did not work.
 // This task is defined at the root to eliminate problems with evaluation order
-project.task("copyTagLibsBase",
-        type: Copy,
-        {CopySpec copy ->
-            copy.from "${BuildUtils.getApiProjectPath(gradle).replace(":", "/").substring(1)}/webapp"
-            copy.into "${project.buildDir}/webapp"
-            copy.include 'WEB-INF/web.xml'
-            copy.include 'WEB-INF/*.tld'
-            copy.include 'WEB-INF/*.jspf'
-        }
-)
+if (project.findProject(BuildUtils.getApiProjectPath(gradle)) != null)
+{
+    project.task("copyTagLibsBase",
+            type: Copy,
+            { CopySpec copy ->
+                copy.from "${BuildUtils.getApiProjectPath(gradle).replace(":", "/").substring(1)}/webapp"
+                copy.into "${project.buildDir}/webapp"
+                copy.include 'WEB-INF/web.xml'
+                copy.include 'WEB-INF/*.tld'
+                copy.include 'WEB-INF/*.jspf'
+            }
+    )
+}
 
 project.task("showDiscrepancies",
         group: "Help",

--- a/gradle.properties
+++ b/gradle.properties
@@ -58,7 +58,7 @@ windowsProteomicsBinariesVersion=1.0
 bintrayPluginVersion=1.8.4
 artifactoryPluginVersion=4.13.0
 gradleNodePluginVersion=2.2.4
-gradlePluginsVersion=1.27.0-SNAPSHOT
+gradlePluginsVersion=1.27.0
 owaspDependencyCheckPluginVersion=5.2.1
 versioningPluginVersion=1.1.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -58,7 +58,7 @@ windowsProteomicsBinariesVersion=1.0
 bintrayPluginVersion=1.8.4
 artifactoryPluginVersion=4.13.0
 gradleNodePluginVersion=2.2.4
-gradlePluginsVersion=1.25.1
+gradlePluginsVersion=1.27.0_standaloneBuild-SNAPSHOT
 owaspDependencyCheckPluginVersion=5.2.1
 versioningPluginVersion=1.1.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -58,7 +58,7 @@ windowsProteomicsBinariesVersion=1.0
 bintrayPluginVersion=1.8.4
 artifactoryPluginVersion=4.13.0
 gradleNodePluginVersion=2.2.4
-gradlePluginsVersion=1.27.0_standaloneBuild-SNAPSHOT
+gradlePluginsVersion=1.27.0-SNAPSHOT
 owaspDependencyCheckPluginVersion=5.2.1
 versioningPluginVersion=1.1.0
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -33,6 +33,14 @@ dependencies
    xsdDoc "docflex:docflex-xml-re:${docflexXmlReVersion}"
 }
 
+project.tasks.register("tomcatLibsZip", Zip) {
+    Zip zip ->
+        zip.group = "Build"
+        zip.description = "produce jar file with jars to be deployed in \$CATALINA_HOME/lib"
+        zip.from project.configurations.tomcatJars.getAsFileTree()
+        zip.archiveBaseName.set("tomcat-libs")
+        zip.destinationDirectory = project.file(project.labkey.explodedModuleLibDir)
+}
 
 configurations
         {
@@ -154,10 +162,25 @@ project.publishing {
             }
         }
 
+        tomcatJars(MavenPublication) {
+            groupId = 'org.labkey.api'
+            artifactId = 'tomcat-libs'
+            version = project.version
+            artifact project.tasks.tomcatLibsZip
+            pom {
+                name = "LabKey Server Tomcat Libs"
+                description = "Additional Tomcat libs for LabKey Server."
+                developers PomFileHelper.getLabKeyTeamDevelopers()
+                licenses PomFileHelper.getApacheLicense()
+                organization PomFileHelper.getLabKeyOrganization()
+                scm PomFileHelper.getLabKeyGitScm()
+            }
+        }
+
         if (BuildUtils.shouldPublish(project))
         {
             project.artifactoryPublish {
-                publications('jsDocs', 'xsdDocs')
+                publications('jsDocs', 'xsdDocs', 'tomcatJars')
             }
             project.subprojects {
                 artifactoryPublish.skip = true

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -35,7 +35,7 @@ dependencies
 
 project.tasks.register("tomcatLibsZip", Zip) {
     Zip zip ->
-        zip.group = "Build"
+        zip.group = GroupNames.BUILD
         zip.description = "produce jar file with jars to be deployed in \$CATALINA_HOME/lib"
         zip.from project.configurations.tomcatJars.getAsFileTree()
         zip.archiveBaseName.set("tomcat-libs")
@@ -163,7 +163,7 @@ project.publishing {
         }
 
         tomcatJars(MavenPublication) {
-            groupId = 'org.labkey.api'
+            groupId = 'org.labkey.build'
             artifactId = 'tomcat-libs'
             version = project.version
             artifact project.tasks.tomcatLibsZip


### PR DESCRIPTION
#### Rationale
'copyTagLibsBase' is no longer needed as of LabKey/gradlePlugin#123. The 'copyTagLibs' task added by the module plugin used to depend on it, but now it pulls the tag libs directly from the API module source (or from the published module for standalone module builds)

#### Related Pull Requests
* LabKey/gradlePlugin#123

#### Changes
* Delete 'copyTagLibsBase' task
* Update `gradlePluginsVersion`
