### PR TITLE
Upgrade to Spring Framework 5.3.22

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -251,12 +251,6 @@ allprojects {
                     force "io.netty:netty-common:${nettyVersion}"
                     force "io.netty:netty-codec-http:${nettyVersion}"
 
-                    // Issue 45969 - update to spring-expression 5.3.22 while keeping the rest of Spring on an older
-                    // release until we can do the full update. Need to force both so that spring-expression (a
-                    // transitive dependency) doesn't pull spring-core to the same newer version
-                    force "org.springframework:spring-core:${springVersion}"
-                    force "org.springframework:spring-expression:5.3.22"
-
                     dependencySubstitution {
                         // Because the client api artifact name is not the same as the directory structure, we use
                         // Gradle's dependency substitution so the dependency will appear correctly in the pom files that

--- a/gradle.properties
+++ b/gradle.properties
@@ -256,8 +256,6 @@ springBootVersion=2.7.2
 # This MUST match the Tomcat version dictated by springBootVersion
 springBootTomcatVersion=9.0.65
 
-# N.B. Spring version 5+ brings in a change to form handling such that GET and POST parameters are both used when
-# posting a form. For some of our forms this causes heartache.
 springVersion=5.3.22
 
 sqliteJdbcVersion=3.7.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -258,7 +258,7 @@ springBootTomcatVersion=9.0.65
 
 # N.B. Spring version 5+ brings in a change to form handling such that GET and POST parameters are both used when
 # posting a form. For some of our forms this causes heartache.
-springVersion=4.3.20.RELEASE
+springVersion=5.3.22
 
 sqliteJdbcVersion=3.7.2
 

--- a/server/configs/pg.properties
+++ b/server/configs/pg.properties
@@ -13,8 +13,8 @@ databaseDefaultPort=5432
 
 jdbcDriverClassName=org.postgresql.Driver
 jdbcURL=jdbc:postgresql://${jdbcHost}:${jdbcPort}/${jdbcDatabase}${jdbcURLParameters}
-jdbcUser=labkey
-jdbcPassword=labkey
+jdbcUser=postgres
+jdbcPassword=sasa
 
 # key for the encrypted property store and other potentially sensitive content
 encryptionKey=defaultKey

--- a/server/configs/pg.properties
+++ b/server/configs/pg.properties
@@ -13,8 +13,8 @@ databaseDefaultPort=5432
 
 jdbcDriverClassName=org.postgresql.Driver
 jdbcURL=jdbc:postgresql://${jdbcHost}:${jdbcPort}/${jdbcDatabase}${jdbcURLParameters}
-jdbcUser=postgres
-jdbcPassword=sasa
+jdbcUser=labkey
+jdbcPassword=labkey
 
 # key for the encrypted property store and other potentially sensitive content
 encryptionKey=defaultKey


### PR DESCRIPTION
#### Rationale
We want to be on the latest, maintained version of Spring Framework.

#### Changes
* Update to 5.3.22
* Remove hack to force just Spring Expression library to 5.3.22