### PR TITLE
Upgrade NPM and Node to current LTS for compatibility with M1/arm64 CPUs

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -64,8 +64,8 @@ versioningPluginVersion=1.1.0
 # Versions of node and npm to use during the build. If set, these versions
 # will be downloaded and used. If not set, the existing local installations will be use
 # The version of npm corresponds to the given version of node
-npmVersion=6.14.13
-nodeVersion=14.17.1
+npmVersion=8.1.2
+nodeVersion=16.13.1
 nodeRepo=https://nodejs.org/dist
 # Directory in a project's build directory where the node binary will be placed
 nodeWorkDirectory=.node

--- a/gradle.properties
+++ b/gradle.properties
@@ -57,7 +57,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.21.0
 gradleNodePluginVersion=3.0.1
-gradlePluginsVersion=1.32.0-updateNodeNPM-SNAPSHOT
+gradlePluginsVersion=1.32.0
 owaspDependencyCheckPluginVersion=5.2.1
 versioningPluginVersion=1.1.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -57,7 +57,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.21.0
 gradleNodePluginVersion=3.0.1
-gradlePluginsVersion=1.31.0
+gradlePluginsVersion=1.32.0-updateNodeNPM-SNAPSHOT
 owaspDependencyCheckPluginVersion=5.2.1
 versioningPluginVersion=1.1.0
 


### PR DESCRIPTION
#### Rationale
New MacBooks use a new chipset. Node 14.x didn't publish builds that were compiled for the new architecture, but newer versions do. 16.x is their current LTS release, and it pairs with NPM 8.x

#### Related Pull Requests
* https://github.com/LabKey/server/pull/161
* https://github.com/LabKey/labkey-ui-components/pull/699
* https://github.com/LabKey/biologics/pull/1112
* https://github.com/LabKey/sampleManagement/pull/792
* https://github.com/LabKey/inventory/pull/356
* https://github.com/LabKey/gradlePlugin/pull/140
* https://github.com/LabKey/cds/pull/432
* https://github.com/LabKey/hjfSampleRequests/pull/14
* https://github.com/LabKey/platform/pull/2920
* https://github.com/LabKey/commonAssays/pull/412
* https://github.com/LabKey/snprcEHRModules/pull/392
* https://github.com/LabKey/wnprc-modules/pull/149

#### Changes
* Bump NPM and Node versions