### PR TITLE
Update dependencies for 21.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 build/
 enlistment.properties
 server/config.properties
+#IntelliJ build output directory
+server/bootstrap/out/
 
 # Ignore other common repository locations
 dist/

--- a/build.gradle
+++ b/build.gradle
@@ -219,6 +219,9 @@ allprojects {
                     force "junit:junit:${junitVersion}"
                     // force consistency in nlp and saml that bring this in transitively
                     force "org.codehaus.woodstox:stax2-api:${stax2ApiVersion}"
+                    // force consistency in transitive dependency for fileTransfer compared to api
+                    // This can be removed when the googleHttpClient version is updated to bring in a consistent version
+                    force "com.google.code.findbugs:jsr305:${jsr305Version}"
 
                     dependencySubstitution {
                         // Because the client api artifact name is not the same as the directory structure, we use

--- a/build.gradle
+++ b/build.gradle
@@ -209,9 +209,6 @@ allprojects {
                     // saml has transitive dependencies on old versions of batik and xmlgraphics-commons, which conflict with more recent versions in api
                     force "org.apache.xmlgraphics:batik-css:${batikVersion}"
                     force "org.apache.xmlgraphics:xmlgraphics-commons:${fopVersion}"
-                    // force consistency in TCRdb, mspipeline, omerointegration
-                    force "ch.qos.logback:logback-classic:${logbackVersion}"
-                    force "ch.qos.logback:logback-core:${logbackVersion}"
                     // force consistency in TCRdb, WNPRC
                     force "org.javassist:javassist:${javassistVersion}"
                     force "org.ow2.asm:asm:${asmVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ plugins {
     id "com.jfrog.artifactory" version "${artifactoryPluginVersion}" apply false
     id "com.github.node-gradle.node" version "${gradleNodePluginVersion}" apply false
     id "org.owasp.dependencycheck" version "${owaspDependencyCheckPluginVersion}" apply false
-//    id "com.github.ben-manes.versions" version "0.33.0"
+//    id "com.github.ben-manes.versions" version "0.39.0"
     id "org.labkey.build.multiGit"
 }
 
@@ -212,6 +212,11 @@ allprojects {
                     // force consistency in TCRdb, WNPRC
                     force "org.javassist:javassist:${javassistVersion}"
                     force "org.ow2.asm:asm:${asmVersion}"
+                    // force junit and hamcrest versions to be consistent with what comes from labkey-client-api via json-simple.
+                    // The hamcrest dependencies come through transitively from jackson, json-simple, junit, jmock
+                    force "org.hamcrest:hamcrest-core:${hamcrestVersion}"
+                    force "org.hamcrest:hamcrest-library:${hamcrestVersion}"
+                    force "junit:junit:${junitVersion}"
 
                     dependencySubstitution {
                         // Because the client api artifact name is not the same as the directory structure, we use

--- a/build.gradle
+++ b/build.gradle
@@ -217,6 +217,8 @@ allprojects {
                     force "org.hamcrest:hamcrest-core:${hamcrestVersion}"
                     force "org.hamcrest:hamcrest-library:${hamcrestVersion}"
                     force "junit:junit:${junitVersion}"
+                    // force consistency in nlp and saml that bring this in transitively
+                    force "org.codehaus.woodstox:stax2-api:${stax2ApiVersion}"
 
                     dependencySubstitution {
                         // Because the client api artifact name is not the same as the directory structure, we use

--- a/gradle.properties
+++ b/gradle.properties
@@ -168,9 +168,9 @@ httpclientVersion=4.5.13
 httpcoreVersion=4.4.14
 httpmimeVersion=4.5.13
 
-jacksonVersion=2.9.5
-jacksonAnnotationsVersion=2.9.5
-jacksonJaxrsBaseVersion=2.9.5
+jacksonVersion=2.12.3
+jacksonAnnotationsVersion=2.12.3
+jacksonJaxrsBaseVersion=2.12.3
 
 jamaVersion=1.0.3
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -189,7 +189,7 @@ jmockVersion=2.6.0
 
 jodaTimeVersion=2.8.1
 
-jsonSimpleVersion=1.1
+jsonSimpleVersion=1.1.1
 
 jtdsVersion=1.3.1
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -185,7 +185,7 @@ jaxrpcVersion=1.1
 
 jfreechartVersion=1.0.19
 
-jmockVersion=2.12.0
+jmockVersion=2.6.0
 
 jodaTimeVersion=2.8.1
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -201,7 +201,7 @@ jxlVersion=2.6.3
 
 kaptchaVersion=2.3
 
-log4j2Version=2.13.3
+log4j2Version=2.14.1
 
 logbackVersion=1.1.1
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -57,7 +57,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.21.0
 gradleNodePluginVersion=3.0.1
-gradlePluginsVersion=1.28.0-versionUpdates217-SNAPSHOT
+gradlePluginsVersion=1.28.0
 owaspDependencyCheckPluginVersion=5.2.1
 versioningPluginVersion=1.1.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -192,6 +192,9 @@ jmockVersion=2.6.0
 
 jodaTimeVersion=2.8.1
 
+# brought in transitively from guava and other google packages.  Need to resolve consistently
+jsr305Version=3.0.2
+
 jsonSimpleVersion=1.1.1
 
 jtdsVersion=1.3.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ buildFromSource=true
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
 labkeyVersion=21.7-SNAPSHOT
-labkeyClientApiVersion=1.3.2
+labkeyClientApiVersion=1.4.0-versionUpdates217-SNAPSHOT
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.
 windowsUtilsVersion=1.0
@@ -57,7 +57,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.21.0
 gradleNodePluginVersion=3.0.1
-gradlePluginsVersion=1.26.0
+gradlePluginsVersion=1.28.0-versionUpdates217-SNAPSHOT
 owaspDependencyCheckPluginVersion=5.2.1
 versioningPluginVersion=1.1.0
 
@@ -110,26 +110,26 @@ bouncycastleVersion=1.60
 
 cglibNodepVersion=2.2.3
 
-commonsCollectionsVersion=3.2.2
-commonsCollections4Version=4.2
-commonsCodecVersion=1.10
 # the beanutils version is not the default version brought from commons-validator and/or commons-digester
 # in the :server:api module but is required for some of our code to compile
-commonsBeanutilsVersion=1.7.0
+commonsBeanutilsVersion=1.8.3
+commonsCollectionsVersion=3.2.2
+commonsCollections4Version=4.4
+commonsCodecVersion=1.15
 # sync with version Tika ships
 commonsCompressVersion=1.20
 commonsDbcpVersion=1.4
 commonsDiscoveryVersion=0.2
 commonsDigesterVersion=1.8.1
-commonsFileuploadVersion=1.3.1
+commonsFileuploadVersion=1.4
 commonsIoVersion=2.8.0
 commonsLangVersion=2.6
 commonsLang3Version=3.12.0
 commonsLoggingVersion=1.2
 commonsMath3Version=3.6.1
-commonsNetVersion=3.5
+commonsNetVersion=3.8.0
 commonsPoolVersion=1.6
-commonsValidatorVersion=1.5.0
+commonsValidatorVersion=1.7
 
 dom4jVersion=1.6.1
 
@@ -166,7 +166,7 @@ htsjdkVersion=2.21.3
 
 httpclientVersion=4.5.13
 httpcoreVersion=4.4.14
-httpmimeVersion=4.5.3
+httpmimeVersion=4.5.13
 
 jacksonVersion=2.9.5
 jacksonAnnotationsVersion=2.9.5

--- a/gradle.properties
+++ b/gradle.properties
@@ -183,6 +183,9 @@ jaxbVersion=2.3.0
 
 jaxrpcVersion=1.1
 
+# jfreechart brings this in as a transitive dependency; targetedms declares this as a direct dependency
+jcommonVersion=1.0.23
+
 jfreechartVersion=1.0.19
 
 jmockVersion=2.6.0
@@ -246,6 +249,9 @@ springBootTomcatVersion=9.0.41
 springVersion=4.3.20.RELEASE
 
 sqliteJdbcVersion=3.7.2
+
+# NLP and SAML bring stax2-api in as a transitive dependency but with very different versions.  We force the later version.
+stax2ApiVersion=4.2.1
 
 thumbnailatorVersion=0.4.8
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -152,7 +152,7 @@ graalVersion=20.0.0
 # We resolve to the later version here to keep things consistent
 gsonVersion=2.2.4
 
-guavaVersion=24.0-jre
+guavaVersion=30.1.1-jre
 gwtVersion=2.8.2
 gwtServletVersion=2.8.2
 # For dev builds, the targeted, single permutation browser. Can be either gwt-user-firefox, gwt-user-chrome, or gwt-user-ie

--- a/gradle.properties
+++ b/gradle.properties
@@ -172,7 +172,7 @@ jacksonVersion=2.9.5
 jacksonAnnotationsVersion=2.9.5
 jacksonJaxrsBaseVersion=2.9.5
 
-jamaVersion=1.0.2
+jamaVersion=1.0.3
 
 javassistVersion=3.20.0-GA
 
@@ -183,7 +183,7 @@ jaxbVersion=2.3.0
 
 jaxrpcVersion=1.1
 
-jfreechartVersion=1.0.14
+jfreechartVersion=1.0.19
 
 jmockVersion=2.6.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ buildFromSource=true
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
 labkeyVersion=21.7-SNAPSHOT
-labkeyClientApiVersion=1.4.0-versionUpdates217-SNAPSHOT
+labkeyClientApiVersion=1.4.0
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.
 windowsUtilsVersion=1.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -203,8 +203,6 @@ kaptchaVersion=2.3
 
 log4j2Version=2.14.1
 
-logbackVersion=1.1.1
-
 mysqlDriverVersion=8.0.18
 
 objenesisVersion=1.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -158,7 +158,7 @@ gwtServletVersion=2.8.2
 # For dev builds, the targeted, single permutation browser. Can be either gwt-user-firefox, gwt-user-chrome, or gwt-user-ie
 gwtBrowser=gwt-user-chrome
 
-hamcrestCoreVersion=1.3
+hamcrestVersion=1.3
 
 # Note: if changing this, we might need to match with the picard version in the SequenceAnalysis module build.gradle
 # It is also necessary to update SequenceAnalysisManager.htsjdkVersion
@@ -195,7 +195,7 @@ jtdsVersion=1.3.1
 
 jtidyVersion=r918
 
-junitVersion=4.12
+junitVersion=4.13.2
 
 jxlVersion=2.6.3
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -203,7 +203,7 @@ kaptchaVersion=2.3
 
 log4j2Version=2.14.1
 
-mysqlDriverVersion=8.0.18
+mysqlDriverVersion=8.0.23
 
 objenesisVersion=1.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -91,7 +91,7 @@ activationVersion=1.2.1
 
 annotationsVersion=15.0
 
-apacheTomcatVersion=8.5.51
+apacheTomcatVersion=8.5.66
 
 #Unifying version used by DISCVR and Premium
 apacheDirectoryVersion=1.0.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -185,7 +185,7 @@ jaxrpcVersion=1.1
 
 jfreechartVersion=1.0.19
 
-jmockVersion=2.6.0
+jmockVersion=2.12.0
 
 jodaTimeVersion=2.8.1
 


### PR DESCRIPTION
#### Rationale
Keeping dependency versions updated.  

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2352 and all PRs related there.

#### Changes
* Remove force of logback version since it is referenced in only one module
* Add a few more forced versions to reconcile transitive external dependencies
