### PR TITLE
Upgrade gson, MySQL JDBC driver, and Jackson

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -168,9 +168,6 @@ httpclientVersion=4.5.13
 httpcoreVersion=4.4.14
 httpmimeVersion=4.5.13
 
-# Using 2.12.3 produces a runtime error related to support for java.time.LocalDate
-# that can probably be resolved with some other dependencies in the mix but attempts
-# so far have been unsuccessful
 jacksonVersion=2.13.0
 jacksonAnnotationsVersion=2.13.0
 jacksonJaxrsBaseVersion=2.13.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -150,7 +150,7 @@ graalVersion=20.0.0
 
 # Cloud and SequenceAnalysis bring gson in as a transitive dependency.
 # We resolve to the later version here to keep things consistent
-gsonVersion=2.8.8
+gsonVersion=2.8.9
 
 guavaVersion=31.0.1-jre
 gwtVersion=2.8.2
@@ -171,9 +171,9 @@ httpmimeVersion=4.5.13
 # Using 2.12.3 produces a runtime error related to support for java.time.LocalDate
 # that can probably be resolved with some other dependencies in the mix but attempts
 # so far have been unsuccessful
-jacksonVersion=2.11.3
-jacksonAnnotationsVersion=2.11.3
-jacksonJaxrsBaseVersion=2.11.3
+jacksonVersion=2.13.0
+jacksonAnnotationsVersion=2.13.0
+jacksonJaxrsBaseVersion=2.13.0
 
 jamaVersion=1.0.3
 
@@ -212,7 +212,7 @@ kaptchaVersion=2.3
 
 log4j2Version=2.14.1
 
-mysqlDriverVersion=8.0.26
+mysqlDriverVersion=8.0.27
 
 objenesisVersion=1.0
 


### PR DESCRIPTION
#### Rationale
Upgrade gson 2.8.8 --> 2.8.9
Upgrade MySQL JDBC driver 8.0.26 -> 8.0.27
Upgrade Jackson 2.11.3 --> 2.13.0

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2758