### PR TITLE
Issue 45345: Optimize default DB connection pool config

### DIFF
--- a/webapps/labkey.xml
+++ b/webapps/labkey.xml
@@ -8,7 +8,6 @@
         driverClassName="@@jdbcDriverClassName@@"
         url="@@jdbcURL@@"
         maxTotal="20"
-        initialSize="3"
         maxIdle="3"
         minIdle="1"
         maxWaitMillis="120000"

--- a/webapps/labkey.xml
+++ b/webapps/labkey.xml
@@ -8,10 +8,15 @@
         driverClassName="@@jdbcDriverClassName@@"
         url="@@jdbcURL@@"
         maxTotal="20"
-        maxIdle="10"
+        initialSize="3"
+        maxIdle="3"
+        minIdle="1"
         maxWaitMillis="120000"
+        testOnBorrow="false"
+        testWhileIdle="true"
+        timeBetweenEvictionRunsMillis="300000"
+        minEvictableIdleTimeMillis="300000"
         accessToUnderlyingConnectionAllowed="true"
-        validationQuery="SELECT 1"
         />
 
     <Resource name="mail/Session" auth="Container"


### PR DESCRIPTION
#### Rationale
Reviewing performance data, we're spending a surprising amount of time validating DB connections before using them.

#### Changes
* Switch from validating DB connections when borrowing from the pool to idle times
* Be more prescriptive for the desired size of the pool - initial and idle