### PR TITLE
Add external maven repositories and try again without scijava proxy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,10 @@ buildscript {
     repositories {
         mavenCentral()
         maven {
-            url "${artifactory_contextUrl}/plugins-release"
+            url "https://plugins.gradle.org/m2"
+        }
+        maven {
+            url "${artifactory_contextUrl}/plugins-release-no-proxy"
         }
         if (gradlePluginsVersion.contains("SNAPSHOT") || versioningPluginVersion.contains("SNAPSHOT"))
         {
@@ -109,7 +112,7 @@ allprojects {
                     }
                     maven {
 
-                        url "${artifactory_contextUrl}/libs-release"
+                        url "${artifactory_contextUrl}/libs-release-no-proxy"
 
                         if (project.hasProperty('artifactory_user') && project.hasProperty('artifactory_password'))
                         {
@@ -123,7 +126,7 @@ allprojects {
                         }
                     }
                     maven {
-                        url "${artifactory_contextUrl}/libs-snapshot"
+                        url "${artifactory_contextUrl}/libs-snapshot-no-proxy"
 
                         if (project.hasProperty('artifactory_user') && project.hasProperty('artifactory_password'))
                         {


### PR DESCRIPTION
#### Rationale
We want to reduce the usage of Artifactory to a minimum, so we'll stop proxying for the gradle plugins repository and the scijava repository. 

#### Related Pull Requests
#234 

#### Changes
* Declare repository for gradle plugins
* Use virtual repositories without a proxy for scijava
