### PR TITLE
Publish jar for embedded distributions

### DIFF
--- a/gradle/settings/all.gradle
+++ b/gradle/settings/all.gradle
@@ -31,6 +31,12 @@ if (hasProperty('gradleExcludeModuleDirs'))
     excludedDirs.addAll("${gradleExcludeModuleDirs}".toLowerCase().split(","))
 }
 
+// Include ':server:embedded' unless explicitly excluded
+if (!excludedDirs.contains("embedded"))
+{
+    include BuildUtils.getEmbeddedProjectPath(gradle)
+}
+
 BuildUtils.includeModules(this.settings, rootDir, ["server/modules"], excludedDirs, true)
 
 // include the test distribution, which is used to create an artifact for TeamCity to pass around to the agents

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -180,6 +180,14 @@ project.publishing {
 
         if (BuildUtils.shouldPublish(project))
         {
+            var embeddedProject = project.findProject(BuildUtils.getEmbeddedProjectPath(project.gradle))
+
+            if (embeddedProject != null)
+            {
+                project.artifactoryPublish {
+                    embeddedProject.publications('embeddedJar')
+                }
+            }
             project.artifactoryPublish {
                 publications('jsDocs', 'xsdDocs', 'tomcatJars')
             }

--- a/server/embedded/build.gradle
+++ b/server/embedded/build.gradle
@@ -1,4 +1,5 @@
 import org.labkey.gradle.util.BuildUtils
+import org.labkey.gradle.util.PomFileHelper
 
 plugins {
     id "java"
@@ -37,3 +38,22 @@ dependencies {
 }
 
 BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: BuildUtils.getBootstrapProjectPath(gradle))
+
+project.publishing {
+    publications {
+        embeddedJar(MavenPublication) {
+            groupId = 'org.labkey.build'
+            artifactId = 'embedded'
+            version = project.version
+            artifact project.tasks.jar.outputs.files.singleFile
+            pom {
+                name = "LabKey Server Embedded"
+                description = "LabKey classes for producing distributions with embedded TomCat."
+                developers PomFileHelper.getLabKeyTeamDevelopers()
+                licenses PomFileHelper.getApacheLicense()
+                organization PomFileHelper.getLabKeyOrganization()
+                scm PomFileHelper.getLabKeyGitScm()
+            }
+        }
+    }
+}


### PR DESCRIPTION
#### Rationale
In order to build embedded distributions from standalone modules, they need to be able to pull the embedded jar from Artifactory instead of building it from `:server:embedded`

#### Changes
* Publish `:server:embedded:jar` to Artifactory
* Include '`:server:embedded`' project in `-PmoduleSet=all`
