### PR TITLE
Declare mavenCentral repository explicitly as first repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     repositories {
         mavenCentral()
         maven {
-            url "${artifactory_contextUrl}/plugins-release-no-mc"
+            url "${artifactory_contextUrl}/plugins-release"
         }
         if (gradlePluginsVersion.contains("SNAPSHOT") || versioningPluginVersion.contains("SNAPSHOT"))
         {
@@ -115,7 +115,7 @@ allprojects {
                     }
                     maven {
 
-                        url "${artifactory_contextUrl}/libs-release-no-mc"
+                        url "${artifactory_contextUrl}/libs-release"
 
                         if (project.hasProperty('artifactory_user') && project.hasProperty('artifactory_password'))
                         {
@@ -129,7 +129,7 @@ allprojects {
                         }
                     }
                     maven {
-                        url "${artifactory_contextUrl}/libs-snapshot-no-mc"
+                        url "${artifactory_contextUrl}/libs-snapshot"
 
                         if (project.hasProperty('artifactory_user') && project.hasProperty('artifactory_password'))
                         {

--- a/build.gradle
+++ b/build.gradle
@@ -278,6 +278,7 @@ if (BuildUtils.shouldPublish(project) || BuildUtils.shouldPublishDistribution(pr
             }
             defaults
                     {
+                        publishBuildInfo = false
                         publishPom = true
                         publishIvy = false
                     }

--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,9 @@ import org.labkey.gradle.task.PurgeNpmAlphaVersions
 
 buildscript {
     repositories {
+        mavenCentral()
         maven {
-            url "${artifactory_contextUrl}/plugins-release"
+            url "${artifactory_contextUrl}/plugins-release-no-mc"
         }
         if (gradlePluginsVersion.contains("SNAPSHOT") || versioningPluginVersion.contains("SNAPSHOT"))
         {
@@ -98,6 +99,7 @@ allprojects {
 
     repositories
             {
+                mavenCentral()
                 // this if statement is necessary because the TeamCity artifactory plugin overrides
                 // the repositories but does not use these artifactory_ urls.  For others who are
                 // developing or building, you do need to specify the three artifactory_ properties
@@ -143,7 +145,7 @@ allprojects {
 //                    	url "https://repository.apache.org/content/repositories/orgapachetomcat-1322/"
 //                    }
                 }
-                mavenCentral()
+
             }
     configurations.all
             {

--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ allprojects {
                     }
                     maven {
 
-                        url "${artifactory_contextUrl}/libs-release"
+                        url "${artifactory_contextUrl}/libs-release-no-mc"
 
                         if (project.hasProperty('artifactory_user') && project.hasProperty('artifactory_password'))
                         {
@@ -123,7 +123,7 @@ allprojects {
                         }
                     }
                     maven {
-                        url "${artifactory_contextUrl}/libs-snapshot"
+                        url "${artifactory_contextUrl}/libs-snapshot-no-mc"
 
                         if (project.hasProperty('artifactory_user') && project.hasProperty('artifactory_password'))
                         {


### PR DESCRIPTION
#### Rationale
We plan to update our Artifactory configuration so it no longer proxies for certain remote repositories. This requires that builds that require these remote repositories declare these repositories themselves.  We put mavenCentral as the first repository so it won't query our Artifactory instance when looking for external dependencies.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Stop publishing `buildInfo`
* Explicitly declare mavenCentral as first repository to check
