### PR TITLE
Upgrade Tika 1.26 -> 2.1.0 plus dependencies

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -101,12 +101,13 @@ apacheMinaVersion=2.0.19
 # (mothership) -> json-path -> json-smart -> accessor-smart
 # (core) -> graalvm
 # tika
-asmVersion=9.1
+asmVersion=9.2
 
 # Apache Batik -- Batik version is dictated by Apache FOP, but we need to pull in batik-codec separately
 batikVersion=1.10
 
-bouncycastleVersion=1.60
+# sync with Tika version
+bouncycastleVersion=1.69
 
 cglibNodepVersion=2.2.3
 
@@ -117,7 +118,7 @@ commonsCollectionsVersion=3.2.2
 commonsCollections4Version=4.4
 commonsCodecVersion=1.15
 # sync with version Tika ships
-commonsCompressVersion=1.20
+commonsCompressVersion=1.21
 commonsDbcpVersion=1.4
 commonsDiscoveryVersion=0.2
 commonsDigesterVersion=1.8.1
@@ -219,7 +220,7 @@ opencsvVersion=2.3
 patriciaTrieVersion=0.6
 
 # sync with version Tika ships
-pdfboxVersion=2.0.23
+pdfboxVersion=2.0.24
 
 # sync with version Tika ships
 poiVersion=4.1.2
@@ -232,15 +233,16 @@ quartzVersion=2.1.7
 
 rforgeVersion=0.6-8
 
-romeVersion=1.7.1
+# sync with Tika version
+romeVersion=1.16.0
 
 # this version is required for Tomcat 7 support
 servletApiVersion=3.0
 
 # this version is forced for compatibility with pipeline and tika
-slf4jLog4j12Version=1.7.30
+slf4jLog4j12Version=1.7.32
 # this version is forced for compatibility with api, LDK, and workflow
-slf4jLog4jApiVersion=1.7.30
+slf4jLog4jApiVersion=1.7.32
 
 
 springBootVersion=2.2.13.RELEASE
@@ -259,7 +261,7 @@ stax2ApiVersion=4.2.1
 thumbnailatorVersion=0.4.8
 
 # used for tika-core in API and tika-parsers in search
-tikaVersion=1.26
+tikaVersion=2.1.0
 tukaaniXZVersion=1.9
 
 validationApiVersion=1.1.0.Final


### PR DESCRIPTION
#### Rationale
It's time to upgrade

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2812