### PR TITLE
Don't use TLS for connecting to test Database

### DIFF
--- a/server/configs/mssql.properties
+++ b/server/configs/mssql.properties
@@ -17,7 +17,7 @@ databaseType=mssql
 databaseVersion=2008
 
 jdbcDriverClassName=com.microsoft.sqlserver.jdbc.SQLServerDriver
-jdbcURL=jdbc:sqlserver://${jdbcHost}:${jdbcPort};databaseName=${jdbcDatabase};trustServerCertificate=true;applicationName=LabKey Server;sslProtocol=TLSv1.2;${jdbcURLParameters}
+jdbcURL=jdbc:sqlserver://${jdbcHost}:${jdbcPort};databaseName=${jdbcDatabase};trustServerCertificate=true;applicationName=LabKey Server;encrypt=false;${jdbcURLParameters}
 jdbcUser=sa
 jdbcPassword=sa
 

--- a/server/configs/mssql.properties
+++ b/server/configs/mssql.properties
@@ -17,7 +17,7 @@ databaseType=mssql
 databaseVersion=2008
 
 jdbcDriverClassName=com.microsoft.sqlserver.jdbc.SQLServerDriver
-jdbcURL=jdbc:sqlserver://${jdbcHost}:${jdbcPort};databaseName=${jdbcDatabase};trustServerCertificate=true;applicationName=LabKey Server;${jdbcURLParameters}
+jdbcURL=jdbc:sqlserver://${jdbcHost}:${jdbcPort};databaseName=${jdbcDatabase};trustServerCertificate=true;applicationName=LabKey Server;sslProtocol=TLSv1.2${jdbcURLParameters}
 jdbcUser=sa
 jdbcPassword=sa
 

--- a/server/configs/mssql.properties
+++ b/server/configs/mssql.properties
@@ -17,7 +17,7 @@ databaseType=mssql
 databaseVersion=2008
 
 jdbcDriverClassName=com.microsoft.sqlserver.jdbc.SQLServerDriver
-jdbcURL=jdbc:sqlserver://${jdbcHost}:${jdbcPort};databaseName=${jdbcDatabase};trustServerCertificate=true;applicationName=LabKey Server;sslProtocol=TLSv1.2${jdbcURLParameters}
+jdbcURL=jdbc:sqlserver://${jdbcHost}:${jdbcPort};databaseName=${jdbcDatabase};trustServerCertificate=true;applicationName=LabKey Server;sslProtocol=TLSv1.2;${jdbcURLParameters}
 jdbcUser=sa
 jdbcPassword=sa
 


### PR DESCRIPTION
#### Rationale
The Microsoft SQL Server driver might attempt to use an insecure version of TLS on older versions of SQL Server
https://github.com/Microsoft/mssql-jdbc/wiki/SSLProtocol

#### Related Pull Requests
* #264 

#### Changes
* Add `encrypt=false` to JDBC URL
