### PR TITLE
Use Tomcat 8.5.69 to compile JSPs since this version no longer emits deprecated code

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -91,7 +91,7 @@ activationVersion=1.2.1
 
 annotationsVersion=15.0
 
-apacheTomcatVersion=8.5.66
+apacheTomcatVersion=8.5.69
 
 #Unifying version used by DISCVR and Premium
 apacheDirectoryVersion=1.0.3


### PR DESCRIPTION
#### Rationale
Previous to Tomcat 8.5.69, Jasper generated code with "boxed primitive constructors" (e.g., `new Integer(27)`), which have been deprecated and, as of JDK 16, marked for removal. See https://bz.apache.org/bugzilla/show_bug.cgi?id=65377

#### Changes
* Use Tomcat 8.5.69 to compile JSPs
