### PR TITLE
Issue 45969: Update spring-expression to 5.3.22

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -252,7 +252,7 @@ allprojects {
                     force "io.netty:netty-codec-http:${nettyVersion}"
 
                     force "org.springframework:spring-core:${springVersion}"
-                    force "org.springframework:spring-expression:5.3.17"
+                    force "org.springframework:spring-expression:5.3.22"
 
                     dependencySubstitution {
                         // Because the client api artifact name is not the same as the directory structure, we use

--- a/build.gradle
+++ b/build.gradle
@@ -251,6 +251,9 @@ allprojects {
                     force "io.netty:netty-common:${nettyVersion}"
                     force "io.netty:netty-codec-http:${nettyVersion}"
 
+                    // Issue 45969 - update to spring-expression 5.3.22 while keeping the rest of Spring on an older
+                    // release until we can do the full update. Need to force both so that spring-expression (a
+                    // transitive dependency) doesn't pull spring-core to the same newer version
                     force "org.springframework:spring-core:${springVersion}"
                     force "org.springframework:spring-expression:5.3.22"
 

--- a/build.gradle
+++ b/build.gradle
@@ -251,6 +251,9 @@ allprojects {
                     force "io.netty:netty-common:${nettyVersion}"
                     force "io.netty:netty-codec-http:${nettyVersion}"
 
+                    force "org.springframework:spring-core:${springVersion}"
+                    force "org.springframework:spring-expression:5.3.17"
+
                     dependencySubstitution {
                         // Because the client api artifact name is not the same as the directory structure, we use
                         // Gradle's dependency substitution so the dependency will appear correctly in the pom files that


### PR DESCRIPTION
#### Rationale
We want to adopt some of the fixes in spring-expression before we do a full Spring upgrade later, in 22.11

#### Changes
* Force version to 5.3.22 while keeping the rest of Spring at the older release