### PR TITLE
update LabKey version to : 21.10-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -45,7 +45,7 @@ buildFromSource=true
 
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
-labkeyVersion=21.9-SNAPSHOT
+labkeyVersion=21.10-SNAPSHOT
 labkeyClientApiVersion=1.4.0
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.


### PR DESCRIPTION
#### Rationale
Bump LabKey version number on develop to 21.10-SNAPSHOT in preparation for the 21.9 monthly release