### PR TITLE
Gradle 7.5 and remove no-proxy suffix from artifact repositories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,9 +127,9 @@ allprojects {
                                 username = artifactory_user
                                 password = artifactory_password
                             }
-                        }
-                        authentication {
-                            basic(BasicAuthentication)
+                            authentication {
+                                basic(BasicAuthentication)
+                            }
                         }
                     }
                     maven {
@@ -141,9 +141,9 @@ allprojects {
                                 username = artifactory_user
                                 password = artifactory_password
                             }
-                        }
-                        authentication {
-                            basic(BasicAuthentication)
+                            authentication {
+                                basic(BasicAuthentication)
+                            }
                         }
                     }
 // Temporarily uncomment the block below and update the four-digit number to allow building with Tomcat versions that

--- a/build.gradle
+++ b/build.gradle
@@ -127,9 +127,6 @@ allprojects {
                                 username = artifactory_user
                                 password = artifactory_password
                             }
-                            authentication {
-                                basic(BasicAuthentication) // enable preemptive authentication to get around https://www.jfrog.com/jira/browse/RTFACT-4434
-                            }
                         }
                     }
                     maven {
@@ -140,9 +137,6 @@ allprojects {
                             credentials {
                                 username = artifactory_user
                                 password = artifactory_password
-                            }
-                            authentication {
-                                basic(BasicAuthentication) // enable preemptive authentication to get around https://www.jfrog.com/jira/browse/RTFACT-4434
                             }
                         }
                     }

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
             url "https://plugins.gradle.org/m2"
         }
         maven {
-            url "${artifactory_contextUrl}/plugins-release-no-proxy"
+            url "${artifactory_contextUrl}/plugins-release"
         }
         if (gradlePluginsVersion.contains("SNAPSHOT") || versioningPluginVersion.contains("SNAPSHOT"))
         {
@@ -119,7 +119,7 @@ allprojects {
                     }
                     maven {
 
-                        url "${artifactory_contextUrl}/libs-release-no-proxy"
+                        url "${artifactory_contextUrl}/libs-release"
 
                         if (project.hasProperty('artifactory_user') && project.hasProperty('artifactory_password'))
                         {
@@ -133,7 +133,7 @@ allprojects {
                         }
                     }
                     maven {
-                        url "${artifactory_contextUrl}/libs-snapshot-no-proxy"
+                        url "${artifactory_contextUrl}/libs-snapshot"
 
                         if (project.hasProperty('artifactory_user') && project.hasProperty('artifactory_password'))
                         {

--- a/build.gradle
+++ b/build.gradle
@@ -128,6 +128,9 @@ allprojects {
                                 password = artifactory_password
                             }
                         }
+                        authentication {
+                            basic(BasicAuthentication)
+                        }
                     }
                     maven {
                         url "${artifactory_contextUrl}/libs-snapshot"
@@ -138,6 +141,9 @@ allprojects {
                                 username = artifactory_user
                                 password = artifactory_password
                             }
+                        }
+                        authentication {
+                            basic(BasicAuthentication)
                         }
                     }
 // Temporarily uncomment the block below and update the four-digit number to allow building with Tomcat versions that

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
#### Rationale
Latest is greatest and it's good to tidy things up when we can.


