### PR TITLE
Upgrade Google Client API 1.35.2 -> 2.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -210,6 +210,8 @@ allprojects {
                         force "xml-apis:xml-apis:${xmlApisVersion}"
                     // cloud and SequenceAnalysis bring this in as a transitive dependency. We resolve to the later version here to keep things consistent
                     force "com.google.code.gson:gson:${gsonVersion}"
+                    // different google APIs bring in different versions; force the latest
+                    force "com.google.http-client:google-http-client-gson:${googleHttpClientGsonVersion}"
                     // workflow (Activiti) brings in older versions of these libraries, so we need to force these versions
                     force "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
                     force "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -140,9 +140,9 @@ flyingsaucerVersion=R8
 fopVersion=2.7
 
 googleApiServicesCalendarVersion=v3-rev411-1.25.0
-googleApiClientVersion=1.35.2
-# Version pulled in by Google API Client 1.35.2 - force for consistency
-googleHttpClientGsonVersion=1.42.0
+googleApiClientVersion=2.0.0
+# Force lastest for consistency
+googleHttpClientGsonVersion=1.42.2
 googleHttpClientVersion=1.42.2
 googleOauthClientVersion=1.34.1
 googleProtocolBufVersion=3.21.5


### PR DESCRIPTION
#### Rationale
Upgrade to the latest and add a project-wide force for Google HTTP GSON dependency
