### PR TITLE
Upgrade JAXB 2.3.0 -> 2.3.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ allprojects {
     // exclude log4j, which may come in transitively, from all configurations to avoid its potential vulnerabilities
     configurations.all {
         exclude group: "log4j", module:"log4j"
-        exclude group: "jakarta.activation", module: "jakarta.activation"
+        exclude group: "com.sun.activation", module: "jakarta.activation"
     }
     configurations.driver.setDescription("Dependencies used for SqlUtils")
     configurations.utilities.setDescription("Utility binaries for use on Windows platform")

--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,7 @@ allprojects {
     // exclude log4j, which may come in transitively, from all configurations to avoid its potential vulnerabilities
     configurations.all {
         exclude group: "log4j", module:"log4j"
+        exclude group: "jakarta.activation", module: "jakarta.activation"
     }
     configurations.driver.setDescription("Dependencies used for SqlUtils")
     configurations.utilities.setDescription("Utility binaries for use on Windows platform")

--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,6 @@ allprojects {
     // exclude log4j, which may come in transitively, from all configurations to avoid its potential vulnerabilities
     configurations.all {
         exclude group: "log4j", module:"log4j"
-        exclude group: "com.sun.activation", module: "jakarta.activation"
     }
     configurations.driver.setDescription("Dependencies used for SqlUtils")
     configurations.utilities.setDescription("Utility binaries for use on Windows platform")

--- a/gradle.properties
+++ b/gradle.properties
@@ -180,7 +180,7 @@ javassistVersion=3.20.0-GA
 javaMailVersion=1.6.7
 
 # No longer part of Java 10. Dependency for NIHS and OpenEMPI.
-jaxbVersion=2.3.0
+jaxbVersion=2.3.3
 
 jaxrpcVersion=1.1
 
@@ -234,7 +234,7 @@ poiVersion=5.2.0
 
 pollingWatchVersion=0.2.0
 
-postgresqlDriverVersion=42.4.1
+postgresqlDriverVersion=42.4.2
 
 quartzVersion=2.1.7
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -179,7 +179,7 @@ javassistVersion=3.20.0-GA
 
 javaMailVersion=1.6.7
 
-# No longer part of Java 10. Dependency for NIHS and OpenEMPI.
+# No longer part of Java 10. Dependency for many modules.
 jaxbVersion=2.3.3
 
 jaxrpcVersion=1.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -234,7 +234,7 @@ poiVersion=5.2.0
 
 pollingWatchVersion=0.2.0
 
-postgresqlDriverVersion=42.4.2
+postgresqlDriverVersion=42.4.1
 
 quartzVersion=2.1.7
 


### PR DESCRIPTION
#### Rationale
We're using an older version of JAXB and it's time to upgrade. This upgrade is a bit involved since one of the jars that makes up this library moved to the Eclipse project and was renamed & relicensed. These are the details, as far as I can tell:

* `javax.xml.bind:jaxb-api` was moved to Eclipse and renamed `jakarta.xml.bind:jakarta.xml.bind-api`. Licenses, URLs, etc. have been updated to match.
* `com.sun.xml.bind:jaxb-core` is no longer needed (I believe it was folded into `jaxb-impl`)
* `com.sun.xml.bind:jaxb-impl` remains the same (licensed by Oracle, etc.). In Maven, this is labeled "[Old JAXB Runtime](https://mvnrepository.com/artifact/com.sun.xml.bind/jaxb-impl)" but it still seems to be a dependency for Jakarta XML Binding API, even in the absolute latest releases.

Note that there are 3.0.0 and 4.0.0 versions of Jakarta XML Binding API and Old JAXB Runtime, but that is for another day.

See all the referenced PRs for related changes in 10 other repos.
