### PR TITLE
Update gradle plugin

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -57,7 +57,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.21.0
 gradleNodePluginVersion=3.0.1
-gradlePluginsVersion=1.30.2
+gradlePluginsVersion=1.30.3
 owaspDependencyCheckPluginVersion=5.2.1
 versioningPluginVersion=1.1.0
 


### PR DESCRIPTION
#### Rationale
Gradle plugin v1.30.3 has some fixes that we want before branching for 21.11

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/tree/v1.30.3

#### Changes
* Don't cache the fileModule plugin's moduleXml task
* Adjust test.properties.template usage when running on TeamCity
* Fix extra data source configuration in DoThenSetup
