### PR TITLE
Put mavenCentral last again so we pick up our custom version of the radeox lib

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,6 @@ allprojects {
 
     repositories
             {
-                mavenCentral()
                 // this if statement is necessary because the TeamCity artifactory plugin overrides
                 // the repositories but does not use these artifactory_ urls.  For others who are
                 // developing or building, you do need to specify the three artifactory_ properties
@@ -138,6 +137,7 @@ allprojects {
                         }
                     }
                 }
+                mavenCentral()
             }
     configurations.all
             {


### PR DESCRIPTION
#### Rationale
Though we have updated to a new version of radeox in develop (or, actually on 2/16/2022) and don't rely on our own version of this, for earlier releases we do use one that is published in the `ext-release-local` repository in artifactory, so we need to find that one first.  We can do the switching of ordering in develop, but can merge this change forward in the meantime.

#### Related Pull Requests
#235 


