### PR TITLE
v4.0.0 has been published

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ buildFromSource=true
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
 labkeyVersion=22.11-SNAPSHOT
-labkeyClientApiVersion=4.0.0-SNAPSHOT
+labkeyClientApiVersion=4.0.0
 
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.


### PR DESCRIPTION
#### Rationale
Use the latest released version

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-java/releases/tag/v4.0.0
