### PR TITLE
Bump Log4J to 2.18.0 with fixes to work with embedded Tomcat

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -208,7 +208,7 @@ jxlVersion=2.6.3
 
 kaptchaVersion=2.3
 
-log4j2Version=2.17.2
+log4j2Version=2.18.0
 
 mysqlDriverVersion=8.0.29
 

--- a/server/embedded/build.gradle
+++ b/server/embedded/build.gradle
@@ -1,4 +1,5 @@
 import org.labkey.gradle.util.BuildUtils
+import org.labkey.gradle.util.PomFileHelper
 
 plugins {
     id "java"

--- a/server/embedded/build.gradle
+++ b/server/embedded/build.gradle
@@ -1,5 +1,4 @@
 import org.labkey.gradle.util.BuildUtils
-import org.labkey.gradle.util.PomFileHelper
 
 plugins {
     id "java"
@@ -7,6 +6,9 @@ plugins {
     id "org.springframework.boot" version "${springBootVersion}"
     id "io.spring.dependency-management" version "1.0.8.RELEASE"
 }
+
+// 'dependency-management' plugin doesn't allow us to use 'resolutionStrategy.force' to lock versions
+ext['log4j2.version'] = log4j2Version
 
 sourceSets {
     main {

--- a/server/embedded/build.gradle
+++ b/server/embedded/build.gradle
@@ -33,9 +33,6 @@ dependencies {
     runtimeOnly "javax.mail:javax.mail-api:1.6.2"
     runtimeOnly group: "com.sun.mail", name: "javax.mail", version: "1.6.0"
     runtimeOnly group: "org.apache.tomcat", name: "tomcat-dbcp", version: "${springBootTomcatVersion}"
-    runtimeOnly group: "org.apache.logging.log4j", name: "log4j-api", version: "2.18.0"
-    runtimeOnly group: "org.apache.logging.log4j", name: "log4j-core", version: "2.18.0"
-    runtimeOnly group: "org.apache.logging.log4j", name: "log4j-to-slf4j", version: "2.18.0"
     runtimeOnly "org.postgresql:postgresql:${postgresqlDriverVersion}"
 
     developmentOnly("org.springframework.boot:spring-boot-devtools")

--- a/server/embedded/build.gradle
+++ b/server/embedded/build.gradle
@@ -33,6 +33,9 @@ dependencies {
     runtimeOnly "javax.mail:javax.mail-api:1.6.2"
     runtimeOnly group: "com.sun.mail", name: "javax.mail", version: "1.6.0"
     runtimeOnly group: "org.apache.tomcat", name: "tomcat-dbcp", version: "${springBootTomcatVersion}"
+    runtimeOnly group: "org.apache.logging.log4j", name: "log4j-api", version: "2.18.0"
+    runtimeOnly group: "org.apache.logging.log4j", name: "log4j-core", version: "2.18.0"
+    runtimeOnly group: "org.apache.logging.log4j", name: "log4j-to-slf4j", version: "2.18.0"
     runtimeOnly "org.postgresql:postgresql:${postgresqlDriverVersion}"
 
     developmentOnly("org.springframework.boot:spring-boot-devtools")

--- a/server/embedded/src/org/labkey/embedded/LabKeySpringBootClassLoader.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeySpringBootClassLoader.java
@@ -1,6 +1,5 @@
 package org.labkey.embedded;
 
-import org.apache.logging.slf4j.SLF4JLoggerContext;
 import org.labkey.bootstrap.LabKeyBootstrapClassLoader;
 
 import java.io.IOException;

--- a/server/embedded/src/org/labkey/embedded/LabKeySpringBootClassLoader.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeySpringBootClassLoader.java
@@ -3,6 +3,13 @@ package org.labkey.embedded;
 import org.apache.logging.slf4j.SLF4JLoggerContext;
 import org.labkey.bootstrap.LabKeyBootstrapClassLoader;
 
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+
 /**
  * Variant of the classloader that supports Spring Boot by deferring to the parent classloader for SLF4J classes
  * to avoid conflicting copies (even if they're the same version) between the parent and webapp classloaders.
@@ -22,10 +29,45 @@ public class LabKeySpringBootClassLoader extends LabKeyBootstrapClassLoader
     @Override
     protected boolean filter(String name, boolean isClassName)
     {
-        if (name.startsWith("org.slf4j.") || name.startsWith("org.apache.logging.log4j.") || name.startsWith("org.apache.logging.slf4j."))
+        // Defer to the Spring Boot classloader for SLF4J classes to avoid problems with double-loading.
+        // Eventually we should shift to only configuring and loading SLF4J and Log4J via Spring Boot and not
+        // from inside the webapp.
+        if (name.startsWith("org.slf4j."))
         {
             return true;
         }
         return super.filter(name, isClassName);
+    }
+
+    @Override
+    public Enumeration<URL> getResources(String name) throws IOException
+    {
+        // Spring Boot has its own Log4J configuration files that come from Spring Boot JARs. Log4J uses
+        // number of ServiceLoader-based configurations that enumerate possible sources of additional configuration.
+        // It iterates through them all to see if they're present. We need to filter out the ones that are coming
+        // from Spring Boot because the Log4J loaded within the webapp classloader will fall back to them
+        // and cause problems because they're handled by the outer classloader.
+
+        // Eventually we should shift to only configuring and loading SLF4J and Log4J via Spring Boot and not
+        // from inside the webapp.
+        if (name.equalsIgnoreCase("META-INF/services/org.apache.logging.log4j.util.PropertySource") ||
+           name.equalsIgnoreCase("META-INF/services/org.apache.logging.log4j.spi.Provider") ||
+            name.equalsIgnoreCase("META-INF/org/apache/logging/log4j/core/config/plugins/Log4j2Plugins.dat"))
+        {
+            List<URL> urls = new ArrayList<>();
+            Enumeration<URL> parent = super.getResources(name);
+            while (parent.hasMoreElements())
+            {
+                URL url = parent.nextElement();
+
+                // Filter out the references to Spring Boot scoped JARs
+                if (!url.toString().contains("spring-boot") && !url.toString().contains("log4j-to-slf4j"))
+                {
+                    urls.add(url);
+                }
+            }
+            return Collections.enumeration(urls);
+        }
+        return super.getResources(name);
     }
 }

--- a/server/embedded/src/org/labkey/embedded/LabKeySpringBootClassLoader.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeySpringBootClassLoader.java
@@ -1,5 +1,6 @@
 package org.labkey.embedded;
 
+import org.apache.logging.slf4j.SLF4JLoggerContext;
 import org.labkey.bootstrap.LabKeyBootstrapClassLoader;
 
 /**
@@ -21,7 +22,7 @@ public class LabKeySpringBootClassLoader extends LabKeyBootstrapClassLoader
     @Override
     protected boolean filter(String name, boolean isClassName)
     {
-        if (name.startsWith("org.slf4j."))
+        if (name.startsWith("org.slf4j.") || name.startsWith("org.apache.logging.log4j.") || name.startsWith("org.apache.logging.slf4j."))
         {
             return true;
         }


### PR DESCRIPTION
#### Rationale
We want the latest Log4J, but only if it also works with embedded Tomcat and Spring Boot.

#### Changes
* Bump to 2.18.0
* Filter out Spring Boot-specific config files to avoid confusing the copy of Log4J inside of the webapp