### PR TITLE
Update plugins version and add new purgeNpmAlphaVersions task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ import org.labkey.gradle.task.ShowDiscrepancies
 import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.GroupNames
 import org.labkey.gradle.plugin.NpmRun
+import org.labkey.gradle.task.PurgeNpmAlphaVersions
 
 buildscript {
     repositories {
@@ -412,3 +413,10 @@ project.tasks.register('ijConfigure') {
 }
 
 project.tasks.ijConfigure.dependsOn(project.tasks.ijCodeSetup, project.tasks.ijRunConfigurationsSetup)
+
+project.tasks.register('purgeNpmAlphaVersions', PurgeNpmAlphaVersions) {
+    group = GroupNames.NPM_RUN
+    description = "Given an alpha version prefix for npm packages via the property -P${PurgeNpmAlphaVersions.ALPHA_PREFIX_PROPERTY}=yourPrefix, " +
+            "removes all packages with versions that match that prefix from Artifactory (e.g., @labkey/components-1.2.3-yourPrefix.0 and @labkey/workflow-0.3.4-yourPrefix.1). " +
+            " Use -PdryRun to see what versions would be deleted without actually doing the deletion."
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -57,7 +57,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.21.0
 gradleNodePluginVersion=3.0.1
-gradlePluginsVersion=1.30.0-purgeAlphaVersions-SNAPSHOT
+gradlePluginsVersion=1.30.0
 owaspDependencyCheckPluginVersion=5.2.1
 versioningPluginVersion=1.1.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -57,7 +57,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.21.0
 gradleNodePluginVersion=3.0.1
-gradlePluginsVersion=1.28.1
+gradlePluginsVersion=1.30.0-purgeAlphaVersions-SNAPSHOT
 owaspDependencyCheckPluginVersion=5.2.1
 versioningPluginVersion=1.1.0
 


### PR DESCRIPTION
#### Rationale
The alpha versions of our NPM packages never get removed unless we do that manually, and currently the manual method for doing this within the Artifactory web application requires finding and clicking on each version separately.  Even filtering to the proper versions within the Artifactory UI is not really possible.  Here we add a new Gradle task to do that purging.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/130

#### Changes
* Add task `purgeNpmAlphaVersions`
