### PR TITLE
Upgrade Tika 1.19.1 -> 1.26

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -118,8 +118,6 @@ commonsCodecVersion=1.10
 commonsBeanutilsVersion=1.7.0
 # sync with version Tika ships
 commonsCompressVersion=1.20
-# sync with version Tika ships
-commonsCsvVersion=1.8
 commonsDbcpVersion=1.4
 commonsDiscoveryVersion=0.2
 commonsDigesterVersion=1.8.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -100,15 +100,13 @@ apacheMinaVersion=2.0.19
 
 # (mothership) -> json-path -> json-smart -> accessor-smart
 # (core) -> graalvm
-# tika???
-asmVersion=7.1
+# tika
+asmVersion=9.1
 
 # Apache Batik -- Batik version is dictated by Apache FOP, but we need to pull in batik-codec separately
 batikVersion=1.10
 
 bouncycastleVersion=1.60
-
-bzipVersion=1.0
 
 cglibNodepVersion=2.2.3
 
@@ -119,7 +117,9 @@ commonsCodecVersion=1.10
 # in the :server:api module but is required for some of our code to compile
 commonsBeanutilsVersion=1.7.0
 # sync with version Tika ships
-commonsCompressVersion=1.18
+commonsCompressVersion=1.20
+# sync with version Tika ships
+commonsCsvVersion=1.8
 commonsDbcpVersion=1.4
 commonsDiscoveryVersion=0.2
 commonsDigesterVersion=1.8.1
@@ -178,7 +178,7 @@ jamaVersion=1.0.2
 
 javassistVersion=3.20.0-GA
 
-javaMailVersion=1.6.5
+javaMailVersion=1.6.6
 
 # No longer part of Java 10. Dependency for NIHS and OpenEMPI.
 jaxbVersion=2.3.0
@@ -217,10 +217,10 @@ opencsvVersion=2.3
 patriciaTrieVersion=0.6
 
 # sync with version Tika ships
-pdfboxVersion=2.0.11
+pdfboxVersion=2.0.23
 
 # sync with version Tika ships
-poiVersion=4.0.0
+poiVersion=4.1.2
 
 pollingWatchVersion=0.2.0
 
@@ -236,7 +236,7 @@ romeVersion=1.7.1
 servletApiVersion=3.0
 
 # this version is forced for compatibility with pipeline and tika
-slf4jLog4j12Version=1.7.5
+slf4jLog4j12Version=1.7.30
 # this version is forced for compatibility with api, LDK, and workflow
 slf4jLog4jApiVersion=1.7.30
 
@@ -253,16 +253,17 @@ sqliteJdbcVersion=3.7.2
 
 thumbnailatorVersion=0.4.8
 
-# used for tika-core in API and tika-app in search
-tikaVersion=1.19.1
-tukaaniXZVersion=1.8
+# used for tika-core in API and tika-parsers in search
+tikaVersion=1.26
+tukaaniXZVersion=1.9
 
 validationApiVersion=1.1.0.Final
 
 # saml and query bring in different versions transitively; we force the later one
 xalanVersion=2.7.2
 
-xercesImplVersion=2.11.0
+# sync with Tika
+xercesImplVersion=2.12.1
 
 # version 2.0.2 was relocated to xml-apis:xml-apis:1.0.b2, so we use 1.0.b2 here since later versions of Gradle don't support
 # using the relocated version


### PR DESCRIPTION
#### Rationale
Tika 1.26 fixes issues and allows upgrading of POI, PDFBox, and other dependencies

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2250

#### Changes
* Upgrade Tika 1.19.1 -> 1.26
* Upgrade ASM 7.1 -> 9.1
* Upgrade Commons Compress 1.18 -> 1.20
* Upgrade JavaMail 1.6.5 -> 1.6.6
* Upgrade PDFBox 2.0.11 -> 2.0.23
* Upgrade POI 4.0.0 -> 4.1.2
* Upgrade slf4j-log4j12 1.7.5 -> 1.7.30
* Upgrade TukaaniXZ 1.8 -> 1.9
* Upgrade Xerces 2.11.0 -> 2.12.1