### PR TITLE
Issue 44526: Update to Log4J 2.17.0 to definitively protect against CVE-2021-45105

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -210,7 +210,7 @@ jxlVersion=2.6.3
 
 kaptchaVersion=2.3
 
-log4j2Version=2.16.0
+log4j2Version=2.17.0
 
 mysqlDriverVersion=8.0.26
 


### PR DESCRIPTION
#### Rationale
Log4J has another patch for a variant on the previous vulnerability. LabKey Server does not use the configuration that's vulnerable, but we can still adopt the newest hot fix, 2.17.0.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2878

#### Changes
* Adopt Log4J 2.17.0
