### PR TITLE
Update gradle plugin to 1.34.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -57,7 +57,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.21.0
 gradleNodePluginVersion=3.0.1
-gradlePluginsVersion=1.34.1
+gradlePluginsVersion=1.34.3
 owaspDependencyCheckPluginVersion=5.2.1
 versioningPluginVersion=1.1.0
 


### PR DESCRIPTION
#### Rationale
The latest gradle plugin version fixes an occasional `VMDisconnectedException` on TeamCity.
Seems like tomcat shutdown is hovering around our default timeout in `TeamCity.threadDumpAndKill` and throws an uncaught `VMDisconnectedException`.
```
Execution failed for task ':server:testAutomation:stopTomcat'.
> com.sun.jdi.VMDisconnectedException (no error message)
[...]
Caused by: com.sun.jdi.VMDisconnectedException
       at jdk.jdi/com.sun.tools.jdi.TargetVM.waitForReply(TargetVM.java:310)
       at jdk.jdi/com.sun.tools.jdi.VirtualMachineImpl.waitForTargetReply(VirtualMachineImpl.java:1173)
       at jdk.jdi/com.sun.tools.jdi.PacketStream.waitForReply(PacketStream.java:87)
       at jdk.jdi/com.sun.tools.jdi.JDWP$VirtualMachine$Suspend.waitForReply(JDWP.java:571)
       at jdk.jdi/com.sun.tools.jdi.JDWP$VirtualMachine$Suspend.process(JDWP.java:557)
       at jdk.jdi/com.sun.tools.jdi.VirtualMachineImpl.suspend(VirtualMachineImpl.java:487)
       at com.sun.jdi.VirtualMachine$suspend$0.call(Unknown Source)
       at org.labkey.gradle.plugin.TeamCity.threadDumpAndKill(TeamCity.groovy:345)
```

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/153

#### Changes
* Update `gradlePluginsVersion` to 1.34.3
