### PR TITLE
bump LabKey version on develop

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -45,7 +45,7 @@ buildFromSource=true
 
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
-labkeyVersion=21.11-SNAPSHOT
+labkeyVersion=21.12-SNAPSHOT
 labkeyClientApiVersion=1.4.0
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.


### PR DESCRIPTION
#### Rationale
Bump the LabKey version on the develop branch in preparation for 21.11 branching.
