### PR TITLE
Rotate labkey-errors.log (43686), show logger info in Admin console (…

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -49,6 +49,10 @@
         <constraint name="Arg" within="" contains="" />
         <constraint name="__context__" within="" contains="" />
       </replaceConfiguration>
+      <replaceConfiguration name="Log4J 1.x logger - Use Log4J 2.x, add logger notes" problemDescriptor="Use Log4J 2.x instead of 1.x. Use LogHelper to provide a description to help admins choose their logging level" text="org.apache.log4j.LogManager.getLogger($Arg$)" recursive="false" caseInsensitive="true" type="JAVA" pattern_context="default" reformatAccordingToStyle="true" shortenFQN="true" replacement="org.labkey.api.util.logging.LogHelper.getLogger($Arg$, &quot;Fill in description&quot;)">
+        <constraint name="Arg" within="" contains="" />
+        <constraint name="__context__" within="" contains="" />
+      </replaceConfiguration>
       <replaceConfiguration name="OutputStreamWriter used without specifying character encoding" text="new OutputStreamWriter($Arg$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" replacement="PrintWriters.getPrintWriter($Arg$)">
         <constraint name="Arg" script="&quot;&quot;" nameOfExprType="java.io.OutputStream" exprTypeWithinHierarchy="true" within="" contains="" />
       </replaceConfiguration>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -4,13 +4,13 @@
     <inspection_tool class="ArraysAsListWithZeroOrOneArgument" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="BeforeClassOrAfterClassIsPublicStaticVoidNoArg" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="BeforeOrAfterIsPublicVoidNoArg" enabled="true" level="ERROR" enabled_by_default="true" />
+    <inspection_tool class="BooleanMethodIsAlwaysInverted" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="CatchMayIgnoreExceptionMerged" />
     <inspection_tool class="EmptyCatchBlock" enabled="false" level="WARNING" enabled_by_default="false">
       <option name="m_includeComments" value="true" />
       <option name="m_ignoreTestCases" value="true" />
       <option name="m_ignoreIgnoreParameter" value="true" />
     </inspection_tool>
-    <inspection_tool class="JUnit3StyleTestMethodInJUnit4Class" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="JUnitRule" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="Java8CollectionsApi" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="MissingOverrideAnnotation" enabled="true" level="WARNING" enabled_by_default="true">
@@ -22,14 +22,52 @@
         <constraint name="Expression" script="&quot;&quot;" regexp="(h|q|text|textLink|generateButton|PageFlowUtil.\w*)\(.*\)" nameOfExprType="java.lang.String" negateName="true" within="" contains="" />
         <constraint name="JspWriter" script="&quot;&quot;" nameOfExprType="javax.servlet.jsp.JspWriter" within="" contains="" />
       </searchConfiguration>
-      <replaceConfiguration name="File.getCanonicalPath() fully resolves symbolic links - use FileUtil.getAbsoluteCaseSensitiveFile() instead" text="$arg$.getCanonicalPath()" recursive="true" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" replacement="FileUtil.getAbsoluteCaseSensitiveFile($arg$).getAbsolutePath()">
-        <constraint name="arg" script="&quot;&quot;" nameOfExprType="java.io.File" within="" contains="" />
-        <constraint name="__context__" script="&quot;&quot;" within="" contains="" />
+      <replaceConfiguration name="BufferedReader(FileReader) always uses default character set" text="new BufferedReader(new FileReader($Arg$))" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" replacement="Readers.getReader($Arg$)">
+        <constraint name="Arg" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="BufferedReader(InputStreamReader) used without specifying character encoding" text="new BufferedReader(new InputStreamReader($Arg$))" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" replacement="Readers.getReader($Arg$)">
+        <constraint name="Arg" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="BufferedWriter(FileWriter) always uses default character set" text="new BufferedWriter(new FileWriter($Arg$))" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" replacement="PrintWriters.getPrintWriter($Arg$)">
+        <constraint name="Arg" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="Errors.reject(errorCode)" uuid="754a8524-698d-3596-a571-f9779f728f3a" description="Spring wants an error code, not just the error messsage." problemDescriptor="Don't use a message in place of the errorCode" text="$Errors$.reject($x$)" recursive="false" caseInsensitive="false" type="JAVA" pattern_context="default" reformatAccordingToStyle="true" shortenFQN="true" replacement="$Errors$.reject(org.labkey.api.action.SpringActionController.ERROR_MSG, $x$)">
+        <constraint name="__context__" within="" contains="" />
+        <constraint name="Errors" regexp="Errors" withinHierarchy="true" within="" contains="" />
+        <constraint name="x" within="" contains="" />
       </replaceConfiguration>
       <replaceConfiguration name="File.getCanonicalFile() fully resolves symbolic links - use FileUtil.getAbsoluteCaseSensitiveFile() instead" text="$arg$.getCanonicalFile()" recursive="true" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" replacement="FileUtil.getAbsoluteCaseSensitiveFile($arg$)">
         <constraint name="arg" script="&quot;&quot;" nameOfExprType="java.io.File" within="" contains="" />
         <constraint name="__context__" script="&quot;&quot;" within="" contains="" />
       </replaceConfiguration>
+      <replaceConfiguration name="File.getCanonicalPath() fully resolves symbolic links - use FileUtil.getAbsoluteCaseSensitiveFile() instead" text="$arg$.getCanonicalPath()" recursive="true" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" replacement="FileUtil.getAbsoluteCaseSensitiveFile($arg$).getAbsolutePath()">
+        <constraint name="arg" script="&quot;&quot;" nameOfExprType="java.io.File" within="" contains="" />
+        <constraint name="__context__" script="&quot;&quot;" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="FileReader always uses default character set" text="new FileReader($Arg$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" replacement="Readers.getReader($Arg$)">
+        <constraint name="Arg" script="&quot;&quot;" within="" contains="" />
+        <constraint name="__context__" script="&quot;&quot;" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="FileWriter always uses default character set" text="new FileWriter($Arg$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" replacement="PrintWriters.getPrintWriter($Arg$)">
+        <constraint name="Arg" script="&quot;&quot;" within="" contains="" />
+        <constraint name="__context__" script="&quot;&quot;" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="InputStreamReader used without specifying character encoding" text="new InputStreamReader($Arg$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" replacement="Readers.getReader($Arg$)">
+        <constraint name="Arg" script="&quot;&quot;" nameOfExprType="java.io.InputStream" exprTypeWithinHierarchy="true" within="" contains="" />
+        <constraint name="__context__" target="true" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="IOUtils.toString() always uses default character set" text="IOUtils.toString($Arg$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" replacement="PageFlowUtil.getStreamContentsAsString($Arg$)">
+        <constraint name="Arg" nameOfExprType="java.io.InputStream" exprTypeWithinHierarchy="true" within="" contains="" />
+        <constraint name="__context__" script="&quot;&quot;" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="Log4J logger - notes for Loggers page" problemDescriptor="Use LogHelper to provide a dsecription to help admins choose their logging level" text="org.apache.logging.log4j.LogManager.getLogger($Arg$)" recursive="false" caseInsensitive="true" type="JAVA" pattern_context="default" reformatAccordingToStyle="true" shortenFQN="true" replacement="org.labkey.api.util.logging.LogHelper.getLogger($Arg$, &quot;Fill in description&quot;)">
+        <constraint name="Arg" within="" contains="" />
+        <constraint name="__context__" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="OutputStreamWriter used without specifying character encoding" text="new OutputStreamWriter($Arg$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" replacement="PrintWriters.getPrintWriter($Arg$)">
+        <constraint name="Arg" script="&quot;&quot;" nameOfExprType="java.io.OutputStream" exprTypeWithinHierarchy="true" within="" contains="" />
+      </replaceConfiguration>
+      <searchConfiguration name="printStackTrace" text=".printStackTrace" recursive="true" caseInsensitive="true" type="JAVA" />
       <searchConfiguration name="PrintWriter used without specifying encoding" text="new PrintWriter($Parameter$, $Parameter2$)" recursive="false" caseInsensitive="false" type="JAVA">
         <constraint name="Parameter" script="&quot;&quot;" nameOfExprType="java.io.File|java.io.OutputStream|java.lang.String" exprTypeWithinHierarchy="true" formalTypeWithinHierarchy="true" within="" contains="" />
         <constraint name="Parameter2" script="&quot;&quot;" nameOfExprType="boolean" minCount="0" within="" contains="" />
@@ -38,56 +76,18 @@
         <constraint name="String" script="&quot;&quot;" nameOfExprType="java.lang.String" within="" contains="" />
         <constraint name="__context__" script="&quot;&quot;" within="" contains="" />
       </replaceConfiguration>
-      <replaceConfiguration name="BufferedReader(InputStreamReader) used without specifying character encoding" text="new BufferedReader(new InputStreamReader($Arg$))" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" replacement="Readers.getReader($Arg$)">
-        <constraint name="Arg" within="" contains="" />
-      </replaceConfiguration>
-      <replaceConfiguration name="InputStreamReader used without specifying character encoding" text="new InputStreamReader($Arg$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" replacement="Readers.getReader($Arg$)">
-        <constraint name="Arg" script="&quot;&quot;" nameOfExprType="java.io.InputStream" exprTypeWithinHierarchy="true" within="" contains="" />
-        <constraint name="__context__" target="true" within="" contains="" />
-      </replaceConfiguration>
-      <replaceConfiguration name="OutputStreamWriter used without specifying character encoding" text="new OutputStreamWriter($Arg$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" replacement="PrintWriters.getPrintWriter($Arg$)">
-        <constraint name="Arg" script="&quot;&quot;" nameOfExprType="java.io.OutputStream" exprTypeWithinHierarchy="true" within="" contains="" />
-      </replaceConfiguration>
-      <replaceConfiguration name="BufferedReader(FileReader) always uses default character set" text="new BufferedReader(new FileReader($Arg$))" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" replacement="Readers.getReader($Arg$)">
-        <constraint name="Arg" within="" contains="" />
-      </replaceConfiguration>
-      <replaceConfiguration name="FileReader always uses default character set" text="new FileReader($Arg$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" replacement="Readers.getReader($Arg$)">
-        <constraint name="Arg" script="&quot;&quot;" within="" contains="" />
-        <constraint name="__context__" script="&quot;&quot;" within="" contains="" />
-      </replaceConfiguration>
-      <replaceConfiguration name="BufferedWriter(FileWriter) always uses default character set" text="new BufferedWriter(new FileWriter($Arg$))" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" replacement="PrintWriters.getPrintWriter($Arg$)">
-        <constraint name="Arg" within="" contains="" />
-      </replaceConfiguration>
-      <replaceConfiguration name="FileWriter always uses default character set" text="new FileWriter($Arg$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" replacement="PrintWriters.getPrintWriter($Arg$)">
-        <constraint name="Arg" script="&quot;&quot;" within="" contains="" />
-        <constraint name="__context__" script="&quot;&quot;" within="" contains="" />
-      </replaceConfiguration>
-      <replaceConfiguration name="IOUtils.toString() always uses default character set" text="IOUtils.toString($Arg$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" replacement="PageFlowUtil.getStreamContentsAsString($Arg$)">
-        <constraint name="Arg" nameOfExprType="java.io.InputStream" exprTypeWithinHierarchy="true" within="" contains="" />
-        <constraint name="__context__" script="&quot;&quot;" within="" contains="" />
-      </replaceConfiguration>
       <replaceConfiguration name="String constructor passed bytes without specifying character encoding" text="new String($arg1$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" useStaticImport="true" replacement="new String($arg1$, StringUtilsLabKey.DEFAULT_CHARSET)">
-        <constraint name="arg1" script="&quot;&quot;" nameOfExprType="byte\[\]" expressionTypes="byte[]" within="" contains="" />
-      </replaceConfiguration>
-      <replaceConfiguration name="Errors.reject(errorCode)" uuid="754a8524-698d-3596-a571-f9779f728f3a" description="Spring wants an error code, not just the error messsage." problemDescriptor="Don't use a message in place of the errorCode" text="$Errors$.reject($x$)" recursive="false" caseInsensitive="false" type="JAVA" pattern_context="default" reformatAccordingToStyle="true" shortenFQN="true" replacement="$Errors$.reject(org.labkey.api.action.SpringActionController.ERROR_MSG, $x$)">
-        <constraint name="__context__" within="" contains="" />
-        <constraint name="Errors" regexp="Errors" withinHierarchy="true" within="" contains="" />
-        <constraint name="x" within="" contains="" />
+        <constraint name="arg1" script="&quot;&quot;" nameOfExprType="byte\[\]" within="" contains="" />
       </replaceConfiguration>
       <searchConfiguration name="System.out" text="System.$out$" recursive="true" caseInsensitive="true" type="JAVA">
         <constraint name="out" regexp="(out|err)" within="" contains="" />
       </searchConfiguration>
-      <searchConfiguration name="printStackTrace" text=".printStackTrace" recursive="true" caseInsensitive="true" type="JAVA" />
     </inspection_tool>
     <inspection_tool class="SimplifiableIfStatement" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="TestMethodIsPublicVoidNoArg" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="UnnecessaryBoxing" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="UnnecessaryUnboxing" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="UseOfObsoleteAssert" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="WeakerAccess" enabled="false" level="WARNING" enabled_by_default="false">
-      <option name="SUGGEST_PACKAGE_LOCAL_FOR_MEMBERS" value="true" />
-      <option name="SUGGEST_PACKAGE_LOCAL_FOR_TOP_CLASSES" value="true" />
-      <option name="SUGGEST_PRIVATE_FOR_INNERS" value="false" />
-    </inspection_tool>
+    <inspection_tool class="b1ef1afe-6b2a-36e4-887f-9fc6392b6a53" enabled="true" level="WARNING" enabled_by_default="true" />
   </profile>
 </component>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -45,7 +45,7 @@
         <constraint name="Arg" script="&quot;&quot;" nameOfExprType="java.io.InputStream" exprTypeWithinHierarchy="true" within="" contains="" />
         <constraint name="__context__" target="true" within="" contains="" />
       </replaceConfiguration>
-      <replaceConfiguration name="Log4J logger - notes for Loggers page" problemDescriptor="Use LogHelper to provide a dsecription to help admins choose their logging level" text="org.apache.logging.log4j.LogManager.getLogger($Arg$)" recursive="false" caseInsensitive="true" type="JAVA" pattern_context="default" reformatAccordingToStyle="true" shortenFQN="true" replacement="org.labkey.api.util.logging.LogHelper.getLogger($Arg$, &quot;Fill in description&quot;)">
+      <replaceConfiguration name="Log4J logger - notes for Loggers page" problemDescriptor="Use LogHelper to provide a description to help admins choose their logging level" text="org.apache.logging.log4j.LogManager.getLogger($Arg$)" recursive="false" caseInsensitive="true" type="JAVA" pattern_context="default" reformatAccordingToStyle="true" shortenFQN="true" replacement="org.labkey.api.util.logging.LogHelper.getLogger($Arg$, &quot;Fill in description&quot;)">
         <constraint name="Arg" within="" contains="" />
         <constraint name="__context__" within="" contains="" />
       </replaceConfiguration>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -4,13 +4,13 @@
     <inspection_tool class="ArraysAsListWithZeroOrOneArgument" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="BeforeClassOrAfterClassIsPublicStaticVoidNoArg" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="BeforeOrAfterIsPublicVoidNoArg" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="BooleanMethodIsAlwaysInverted" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="CatchMayIgnoreExceptionMerged" />
     <inspection_tool class="EmptyCatchBlock" enabled="false" level="WARNING" enabled_by_default="false">
       <option name="m_includeComments" value="true" />
       <option name="m_ignoreTestCases" value="true" />
       <option name="m_ignoreIgnoreParameter" value="true" />
     </inspection_tool>
+    <inspection_tool class="JUnit3StyleTestMethodInJUnit4Class" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="JUnitRule" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="Java8CollectionsApi" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="MissingOverrideAnnotation" enabled="true" level="WARNING" enabled_by_default="true">
@@ -22,52 +22,14 @@
         <constraint name="Expression" script="&quot;&quot;" regexp="(h|q|text|textLink|generateButton|PageFlowUtil.\w*)\(.*\)" nameOfExprType="java.lang.String" negateName="true" within="" contains="" />
         <constraint name="JspWriter" script="&quot;&quot;" nameOfExprType="javax.servlet.jsp.JspWriter" within="" contains="" />
       </searchConfiguration>
-      <replaceConfiguration name="BufferedReader(FileReader) always uses default character set" text="new BufferedReader(new FileReader($Arg$))" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" replacement="Readers.getReader($Arg$)">
-        <constraint name="Arg" within="" contains="" />
-      </replaceConfiguration>
-      <replaceConfiguration name="BufferedReader(InputStreamReader) used without specifying character encoding" text="new BufferedReader(new InputStreamReader($Arg$))" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" replacement="Readers.getReader($Arg$)">
-        <constraint name="Arg" within="" contains="" />
-      </replaceConfiguration>
-      <replaceConfiguration name="BufferedWriter(FileWriter) always uses default character set" text="new BufferedWriter(new FileWriter($Arg$))" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" replacement="PrintWriters.getPrintWriter($Arg$)">
-        <constraint name="Arg" within="" contains="" />
-      </replaceConfiguration>
-      <replaceConfiguration name="Errors.reject(errorCode)" uuid="754a8524-698d-3596-a571-f9779f728f3a" description="Spring wants an error code, not just the error messsage." problemDescriptor="Don't use a message in place of the errorCode" text="$Errors$.reject($x$)" recursive="false" caseInsensitive="false" type="JAVA" pattern_context="default" reformatAccordingToStyle="true" shortenFQN="true" replacement="$Errors$.reject(org.labkey.api.action.SpringActionController.ERROR_MSG, $x$)">
-        <constraint name="__context__" within="" contains="" />
-        <constraint name="Errors" regexp="Errors" withinHierarchy="true" within="" contains="" />
-        <constraint name="x" within="" contains="" />
+      <replaceConfiguration name="File.getCanonicalPath() fully resolves symbolic links - use FileUtil.getAbsoluteCaseSensitiveFile() instead" text="$arg$.getCanonicalPath()" recursive="true" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" replacement="FileUtil.getAbsoluteCaseSensitiveFile($arg$).getAbsolutePath()">
+        <constraint name="arg" script="&quot;&quot;" nameOfExprType="java.io.File" within="" contains="" />
+        <constraint name="__context__" script="&quot;&quot;" within="" contains="" />
       </replaceConfiguration>
       <replaceConfiguration name="File.getCanonicalFile() fully resolves symbolic links - use FileUtil.getAbsoluteCaseSensitiveFile() instead" text="$arg$.getCanonicalFile()" recursive="true" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" replacement="FileUtil.getAbsoluteCaseSensitiveFile($arg$)">
         <constraint name="arg" script="&quot;&quot;" nameOfExprType="java.io.File" within="" contains="" />
         <constraint name="__context__" script="&quot;&quot;" within="" contains="" />
       </replaceConfiguration>
-      <replaceConfiguration name="File.getCanonicalPath() fully resolves symbolic links - use FileUtil.getAbsoluteCaseSensitiveFile() instead" text="$arg$.getCanonicalPath()" recursive="true" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" replacement="FileUtil.getAbsoluteCaseSensitiveFile($arg$).getAbsolutePath()">
-        <constraint name="arg" script="&quot;&quot;" nameOfExprType="java.io.File" within="" contains="" />
-        <constraint name="__context__" script="&quot;&quot;" within="" contains="" />
-      </replaceConfiguration>
-      <replaceConfiguration name="FileReader always uses default character set" text="new FileReader($Arg$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" replacement="Readers.getReader($Arg$)">
-        <constraint name="Arg" script="&quot;&quot;" within="" contains="" />
-        <constraint name="__context__" script="&quot;&quot;" within="" contains="" />
-      </replaceConfiguration>
-      <replaceConfiguration name="FileWriter always uses default character set" text="new FileWriter($Arg$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" replacement="PrintWriters.getPrintWriter($Arg$)">
-        <constraint name="Arg" script="&quot;&quot;" within="" contains="" />
-        <constraint name="__context__" script="&quot;&quot;" within="" contains="" />
-      </replaceConfiguration>
-      <replaceConfiguration name="InputStreamReader used without specifying character encoding" text="new InputStreamReader($Arg$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" replacement="Readers.getReader($Arg$)">
-        <constraint name="Arg" script="&quot;&quot;" nameOfExprType="java.io.InputStream" exprTypeWithinHierarchy="true" within="" contains="" />
-        <constraint name="__context__" target="true" within="" contains="" />
-      </replaceConfiguration>
-      <replaceConfiguration name="IOUtils.toString() always uses default character set" text="IOUtils.toString($Arg$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" replacement="PageFlowUtil.getStreamContentsAsString($Arg$)">
-        <constraint name="Arg" nameOfExprType="java.io.InputStream" exprTypeWithinHierarchy="true" within="" contains="" />
-        <constraint name="__context__" script="&quot;&quot;" within="" contains="" />
-      </replaceConfiguration>
-      <replaceConfiguration name="Log4J logger - notes for Loggers page" problemDescriptor="Use LogHelper to provide a dsecription to help admins choose their logging level" text="org.apache.logging.log4j.LogManager.getLogger($Arg$)" recursive="false" caseInsensitive="true" type="JAVA" pattern_context="default" reformatAccordingToStyle="true" shortenFQN="true" replacement="org.labkey.api.util.logging.LogHelper.getLogger($Arg$, &quot;Fill in description&quot;)">
-        <constraint name="Arg" within="" contains="" />
-        <constraint name="__context__" within="" contains="" />
-      </replaceConfiguration>
-      <replaceConfiguration name="OutputStreamWriter used without specifying character encoding" text="new OutputStreamWriter($Arg$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" replacement="PrintWriters.getPrintWriter($Arg$)">
-        <constraint name="Arg" script="&quot;&quot;" nameOfExprType="java.io.OutputStream" exprTypeWithinHierarchy="true" within="" contains="" />
-      </replaceConfiguration>
-      <searchConfiguration name="printStackTrace" text=".printStackTrace" recursive="true" caseInsensitive="true" type="JAVA" />
       <searchConfiguration name="PrintWriter used without specifying encoding" text="new PrintWriter($Parameter$, $Parameter2$)" recursive="false" caseInsensitive="false" type="JAVA">
         <constraint name="Parameter" script="&quot;&quot;" nameOfExprType="java.io.File|java.io.OutputStream|java.lang.String" exprTypeWithinHierarchy="true" formalTypeWithinHierarchy="true" within="" contains="" />
         <constraint name="Parameter2" script="&quot;&quot;" nameOfExprType="boolean" minCount="0" within="" contains="" />
@@ -76,18 +38,60 @@
         <constraint name="String" script="&quot;&quot;" nameOfExprType="java.lang.String" within="" contains="" />
         <constraint name="__context__" script="&quot;&quot;" within="" contains="" />
       </replaceConfiguration>
+      <replaceConfiguration name="BufferedReader(InputStreamReader) used without specifying character encoding" text="new BufferedReader(new InputStreamReader($Arg$))" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" replacement="Readers.getReader($Arg$)">
+        <constraint name="Arg" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="InputStreamReader used without specifying character encoding" text="new InputStreamReader($Arg$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" replacement="Readers.getReader($Arg$)">
+        <constraint name="Arg" script="&quot;&quot;" nameOfExprType="java.io.InputStream" exprTypeWithinHierarchy="true" within="" contains="" />
+        <constraint name="__context__" target="true" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="Log4J logger - notes for Loggers page" problemDescriptor="Use LogHelper to provide a dsecription to help admins choose their logging level" text="org.apache.logging.log4j.LogManager.getLogger($Arg$)" recursive="false" caseInsensitive="true" type="JAVA" pattern_context="default" reformatAccordingToStyle="true" shortenFQN="true" replacement="org.labkey.api.util.logging.LogHelper.getLogger($Arg$, &quot;Fill in description&quot;)">
+        <constraint name="Arg" within="" contains="" />
+        <constraint name="__context__" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="OutputStreamWriter used without specifying character encoding" text="new OutputStreamWriter($Arg$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" replacement="PrintWriters.getPrintWriter($Arg$)">
+        <constraint name="Arg" script="&quot;&quot;" nameOfExprType="java.io.OutputStream" exprTypeWithinHierarchy="true" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="BufferedReader(FileReader) always uses default character set" text="new BufferedReader(new FileReader($Arg$))" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" replacement="Readers.getReader($Arg$)">
+        <constraint name="Arg" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="FileReader always uses default character set" text="new FileReader($Arg$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" replacement="Readers.getReader($Arg$)">
+        <constraint name="Arg" script="&quot;&quot;" within="" contains="" />
+        <constraint name="__context__" script="&quot;&quot;" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="BufferedWriter(FileWriter) always uses default character set" text="new BufferedWriter(new FileWriter($Arg$))" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" replacement="PrintWriters.getPrintWriter($Arg$)">
+        <constraint name="Arg" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="FileWriter always uses default character set" text="new FileWriter($Arg$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" replacement="PrintWriters.getPrintWriter($Arg$)">
+        <constraint name="Arg" script="&quot;&quot;" within="" contains="" />
+        <constraint name="__context__" script="&quot;&quot;" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="IOUtils.toString() always uses default character set" text="IOUtils.toString($Arg$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" replacement="PageFlowUtil.getStreamContentsAsString($Arg$)">
+        <constraint name="Arg" nameOfExprType="java.io.InputStream" exprTypeWithinHierarchy="true" within="" contains="" />
+        <constraint name="__context__" script="&quot;&quot;" within="" contains="" />
+      </replaceConfiguration>
       <replaceConfiguration name="String constructor passed bytes without specifying character encoding" text="new String($arg1$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" useStaticImport="true" replacement="new String($arg1$, StringUtilsLabKey.DEFAULT_CHARSET)">
-        <constraint name="arg1" script="&quot;&quot;" nameOfExprType="byte\[\]" within="" contains="" />
+        <constraint name="arg1" script="&quot;&quot;" nameOfExprType="byte\[\]" expressionTypes="byte[]" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="Errors.reject(errorCode)" uuid="754a8524-698d-3596-a571-f9779f728f3a" description="Spring wants an error code, not just the error messsage." problemDescriptor="Don't use a message in place of the errorCode" text="$Errors$.reject($x$)" recursive="false" caseInsensitive="false" type="JAVA" pattern_context="default" reformatAccordingToStyle="true" shortenFQN="true" replacement="$Errors$.reject(org.labkey.api.action.SpringActionController.ERROR_MSG, $x$)">
+        <constraint name="__context__" within="" contains="" />
+        <constraint name="Errors" regexp="Errors" withinHierarchy="true" within="" contains="" />
+        <constraint name="x" within="" contains="" />
       </replaceConfiguration>
       <searchConfiguration name="System.out" text="System.$out$" recursive="true" caseInsensitive="true" type="JAVA">
         <constraint name="out" regexp="(out|err)" within="" contains="" />
       </searchConfiguration>
+      <searchConfiguration name="printStackTrace" text=".printStackTrace" recursive="true" caseInsensitive="true" type="JAVA" />
     </inspection_tool>
     <inspection_tool class="SimplifiableIfStatement" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="TestMethodIsPublicVoidNoArg" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="UnnecessaryBoxing" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="UnnecessaryUnboxing" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="UseOfObsoleteAssert" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="b1ef1afe-6b2a-36e4-887f-9fc6392b6a53" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="WeakerAccess" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="SUGGEST_PACKAGE_LOCAL_FOR_MEMBERS" value="true" />
+      <option name="SUGGEST_PACKAGE_LOCAL_FOR_TOP_CLASSES" value="true" />
+      <option name="SUGGEST_PRIVATE_FOR_INNERS" value="false" />
+    </inspection_tool>
   </profile>
 </component>

--- a/webapps/log4j2.xml
+++ b/webapps/log4j2.xml
@@ -21,8 +21,22 @@
             </PatternLayout>
             <Policies>
                 <OnStartupTriggeringPolicy />
+                <SizeBasedTriggeringPolicy size="100 MB"/>
             </Policies>
-            <DefaultRolloverStrategy max="3"/>
+            <DefaultRolloverStrategy fileIndex="min">
+                <Delete basePath="${sys:labkey.log.home}">
+                    <ScriptCondition>
+                        <!-- Use custom Java code to retain the first log file from the current session if it's about
+                        to be rotated out. It may have root cause information about problems that would otherwise be lost -->
+                        <Script name="retainFirst" language="rhino"><![CDATA[
+                                var ErrorLogRotator = org.labkey.api.util.logging.ErrorLogRotator;
+                                var rotator = new ErrorLogRotator();
+                                rotator.filter(pathList);
+                            ]]>
+                        </Script>
+                    </ScriptCondition>
+                </Delete>
+            </DefaultRolloverStrategy>
 
         </RollingFile>
 


### PR DESCRIPTION
#### Rationale
* Runaway error logging can fill the disk via labkey-errors.log, further compounding server problems
* Users like to know what loggers may have debug logging of interest. They can currently find some guidance at https://www.labkey.org/Documentation/wiki-page.view?name=loggers
* Issue 43787: Add use-case guidance to Loggers page of admin console
* Issue 43686: Improve log rotation on labkey-errors.log to avoid filling disk

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2618

#### Changes
* Rotate labkey-errors.log at 100MB
* Retain last 3 files, plus ensure that we archive the error log with the first error logging from the current startup in a separate dated file
* IntelliJ inspection to encourage adding a note for Loggers
