### PR TITLE
Update labkey-client-api to v3.1.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ buildFromSource=true
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
 labkeyVersion=22.10-SNAPSHOT
-labkeyClientApiVersion=3.1.0-storageClientAPI-SNAPSHOT
+labkeyClientApiVersion=3.1.0
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.
 windowsUtilsVersion=1.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ buildFromSource=true
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
 labkeyVersion=22.10-SNAPSHOT
-labkeyClientApiVersion=3.0.0
+labkeyClientApiVersion=3.1.0-storageClientAPI-SNAPSHOT
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.
 windowsUtilsVersion=1.0


### PR DESCRIPTION
#### Rationale
Test and upgrade to the latest Java client API

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-java/pull/36