### PR TITLE
Include VM options required for JDK 16+ compatibility

### DIFF
--- a/.idea/runConfigurations/templates/LabKeyEmbedded_Dev.xml
+++ b/.idea/runConfigurations/templates/LabKeyEmbedded_Dev.xml
@@ -4,7 +4,7 @@
     <option name="SPRING_BOOT_MAIN_CLASS" value="org.labkey.embedded.LabKeyServer" />
     <option name="HIDE_BANNER" value="true" />
     <option name="ENABLE_JMX_AGENT" value="false" />
-    <option name="VM_PARAMETERS" value="-Ddevmode=true" />
+    <option name="VM_PARAMETERS" value="--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED -Ddevmode=true" />
     <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$/build/deploy/embedded" />
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
     <option name="ALTERNATIVE_JRE_PATH" value="labkey" />

--- a/.idea/runConfigurations/templates/LabKey_Dev.xml
+++ b/.idea/runConfigurations/templates/LabKey_Dev.xml
@@ -3,7 +3,7 @@
     <option name="MAIN_CLASS_NAME" value="org.apache.catalina.startup.Bootstrap" />
     <module name="labkey-server.server.modules.platform.api.main" />
     <option name="PROGRAM_PARAMETERS" value="start" />
-    <option name="VM_PARAMETERS" value="-Dcatalina.base=&quot;./&quot; -Dcatalina.home=&quot;./&quot; -Djava.io.tmpdir=&quot;./temp&quot; -Ddevmode=true -ea -Dsun.io.useCanonCaches=false -Xmx2G -classpath &quot;./bin/*PATH_SEPARATOR$APPLICATION_HOME_DIR$/lib/idea_rt.jar&quot;" />
+    <option name="VM_PARAMETERS" value="-Dcatalina.base=&quot;./&quot; -Dcatalina.home=&quot;./&quot; -Djava.io.tmpdir=&quot;./temp&quot; --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED -Ddevmode=true -ea -Dsun.io.useCanonCaches=false -Xmx2G -classpath &quot;./bin/*PATH_SEPARATOR$APPLICATION_HOME_DIR$/lib/idea_rt.jar&quot;" />
     <option name="WORKING_DIRECTORY" value="$CATALINA_HOME$" />
     <method v="2" />
   </configuration>

--- a/.idea/runConfigurations/templates/LabKey_Production.xml
+++ b/.idea/runConfigurations/templates/LabKey_Production.xml
@@ -5,7 +5,7 @@
     <option name="MAIN_CLASS_NAME" value="org.apache.catalina.startup.Bootstrap" />
     <module name="labkey-server.server.modules.platform.api.main" />
     <option name="PROGRAM_PARAMETERS" value="start" />
-    <option name="VM_PARAMETERS" value="-Dcatalina.base=&quot;./&quot; -Dcatalina.home=&quot;./&quot; -Djava.io.tmpdir=&quot;./temp&quot; -Ddevmode=false -Dsun.io.useCanonCaches=false -Xmx2G -classpath &quot;./bin/*PATH_SEPARATOR$APPLICATION_HOME_DIR$/lib/idea_rt.jar&quot;" />
+    <option name="VM_PARAMETERS" value="-Dcatalina.base=&quot;./&quot; -Dcatalina.home=&quot;./&quot; -Djava.io.tmpdir=&quot;./temp&quot; --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED -Ddevmode=false -Dsun.io.useCanonCaches=false -Xmx2G -classpath &quot;./bin/*PATH_SEPARATOR$APPLICATION_HOME_DIR$/lib/idea_rt.jar&quot;" />
     <option name="WORKING_DIRECTORY" value="$CATALINA_HOME$" />
     <RunnerSettings RunnerId="Debug">
       <option name="DEBUG_PORT" value="3078" />


### PR DESCRIPTION
#### Rationale
JDK 16 and up require VM options to enable reflection on core Java classes

#### Changes
* Include the magic arguments in the IntelliJ debug configuration