### PR TITLE
Upgrade to NPM LTS current release for compatibility with M1/arm64 CPUs

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -65,7 +65,7 @@ versioningPluginVersion=1.1.0
 # will be downloaded and used. If not set, the existing local installations will be use
 # The version of npm corresponds to the given version of node
 npmVersion=6.14.13
-nodeVersion=14.17.1
+nodeVersion=16.13.1
 nodeRepo=https://nodejs.org/dist
 # Directory in a project's build directory where the node binary will be placed
 nodeWorkDirectory=.node


### PR DESCRIPTION
#### Rationale
New MacBooks use a new chipset. NPM 14.x didn't publish builds that were compiled for the new architecture, but newer versions do. 16.x is their current LTS release

**PR Against Develop:** https://github.com/LabKey/server/pull/161

#### Changes
* Switch from NPM 14.7.1 to 16.3.1