### PR TITLE
Issue 44947: Make log rotation file naming consistent across log types

### DIFF
--- a/webapps/log4j2.xml
+++ b/webapps/log4j2.xml
@@ -53,7 +53,7 @@
                 <OnStartupTriggeringPolicy />
                 <SizeBasedTriggeringPolicy size="100 MB"/>
             </Policies>
-            <DefaultRolloverStrategy max="3"/>
+            <DefaultRolloverStrategy max="3" fileIndex="min" />
         </RollingFile>
 
         <RollingFile name="QUERY_STATS"
@@ -69,7 +69,7 @@
                 <OnStartupTriggeringPolicy />
                 <SizeBasedTriggeringPolicy size="100 MB"/>
             </Policies>
-            <DefaultRolloverStrategy max="3"/>
+            <DefaultRolloverStrategy max="3" fileIndex="min" />
         </RollingFile>
 
         <RollingFile name="LABKEY"
@@ -84,6 +84,7 @@
             <Policies>
                 <SizeBasedTriggeringPolicy size="10 MB"/>
             </Policies>
+            <DefaultRolloverStrategy fileIndex="min" />
         </RollingFile>
 
         <RollingFile name="LABKEY_AUDIT"
@@ -98,6 +99,7 @@
             <Policies>
                 <SizeBasedTriggeringPolicy size="10 MB"/>
             </Policies>
+            <DefaultRolloverStrategy fileIndex="min" />
         </RollingFile>
 
         <SessionAppender name="SessionAppender">
@@ -117,6 +119,7 @@
             <Policies>
                 <SizeBasedTriggeringPolicy size="1000 KB"/>
             </Policies>
+            <DefaultRolloverStrategy fileIndex="min" />
         </RollingFile>
 
         <RollingFile name="THREAD_DUMP"
@@ -130,6 +133,7 @@
             <Policies>
                 <SizeBasedTriggeringPolicy size="10 MB"/>
             </Policies>
+            <DefaultRolloverStrategy fileIndex="min" />
         </RollingFile>
 
     </Appenders>


### PR DESCRIPTION
#### Rationale
It's confusing when we rotate logs in opposite directions

#### Changes
* Always use .1 as the most recently rotated file, and .2, .3, etc as the older copies