### PR TITLE
Backport Update to 2.16.0 for Log4J vulnerability CVE-2021-45046

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -204,7 +204,7 @@ jxlVersion=2.6.3
 
 kaptchaVersion=2.3
 
-log4j2Version=2.13.3
+log4j2Version=2.16.0
 
 logbackVersion=1.1.1
 


### PR DESCRIPTION
Backport (#167)