### PR TITLE
Upgrade jexcelapi 2.6.3 -> 2.6.12

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -202,7 +202,7 @@ jtidyVersion=r918
 
 junitVersion=4.13.2
 
-jxlVersion=2.6.3
+jxlVersion=2.6.12
 
 kaptchaVersion=2.3
 


### PR DESCRIPTION
#### Rationale
15 years on one version is long enough. Upgrade to the super modern 13-year-old version.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3181