### PR TITLE
Add GitHub release automation workflows

### DIFF
--- a/.github/workflows/branch_release.yml
+++ b/.github/workflows/branch_release.yml
@@ -1,0 +1,23 @@
+---
+# Workflow to automate creation and updating of release branches
+name: Release Branching
+
+# Trigger on tags created by TeamCity
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  branch_release:
+    if: github.event.created && github.event.sender.login == 'labkey-teamcity'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Create branches and PRs
+        uses: LabKey/gitHubActions/branch-release@develop
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/merge_release.yml
+++ b/.github/workflows/merge_release.yml
@@ -1,0 +1,28 @@
+---
+# Workflow to automate merging release branches
+name: Release Merging
+
+# Trigger on PR approval
+on:
+  pull_request_review:
+    types:
+      - submitted
+
+jobs:
+  merge_release:
+    if: >
+      github.event.review.state == 'approved' &&
+      github.event.pull_request.user.login == 'github-actions[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Merge PR
+        uses: LabKey/gitHubActions/merge-release@develop
+        with:
+          target_branch: ${{ github.event.pull_request.base.ref }}
+          merge_branch: ${{ github.event.pull_request.head.ref }}
+          pr_number: ${{ github.event.pull_request.number }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -1,0 +1,26 @@
+---
+# Workflow to validate Pull Request branches
+name: PR Validation
+
+# Trigger on PR creation
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+
+jobs:
+  validate_pr:
+    if: github.event.pull_request.head.repo.owner.login == 'LabKey'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Validate PR Branches
+        uses: LabKey/gitHubActions/validate-pr@develop
+        with:
+          pr_base: ${{ github.event.pull_request.base.ref }}
+          pr_head: ${{ github.event.pull_request.head.ref }}
+          pr_number: ${{ github.event.pull_request.number }}
+          pr_title: ${{ github.event.pull_request.title }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#### Rationale
The release process for module repositories is largely automated. Out github actions have been updated to work with the server repo. We just need to add them.

#### Related Pull Requests
* https://github.com/LabKey/gitHubActions/pull/17

#### Changes
* Add GitHub release automation workflows
