### PR TITLE
Upgrade PostgreSQL JDBC driver 42.3.0 -> 42.3.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -229,7 +229,7 @@ poiVersion=4.1.2
 
 pollingWatchVersion=0.2.0
 
-postgresqlDriverVersion=42.3.0
+postgresqlDriverVersion=42.3.1
 
 quartzVersion=2.1.7
 


### PR DESCRIPTION
#### Rationale
PostgreSQL JDBC driver 42.3.1 fixes a regression introduced in 42.3.0.

[Issue 44252: Upgrade PostgreSQL JDBC driver 42.3.0 -> 42.3.1](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44252)

#### Related Pull Requests[
* https://github.com/LabKey/platform/pull/2752