### PR TITLE
bump LabKey version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -45,7 +45,7 @@ buildFromSource=true
 
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
-labkeyVersion=21.7.4
+labkeyVersion=21.7.5
 labkeyClientApiVersion=1.4.0
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.


### PR DESCRIPTION
#### Rationale
Bump LabKey version for the 21.7.5 maintenance release