### PR TITLE
Force consistent dependency on renamed `woodstox-core` library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -217,8 +217,9 @@ allprojects {
                     force "org.hamcrest:hamcrest-core:${hamcrestVersion}"
                     force "org.hamcrest:hamcrest-library:${hamcrestVersion}"
                     force "junit:junit:${junitVersion}"
-                    // force consistency in nlp and saml that bring this in transitively
+                    // force consistency in nlp and saml that bring these in transitively
                     force "org.codehaus.woodstox:stax2-api:${stax2ApiVersion}"
+                    force "com.fasterxml.woodstox:woodstox-core:${woodstoxCoreVersion}"
                     // force consistency in transitive dependency for fileTransfer compared to api
                     // This can be removed when the googleHttpClient version is updated to bring in a consistent version
                     force "com.google.code.findbugs:jsr305:${jsr305Version}"
@@ -243,6 +244,9 @@ allprojects {
 
                         // jdk5 backport of guava has significant conflicts with guava 18+
                         substitute module('com.google.guava:guava-jdk5') with module("com.google.guava:guava:${guavaVersion}")
+
+                        // This library was renamed
+                        substitute module('org.codehaus.woodstox:woodstox-core-asl') with module("com.fasterxml.woodstox:woodstox-core:${woodstoxCoreVersion}")
 
                         if (project.hasProperty('apacheTomcatVersion'))
                         {

--- a/gradle.properties
+++ b/gradle.properties
@@ -267,6 +267,9 @@ tukaaniXZVersion=1.9
 
 validationApiVersion=1.1.0.Final
 
+# NLP and SAML bring woodstox-core in as a transitive dependency but with very different versions.  We force the later version.
+woodstoxCoreVersion=6.2.1
+
 # saml and query bring in different versions transitively; we force the later one
 xalanVersion=2.7.2
 


### PR DESCRIPTION
#### Rationale
There is a sneaky dependency conflict between `org.codehaus.woodstox:woodstox-core-asl` and `com.fasterxml.woodstox:woodstox-core`.

#### Changes
* Force consistent dependency on renamed `woodstox-core` library
