### PR TITLE
Update to gradle plugin 1.29.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,10 +20,10 @@ org.gradle.jvmargs=-Xmx2048m
 versionConflictAction=delete
 
 # uncomment the following line for running the application with embedded tomcat
-useEmbeddedTomcat
+#useEmbeddedTomcat
 
 # uncomment the following line when using a local build of a server with embedded tomcat
-useLocalBuild
+#useLocalBuild
 
 # uncomment the following line when using SSL for your embedded tomcat server
 #useSsl

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,10 +20,10 @@ org.gradle.jvmargs=-Xmx2048m
 versionConflictAction=delete
 
 # uncomment the following line for running the application with embedded tomcat
-#useEmbeddedTomcat
+useEmbeddedTomcat
 
 # uncomment the following line when using a local build of a server with embedded tomcat
-#useLocalBuild
+useLocalBuild
 
 # uncomment the following line when using SSL for your embedded tomcat server
 #useSsl
@@ -57,7 +57,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.21.0
 gradleNodePluginVersion=3.0.1
-gradlePluginsVersion=1.28.1
+gradlePluginsVersion=1.29.0
 owaspDependencyCheckPluginVersion=5.2.1
 versioningPluginVersion=1.1.0
 


### PR DESCRIPTION
#### Rationale
Gradle plugin 1.29.0 fixes an issue in the manual upgrade script. This fix wasn't needed for the core repository until a recent upgrade.

#### Related Issue
* [43356: manual-upgrade.sh script fails to upgrade standalone installer](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=43356)

#### Changes
* Update to gradle plugin 1.29.0
