### PR TITLE
Upgrade Gson, Guava, Log4j2, Lucene, MySQL JDBC driver, PostgreSQL JD…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -149,9 +149,9 @@ graalVersion=20.0.0
 
 # Cloud and SequenceAnalysis bring gson in as a transitive dependency.
 # We resolve to the later version here to keep things consistent
-gsonVersion=2.8.9
+gsonVersion=2.9.0
 
-guavaVersion=31.0.1-jre
+guavaVersion=31.1-jre
 gwtVersion=2.8.2
 gwtServletVersion=2.8.2
 # For dev builds, the targeted, single permutation browser. Can be either gwt-user-firefox, gwt-user-chrome, or gwt-user-ie
@@ -206,9 +206,9 @@ jxlVersion=2.6.3
 
 kaptchaVersion=2.3
 
-log4j2Version=2.17.1
+log4j2Version=2.17.2
 
-mysqlDriverVersion=8.0.28
+mysqlDriverVersion=8.0.29
 
 objenesisVersion=1.0
 
@@ -225,7 +225,7 @@ poiVersion=5.2.0
 
 pollingWatchVersion=0.2.0
 
-postgresqlDriverVersion=42.3.3
+postgresqlDriverVersion=42.3.5
 
 quartzVersion=2.1.7
 
@@ -243,9 +243,9 @@ slf4jLog4j12Version=1.7.33
 slf4jLog4jApiVersion=1.7.33
 
 
-springBootVersion=2.6.3
+springBootVersion=2.6.7
 # This MUST match the Tomcat version dictated by springBootVersion
-springBootTomcatVersion=9.0.56
+springBootTomcatVersion=9.0.62
 
 # N.B. Spring version 5+ brings in a change to form handling such that GET and POST parameters are both used when
 # posting a form. For some of our forms this causes heartache.


### PR DESCRIPTION
…BC driver, SpringBoot, and Tomcat

#### Rationale
We like to stay current

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3346

#### Changes
* Upgrade Gson 2.8.9 -> 2.9.0
* Upgrade Guava 31.0.1-jre -> 31.1-jre
* Upgrade Log4j2 2.17.1 -> 2.17.2
* Upgrade MySQL JDBC driver 8.0.28 -> 8.0.29
* Upgrade PostgreSQL JDBC driver 42.3.3 -> 42.3.5
* Upgrade SpringBoot 2.6.3 -> 2.6.7
* Upgrade Tomcat 9.0.56 -> 9.0.62
