### PR TITLE
Enable 'debug' level message for saml troubleshooting (uncomment when needed)

### DIFF
--- a/webapps/log4j2.xml
+++ b/webapps/log4j2.xml
@@ -165,7 +165,8 @@
             <AppenderRef ref="LABKEY"/>
         </Logger>
 
-        <!-- uncomment for debugging SAML issues
+        <!-- uncomment to enable 'DEBUG' level on external SAML libraries to troubleshoot.
+        Note: you will also have to set dependency on slf4j lib in saml/build.gradle - uncomment 'slf4j' external libraries and build
         <Logger name="org.opensaml" level="DEBUG">
             <AppenderRef ref="CONSOLE"/>
             <AppenderRef ref="LABKEY"/>

--- a/webapps/log4j2.xml
+++ b/webapps/log4j2.xml
@@ -167,6 +167,7 @@
 
         <Logger name="org.opensaml.xmlsec" level="DEBUG">
             <AppenderRef ref="CONSOLE"/>
+            <AppenderRef ref="LABKEY"/>
         </Logger>
 
         <Logger name="mondrian." level="info" />

--- a/webapps/log4j2.xml
+++ b/webapps/log4j2.xml
@@ -165,6 +165,10 @@
             <AppenderRef ref="LABKEY"/>
         </Logger>
 
+        <Logger name="org.opensaml.xmlsec" level="DEBUG">
+            <AppenderRef ref="CONSOLE"/>
+        </Logger>
+
         <Logger name="mondrian." level="info" />
 
         <!--

--- a/webapps/log4j2.xml
+++ b/webapps/log4j2.xml
@@ -165,10 +165,16 @@
             <AppenderRef ref="LABKEY"/>
         </Logger>
 
-        <Logger name="org.opensaml.xmlsec" level="DEBUG">
+        <!-- uncomment for debugging SAML issues
+        <Logger name="org.opensaml" level="DEBUG">
             <AppenderRef ref="CONSOLE"/>
             <AppenderRef ref="LABKEY"/>
         </Logger>
+
+        <Logger name="org.apache.xml.security" level="DEBUG">
+            <AppenderRef ref="CONSOLE"/>
+            <AppenderRef ref="LABKEY"/>
+        </Logger> -->
 
         <Logger name="mondrian." level="info" />
 


### PR DESCRIPTION
#### Rationale
Secure Issue [45136](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=45136): SAML Encryption not working as expected when <EncryptedAssertion> has a different structure

Adding slf4j as an external library in saml's build.gradle did not enable DEBUG level messages to be able to troubleshoot deeper issues, it had to be enabled manually. 

#### Related Pull Requests
* https://github.com/LabKey/saml/pull/54

#### Changes
* Add external lib saml loggers to enable DEBUG level messages - commented out for now
