### PR TITLE
Migrate labkey-client-api to use a modern JSON library: JSON-java

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,9 @@
 import org.apache.commons.lang3.SystemUtils
+import org.labkey.gradle.plugin.NpmRun
+import org.labkey.gradle.task.PurgeNpmAlphaVersions
 import org.labkey.gradle.task.ShowDiscrepancies
 import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.GroupNames
-import org.labkey.gradle.plugin.NpmRun
-import org.labkey.gradle.task.PurgeNpmAlphaVersions
 
 buildscript {
     repositories {
@@ -229,8 +229,8 @@ allprojects {
                     // force consistency in TCRdb, WNPRC
                     force "org.javassist:javassist:${javassistVersion}"
                     force "org.ow2.asm:asm:${asmVersion}"
-                    // force junit and hamcrest versions to be consistent with what comes from labkey-client-api via json-simple.
-                    // The hamcrest dependencies come through transitively from jackson, json-simple, junit, jmock
+                    // force junit and hamcrest versions to be consistent with what comes from labkey-client-api.
+                    // The hamcrest dependencies come through transitively from jackson, junit, jmock
                     force "org.hamcrest:hamcrest-core:${hamcrestVersion}"
                     force "org.hamcrest:hamcrest-library:${hamcrestVersion}"
                     force "junit:junit:${junitVersion}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ buildFromSource=true
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
 labkeyVersion=22.10-SNAPSHOT
-labkeyClientApiVersion=3.1.0
+labkeyClientApiVersion=4.0.0-jsonUpgrade-SNAPSHOT
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.
 windowsUtilsVersion=1.0
@@ -204,7 +204,7 @@ jsr305Version=3.0.2
 
 jsonSimpleVersion=1.1.1
 
-orgJsonVersion=20220320
+orgJsonVersion=20220924
 
 jtdsVersion=1.3.1
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ buildFromSource=true
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
 labkeyVersion=22.11-SNAPSHOT
-labkeyClientApiVersion=4.0.0-jsonUpgrade-SNAPSHOT
+labkeyClientApiVersion=4.0.0-SNAPSHOT
 
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.


### PR DESCRIPTION
#### Rationale
labkey-client-api was using an old, unsupported JSON library