### PR TITLE
Fix publishing embedded jar to Artifactory

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -180,14 +180,6 @@ project.publishing {
 
         if (BuildUtils.shouldPublish(project))
         {
-            var embeddedProject = project.findProject(BuildUtils.getEmbeddedProjectPath(project.gradle))
-
-            if (embeddedProject != null)
-            {
-                project.artifactoryPublish {
-                    embeddedProject.publications('embeddedJar')
-                }
-            }
             project.artifactoryPublish {
                 publications('jsDocs', 'xsdDocs', 'tomcatJars')
             }

--- a/server/embedded/build.gradle
+++ b/server/embedded/build.gradle
@@ -55,5 +55,13 @@ project.publishing {
                 scm PomFileHelper.getLabKeyGitScm()
             }
         }
+
+        if (BuildUtils.shouldPublish(project))
+        {
+            project.artifactoryPublish {
+                publications('embeddedJar')
+            }
+            project.artifactoryPublish.skip = false
+        }
     }
 }


### PR DESCRIPTION
#### Rationale
The previous attempt to publish the embedded jar throws an error on TeamCity:
```
Could not set unknown property 'embeddedProject' for Publication container of type org.gradle.api.publish.internal.DefaultPublicationContainer.
```
Publishing directly from `:server:embedded` seems to work properly.

#### Related Pull Requests
* #99 

#### Changes
* Publish directly from `:server:embedded` project
