### PR TITLE
bump LabKey version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -45,7 +45,7 @@ buildFromSource=true
 
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
-labkeyVersion=21.6-SNAPSHOT
+labkeyVersion=21.7-SNAPSHOT
 labkeyClientApiVersion=1.3.2
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.


### PR DESCRIPTION
#### Rationale
Bump the LabKey version number for the 21.6 monthly release