### PR TITLE
Use embedded config for declaring dependency on Springboot jar file

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -57,7 +57,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.21.0
 gradleNodePluginVersion=3.0.1
-gradlePluginsVersion=1.30.3
+gradlePluginsVersion=1.31.0-embeddedConfig-SNAPSHOT
 owaspDependencyCheckPluginVersion=5.2.1
 versioningPluginVersion=1.1.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -57,7 +57,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.21.0
 gradleNodePluginVersion=3.0.1
-gradlePluginsVersion=1.31.0-embeddedConfig-SNAPSHOT
+gradlePluginsVersion=1.31.0
 owaspDependencyCheckPluginVersion=5.2.1
 versioningPluginVersion=1.1.0
 

--- a/server/embedded/build.gradle
+++ b/server/embedded/build.gradle
@@ -21,6 +21,7 @@ configurations {
     runtimeClasspath {
         extendsFrom developmentOnly
     }
+    embedded
 }
 
 dependencies {
@@ -64,6 +65,10 @@ project.publishing {
             project.artifactoryPublish.skip = false
         }
     }
+}
+
+project.artifacts {
+    embedded project.tasks.bootJar
 }
 
 // The primary artifact from this build should be the jar produced from the bootJar task as that contains

--- a/server/embedded/build.gradle
+++ b/server/embedded/build.gradle
@@ -45,7 +45,7 @@ project.publishing {
             groupId = 'org.labkey.build'
             artifactId = 'embedded'
             version = project.version
-            artifact project.tasks.jar.outputs.files.singleFile
+            artifact project.tasks.bootJar.outputs.files.singleFile
             pom {
                 name = "LabKey Server Embedded"
                 description = "LabKey classes for producing distributions with embedded TomCat."
@@ -64,4 +64,12 @@ project.publishing {
             project.artifactoryPublish.skip = false
         }
     }
+}
+
+// The primary artifact from this build should be the jar produced from the bootJar task as that contains
+// the SpringBoot classes.  This default jar task produces a jar file containing only the classes from src,
+// which no one really needs.  If produced, this is the jar file that will be used in distributions, making
+// them not really embedding anything.
+jar {
+ onlyIf { false }
 }


### PR DESCRIPTION
#### Rationale
After the update to springBoot version 2.6, in conjunction with adding support for Java 16, the default jar file is now being created from the embedded project, and that default jar is what is being added to distributions.  We introduce a separate configuration that has the `bootJar` attached as an artifact and use that for declaring dependencies.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/139

#### Changes
* Try to prevent the creation of the "plain" jar file from the embedded project
* Add an `embedded` configuration to attach the `bootJar` file to
* Publish the output of `bootJar` not `jar`.
