### PR TITLE
Ignore tools directory. Used for build tools.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ labkey-ui-components/
 remoteapi/
 server/modules/ 
 server/testAutomation/
+tools/
 
 # Include the remoteapi README -- this line will override previous exclusion
 !remoteapi/README.md


### PR DESCRIPTION
#### Rationale
[Special build tools](https://github.com/labkey/tools) might be enlisted to the root of this repository.

#### Changes
* Add `tools/` to `.gitignore`
