### PR TITLE
Downgrade log4j2 2.18.0 -> 2.17.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -208,7 +208,7 @@ jxlVersion=2.6.3
 
 kaptchaVersion=2.3
 
-log4j2Version=2.18.0
+log4j2Version=2.17.2
 
 mysqlDriverVersion=8.0.29
 


### PR DESCRIPTION
#### Rationale
2.18.0 caused problems with embedded Tomcat

#### Related Pull Requests
* https://github.com/LabKey/server/pull/290