### PR TITLE
Go back to jackson 2.11.3 to get rid of problem with java.time.LocalDate support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -168,7 +168,10 @@ httpclientVersion=4.5.13
 httpcoreVersion=4.4.14
 httpmimeVersion=4.5.13
 
-jacksonVersion=2.12.3
+# Using 2.12.3 produces a runtime error related to support for java.time.LocalDate
+# that can probably be resolved with some other dependencies in the mix but attempts
+# so far have been unsuccessful
+jacksonVersion=2.11.3
 jacksonAnnotationsVersion=2.12.3
 jacksonJaxrsBaseVersion=2.12.3
 


### PR DESCRIPTION
#### Rationale
Jackson v2.12.3 introduces some breaking behavior related to `java.time.LocalDate` and I've been unsuccessful in adding dependencies in the right place to get rid of the error.  For now, we'll go back to 2.11.3 where this problem does not seem to appear.

#### Related Pull Requests
* #90 
* https://github.com/LabKey/platform/pull/2361

#### Changes
* Change Jackson version
