### PR TITLE
Upgrade to newest Java remote API version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -190,8 +190,10 @@ allprojects {
                     force "org.apache.commons:commons-math3:${commonsMath3Version}"
                     // force version for api, accounts, fileTransfer, harvest, scrumtime, docker
                     force "org.apache.httpcomponents:httpcore:${httpcoreVersion}"
+                    force "org.apache.httpcomponents.core5:httpcore5:${httpcore5Version}"
                     // force version for api, docker, fileTransfer, harvest, scrumtime, accounts
                     force "org.apache.httpcomponents:httpclient:${httpclientVersion}"
+                    force "org.apache.httpcomponents.client5:httpclient5:${httpclient5Version}"
                     // force version for SequenceAnalysis, api, cloud
                     force "com.google.guava:guava:${guavaVersion}"
                     // force version for accounts, api, query

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ buildFromSource=true
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
 labkeyVersion=22.10-SNAPSHOT
-labkeyClientApiVersion=2.1.0-httpclient-SNAPSHOT
+labkeyClientApiVersion=3.0.0
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.
 windowsUtilsVersion=1.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -167,6 +167,9 @@ hamcrestVersion=1.3
 # It is also necessary to update SequenceAnalysisManager.htsjdkVersion
 htsjdkVersion=2.24.1
 
+httpclient5Version=5.1.3
+httpcore5Version=5.1.4
+
 httpclientVersion=4.5.13
 httpcoreVersion=4.4.14
 httpmimeVersion=4.5.13

--- a/gradle.properties
+++ b/gradle.properties
@@ -141,7 +141,7 @@ fopVersion=2.7
 
 googleApiServicesCalendarVersion=v3-rev411-1.25.0
 googleApiClientVersion=2.0.0
-# Force lastest for consistency
+# Force latest for consistency
 googleHttpClientGsonVersion=1.42.2
 googleHttpClientVersion=1.42.2
 googleOauthClientVersion=1.34.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ buildFromSource=true
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
 labkeyVersion=22.10-SNAPSHOT
-labkeyClientApiVersion=2.0.0
+labkeyClientApiVersion=2.1.0-httpclient-SNAPSHOT
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.
 windowsUtilsVersion=1.0


### PR DESCRIPTION
#### Rationale
Use the latest version

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-java/pull/35
