### PR TITLE
Module name conflict 41636

### DIFF
--- a/server/bootstrap/src/org/labkey/bootstrap/LabkeyServerBootstrapClassLoader.java
+++ b/server/bootstrap/src/org/labkey/bootstrap/LabkeyServerBootstrapClassLoader.java
@@ -16,7 +16,7 @@
 package org.labkey.bootstrap;
 
 /**
- * Here for backwards compatibility with labkey.xml (or similar) deployment descriptors that still refer to the this class
+ * Here for backwards compatibility with labkey.xml (or similar) deployment descriptors that still refer to this class
  * by name. Using LabKeyBootstrapClassLoader is the preferred class.
  */
 @Deprecated

--- a/server/bootstrap/src/org/labkey/bootstrap/ModuleExtractor.java
+++ b/server/bootstrap/src/org/labkey/bootstrap/ModuleExtractor.java
@@ -16,6 +16,8 @@
 
 package org.labkey.bootstrap;
 
+import org.apache.tomcat.util.collections.CaseInsensitiveKeyMap;
+
 import java.io.*;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -63,14 +65,45 @@ public class ModuleExtractor
         // list is critical in this case. File.listFiles() can't estimate the size of its results, so invoking parallel()
         // directly leads to a terrible splitting strategy that has no parallelization benefit.
         // https://stackoverflow.com/questions/34341656/why-is-files-list-parallel-stream-performing-so-much-slower-than-using-collect
-        _moduleDirectories.streamAllModuleDirectories()
-            .flatMap(dir-> {File[] files=dir.listFiles(moduleArchiveFilter); return null==files ? null : Stream.of(files);})
-            .collect(Collectors.toList()) // This intermediate list is critical. See comment above.
-            .parallelStream()
-            .forEach(moduleArchiveFile->{
+        var archives = _moduleDirectories.streamAllModuleDirectories()
+                .flatMap(dir -> {
+                    File[] files = dir.listFiles(moduleArchiveFilter);
+                    return null == files ? null : Stream.of(files);
+                })
+                .map(moduleArchiveFile -> {
+                    try
+                    {
+                        return new ModuleArchive(moduleArchiveFile, _log);
+                    }
+                    catch (IOException e)
+                    {
+                        _log.error("Unable to open module archive " + moduleArchiveFile.getPath() + "!", e);
+                        _errorArchives.put(moduleArchiveFile, moduleArchiveFile.lastModified());
+                        return null;
+                    }
+                }).filter(Objects::nonNull).toList();
+
+        // verify there are no duplicates
+        var nameSet = new CaseInsensitiveKeyMap<ModuleArchive>();
+        for (var moduleArchive : archives)
+        {
+            ModuleArchive found = nameSet.put(moduleArchive.getModuleName(), moduleArchive);
+            if (null != found)
+            {
+                nameSet.put(moduleArchive.getModuleName(), moduleArchive);
+                var re = new IllegalStateException("LabKey found two modules with the name \"" + moduleArchive.getModuleName() + "\".  Please resolve this problem and restart the server");
+                _log.error("Unable to extract module archive " + found.getFile().getPath() + "!");
+                _log.error("Unable to extract module archive " + moduleArchive.getFile().getPath(), re);
+                throw re;
+            }
+        }
+
+        // extract
+        archives.parallelStream()
+            .forEach(moduleArchive->{
+                File moduleArchiveFile = moduleArchive.getFile();
                 try
                 {
-                    ModuleArchive moduleArchive = new ModuleArchive(moduleArchiveFile, _log);
                     File dir = moduleArchive.extractAll();
                     _moduleArchiveFiles.put(moduleArchiveFile, moduleArchive);
                     mapModuleDirToArchive.put(dir.getAbsoluteFile(), moduleArchive);

--- a/server/bootstrap/src/org/labkey/bootstrap/ModuleExtractor.java
+++ b/server/bootstrap/src/org/labkey/bootstrap/ModuleExtractor.java
@@ -16,8 +16,6 @@
 
 package org.labkey.bootstrap;
 
-import org.apache.tomcat.util.collections.CaseInsensitiveKeyMap;
-
 import java.io.*;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -84,13 +82,12 @@ public class ModuleExtractor
                 }).filter(Objects::nonNull).toList();
 
         // verify there are no duplicates
-        var nameSet = new CaseInsensitiveKeyMap<ModuleArchive>();
+        var nameSet = new HashMap<String,ModuleArchive>();
         for (var moduleArchive : archives)
         {
-            ModuleArchive found = nameSet.put(moduleArchive.getModuleName(), moduleArchive);
+            ModuleArchive found = nameSet.put(moduleArchive.getModuleName().toLowerCase(), moduleArchive);
             if (null != found)
             {
-                nameSet.put(moduleArchive.getModuleName(), moduleArchive);
                 var re = new IllegalStateException("LabKey found two modules with the name \"" + moduleArchive.getModuleName() + "\".  Please resolve this problem and restart the server");
                 _log.error("Unable to extract module archive " + found.getFile().getPath() + "!");
                 _log.error("Unable to extract module archive " + moduleArchive.getFile().getPath(), re);


### PR DESCRIPTION
#### Rationale
LabKey server cannot run property with two modules having the same name.   This commit enforces fail-fast for two module archives having the same name.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
