### PR TITLE
Update to reflect the actual community distribution

### DIFF
--- a/gradle/settings/community.gradle
+++ b/gradle/settings/community.gradle
@@ -1,2 +1,37 @@
-// Deprecated. All modules live in 'server/modules'
-apply from: 'all.gradle'
+
+buildscript {
+    repositories {
+        maven {
+            url "${artifactory_contextUrl}/plugins-release"
+        }
+        if (gradlePluginsVersion.contains("SNAPSHOT"))
+        {
+            maven {
+                url "${artifactory_contextUrl}/plugins-snapshot-local"
+            }
+
+        }
+    }
+    dependencies {
+        classpath "org.labkey.build:gradlePlugins:${gradlePluginsVersion}"
+    }
+    configurations.all {
+        // Check for updates every build for SNAPSHOT dependencies
+        resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
+    }
+}
+
+import org.labkey.gradle.util.BuildUtils
+
+BuildUtils.includeBaseModules(this.settings)
+include ":server:modules:platform:announcements"
+include ":server:modules:platform:assay"
+include ":server:modules:platform:issues"
+include ":server:modules:platform:list"
+include ":server:modules:commonAssays:ms2"
+include ":server:modules:platform:search"
+include ":server:modules:platform:study"
+include ":server:modules:platform:survey"
+include ":server:modules:targetedms"
+include ":server:modules:platform:visualization"
+include ":server:modules:platform:wiki"


### PR DESCRIPTION
#### Rationale
The `community` module set doesn't provide you with community modules, but all modules instead.  This update aligns the module set with what's included in the community distribution.

If this is used on TeamCity and really needs to bring in all the modules in `modules`, let's at least rename the file.

#### Changes
* Update `community` module set 
