### PR TITLE
Publish Libraries to deploy into Tomcat

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -33,6 +33,14 @@ dependencies
    xsdDoc "docflex:docflex-xml-re:${docflexXmlReVersion}"
 }
 
+project.tasks.register("tomcatLibsZip", Zip) {
+    Zip zip ->
+        zip.group = "Build"
+        zip.description = "produce jar file with jars to be deployed in \$CATALINA_HOME/lib"
+        zip.from project.configurations.tomcatJars.getAsFileTree()
+        zip.archiveBaseName.set("tomcat-libs")
+        zip.destinationDirectory = project.file(project.labkey.explodedModuleLibDir)
+}
 
 configurations
         {
@@ -154,10 +162,25 @@ project.publishing {
             }
         }
 
+        tomcatJars(MavenPublication) {
+            groupId = 'org.labkey.api'
+            artifactId = 'tomcat-libs'
+            version = project.version
+            artifact project.tasks.tomcatLibsZip
+            pom {
+                name = "LabKey Server Tomcat Libs"
+                description = "Additional Tomcat libs for LabKey Server."
+                developers PomFileHelper.getLabKeyTeamDevelopers()
+                licenses PomFileHelper.getApacheLicense()
+                organization PomFileHelper.getLabKeyOrganization()
+                scm PomFileHelper.getLabKeyGitScm()
+            }
+        }
+
         if (BuildUtils.shouldPublish(project))
         {
             project.artifactoryPublish {
-                publications('jsDocs', 'xsdDocs')
+                publications('jsDocs', 'xsdDocs', 'tomcatJars')
             }
             project.subprojects {
                 artifactoryPublish.skip = true

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -35,7 +35,7 @@ dependencies
 
 project.tasks.register("tomcatLibsZip", Zip) {
     Zip zip ->
-        zip.group = "Build"
+        zip.group = GroupNames.BUILD
         zip.description = "produce jar file with jars to be deployed in \$CATALINA_HOME/lib"
         zip.from project.configurations.tomcatJars.getAsFileTree()
         zip.archiveBaseName.set("tomcat-libs")
@@ -163,7 +163,7 @@ project.publishing {
         }
 
         tomcatJars(MavenPublication) {
-            groupId = 'org.labkey.api'
+            groupId = 'org.labkey.build'
             artifactId = 'tomcat-libs'
             version = project.version
             artifact project.tasks.tomcatLibsZip

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -33,6 +33,7 @@ dependencies
    xsdDoc "docflex:docflex-xml-re:${docflexXmlReVersion}"
 }
 
+// Bundle and publish tomcat libs to enable distributions built by standalone modules
 project.tasks.register("tomcatLibsZip", Zip) {
     Zip zip ->
         zip.group = GroupNames.BUILD


### PR DESCRIPTION
#### Rationale
LabKey distributions include several jars that get deployed to `$CATALINA_HOME/lib`. The gradle plugin currently pulls these jars from the `tomcatJars` configuration of the server project. This new task (`:server:tomcatLibsZip`) allows a standalone module build to pull compatible libraries from Artifactory to produce a distribution.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/123

#### Changes
* Add `:server:tomcatLibsZip` task and publish its output to Artifactory
