### PR TITLE
Remove unused httpmimeVersion property

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -174,7 +174,6 @@ httpcore5Version=5.1.4
 
 httpclientVersion=4.5.13
 httpcoreVersion=4.4.14
-httpmimeVersion=4.5.13
 
 jacksonVersion=2.13.3
 jacksonAnnotationsVersion=2.13.3


### PR DESCRIPTION
#### Rationale
All usages of and references to Apache HttpMime have been removed
