### PR TITLE
Include 'nircEHRModules' in `ehr.gradle`

### DIFF
--- a/gradle/settings/ehr.gradle
+++ b/gradle/settings/ehr.gradle
@@ -27,6 +27,7 @@ import org.labkey.gradle.util.BuildUtils
  */
 
 List<String> ehrModulesDirs = [
+        "server/modules/nircEHRModules",
         "server/modules/onprcEHRModules",
         "server/modules/ehrModules",
         "server/modules/snprcEHRModules",


### PR DESCRIPTION
#### Rationale
Using a specific set of modules for testing EHR speeds up the `ehr_build` and avoids introducing modules that wouldn't normally be deployed with EHR. As a stopgap to include the NIRC EHR modules, I switched `ehr_build` to build all modules but that increases the build time by more than 10 minutes.

#### Changes
* Include `nircEHRModules` when building with `-PmoduleSet=ehr`
