### PR TITLE
Gradle plugins updates to add support for new encryptionKey property name and  later versions of xmlBeans

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -279,4 +279,4 @@ xercesImplVersion=2.12.1
 # using the relocated version
 xmlApisVersion=1.0.b2
 
-xmlbeansVersion=3.0.1
+xmlbeansVersion=3.1.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -57,7 +57,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.21.0
 gradleNodePluginVersion=3.0.1
-gradlePluginsVersion=1.33.0-encryptionKey-SNAPSHOT
+gradlePluginsVersion=1.32.1
 owaspDependencyCheckPluginVersion=5.2.1
 versioningPluginVersion=1.1.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -85,8 +85,6 @@ npmWorkDirectory=.node
 # have extensive other external dependencies should have a local
 # gradle.properties file to declare these version numbers.
 
-# workflow (Activiti) and JavaMail bring in different versions of javax.activation:activation transitively, so
-# we force the latest version
 activationVersion=1.2.2
 
 annotationsVersion=15.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -57,7 +57,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.21.0
 gradleNodePluginVersion=3.0.1
-gradlePluginsVersion=1.32.0
+gradlePluginsVersion=1.33.0-encryptionKey-SNAPSHOT
 owaspDependencyCheckPluginVersion=5.2.1
 versioningPluginVersion=1.1.0
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -56,9 +56,9 @@ buildscript {
 //        classpath "com.fasterxml.jackson.core:jackson-databind:2.12.2"
 //        classpath "org.ajoberstar.grgit:grgit-gradle:4.1.0"
 //    }
-//    dependencies {
-//        classpath "org.labkey.build:gradlePlugins:${gradlePluginsVersion}"
-//    }
+    dependencies {
+        classpath "org.labkey.build:gradlePlugins:${gradlePluginsVersion}"
+    }
     configurations.all {
         // Check for updates every build for SNAPSHOT dependencies
         resolutionStrategy.cacheChangingModulesFor 0, 'seconds'

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,9 +10,6 @@ pluginManagement {
             }
         }
     }
-    // For testing changes to the gradle plugins, uncomment the includeBuild line below and reference the location of
-    // your gradlePlugin enlistment.  The plugins will get built automatically when executing tasks here.
-//    includeBuild '../gradlePlugin'
     plugins {
         id 'org.labkey.build.antlr' version "${gradlePluginsVersion}" apply false
         id 'org.labkey.build.api' version "${gradlePluginsVersion}" apply false
@@ -45,9 +42,23 @@ buildscript {
             }
         }
     }
-    dependencies {
-        classpath "org.labkey.build:gradlePlugins:${gradlePluginsVersion}"
-    }
+    // For testing changes to the gradle plugins, uncomment the dependencies block below and reference the location
+    // of your gradlePlugin enlistment.  Then comment out the following dependencies
+    // block.  You will need to build the gradlePlugins jar file manually to pick up new changes.
+//    dependencies {
+//        classpath files("../gradlePlugin/build/libs/gradlePlugin-${gradlePluginsVersion}.jar")
+//        classpath "org.apache.commons:commons-lang3:${commonsLang3Version}"
+//        classpath "org.apache.commons:commons-text:1.9"
+//        classpath "commons-io:commons-io:${commonsIoVersion}"
+//        classpath "com.yahoo.platform.yui:yuicompressor:2.4.8a"
+//        classpath "org.apache.httpcomponents:httpclient:${httpclientVersion}"
+//        classpath "org.json:json:20210307"
+//        classpath "com.fasterxml.jackson.core:jackson-databind:2.12.2"
+//        classpath "org.ajoberstar.grgit:grgit-gradle:4.1.0"
+//    }
+//    dependencies {
+//        classpath "org.labkey.build:gradlePlugins:${gradlePluginsVersion}"
+//    }
     configurations.all {
         // Check for updates every build for SNAPSHOT dependencies
         resolutionStrategy.cacheChangingModulesFor 0, 'seconds'

--- a/webapps/labkey.xml
+++ b/webapps/labkey.xml
@@ -25,7 +25,7 @@
     <Loader loaderClass="org.labkey.bootstrap.LabKeyBootstrapClassLoader" />
 
     <!-- Encryption key for encrypted property store -->
-    <Parameter name="EncryptionKey" value="@@masterEncryptionKey@@" />
+    <Parameter name="EncryptionKey" value="@@encryptionKey@@" />
 
     <!--@@extraJdbcDataSource@@
     <Resource name="jdbc/@@extraJdbcDataSource@@" auth="Container"


### PR DESCRIPTION
#### Rationale
See related PR.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/143

#### Changes
* Update `xmlbeansVersion` to align with the version brought in by Tika
* Update `gradlePluginsVersion` for support of new encryptionKey and later xmlbeans versions
* Update `settings.gradle` with previous instructions on working with local plugin builds since `includeBuild` doesn't seem to work (anymore)
