### PR TITLE
Enable project file templates by default

### DIFF
--- a/.idea/configTemplates/workspace.xml
+++ b/.idea/configTemplates/workspace.xml
@@ -62,6 +62,9 @@
       </breakpoint_any>
     </exception_breakpoints>
   </component>
+  <component name="FileTemplateManagerImpl">
+    <option name="SCHEME" value="Project" />
+  </component>
   <component name="Git.Settings">
     <option name="UPDATE_TYPE" value="REBASE" />
     <option name="PUSH_UPDATE_ALL_ROOTS" value="false" />


### PR DESCRIPTION
#### Rationale
Custom [IntelliJ file templates](https://github.com/LabKey/server/tree/develop/.idea/fileTemplates) are disabled by default. This will enable them for new enlistments.

#### Changes
* Update '.idea/workspace.xml' template to enable custom file templates
