### PR TITLE
Backport Update to 2.16.0 for Log4J vulnerability CVE-2021-45046

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -210,7 +210,7 @@ jxlVersion=2.6.3
 
 kaptchaVersion=2.3
 
-log4j2Version=2.15.0
+log4j2Version=2.16.0
 
 mysqlDriverVersion=8.0.23
 


### PR DESCRIPTION
Backport (#167)