### PR TITLE
Use latest version of Java client API (v2.0.0)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ buildFromSource=true
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
 labkeyVersion=22.8-SNAPSHOT
-labkeyClientApiVersion=1.5.2
+labkeyClientApiVersion=2.0.0
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.
 windowsUtilsVersion=1.0


### PR DESCRIPTION
#### Rationale
Latest is greatest

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-java/pull/31
