### PR TITLE
Add showingAllVariants configuration for allDepInsight task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -320,10 +320,12 @@ subprojects {
             })
         })
     
-    task("allDepInsight",
-            type: DependencyInsightReportTask,
-            group: "Help",
-            description: "Displays the insight into a specific dependency across all projects")
+    project.tasks.register("allDepInsight", DependencyInsightReportTask) {
+            DependencyInsightReportTask t -> 
+                t.group = "Help"
+                t.description = "Displays the insight into a specific dependency across all projects"
+                t.showingAllVariants=false
+    }
     task("allDependencies",
             type: DependencyReportTask,
             group: "Help",

--- a/gradle.properties
+++ b/gradle.properties
@@ -57,7 +57,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.21.0
 gradleNodePluginVersion=3.0.1
-gradlePluginsVersion=1.34.2-add-opens-SNAPSHOT
+gradlePluginsVersion=1.34.2
 owaspDependencyCheckPluginVersion=5.2.1
 versioningPluginVersion=1.1.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -57,7 +57,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.21.0
 gradleNodePluginVersion=3.0.1
-gradlePluginsVersion=1.34.1
+gradlePluginsVersion=1.34.2-add-opens-SNAPSHOT
 owaspDependencyCheckPluginVersion=5.2.1
 versioningPluginVersion=1.1.0
 


### PR DESCRIPTION
#### Rationale
With Gradle 7.5, the DependencyInsightReportTask now seemingly requires a value for the `showAllVariants` property.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/152

#### Changes
* Update definition of `allDepInsight` task to include new property.
