### PR TITLE
Upgrade Lucene, Tika, and Tika dependencies

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -101,7 +101,7 @@ apacheTomcatVersion=9.0.68
 # (mothership) -> json-path -> json-smart -> accessor-smart
 # (core) -> graalvm
 # tika
-asmVersion=9.2
+asmVersion=9.4
 
 # Apache Batik -- Batik version needs to be compatible with Apache FOP, but we need to pull in batik-codec separately
 batikVersion=1.16
@@ -118,7 +118,7 @@ commonsCollectionsVersion=3.2.2
 commonsCollections4Version=4.4
 commonsCodecVersion=1.15
 # sync with version Tika ships
-commonsCompressVersion=1.21
+commonsCompressVersion=1.22
 commonsDbcpVersion=1.4
 commonsDiscoveryVersion=0.2
 commonsDigesterVersion=1.8.1
@@ -237,10 +237,10 @@ oracleJdbcVersion=21.7.0.0
 patriciaTrieVersion=0.6
 
 # sync with version Tika ships
-pdfboxVersion=2.0.25
+pdfboxVersion=2.0.27
 
 # sync with version Tika ships
-poiVersion=5.2.0
+poiVersion=5.2.3
 
 pollingWatchVersion=0.2.0
 
@@ -257,9 +257,9 @@ romeVersion=1.18.0
 servletApiVersion=4.0.1
 
 # this version is forced for compatibility with pipeline and tika
-slf4jLog4j12Version=1.7.33
+slf4jLog4j12Version=2.0.3
 # this version is forced for compatibility with api, LDK, and workflow
-slf4jLog4jApiVersion=1.7.33
+slf4jLog4jApiVersion=2.0.3
 
 springBootVersion=2.7.5
 # This MUST match the Tomcat version dictated by springBootVersion
@@ -276,7 +276,7 @@ stax2ApiVersion=4.2.1
 thumbnailatorVersion=0.4.8
 
 # used for tika-core in API and tika-parsers in search
-tikaVersion=2.3.0
+tikaVersion=2.6.0
 
 # sync with Tika
 tukaaniXZVersion=1.9
@@ -290,11 +290,11 @@ woodstoxCoreVersion=6.2.1
 xalanVersion=2.7.2
 
 # sync with Tika
-xercesImplVersion=2.12.1
+xercesImplVersion=2.12.2
 
 # version 2.0.2 was relocated to xml-apis:xml-apis:1.0.b2, so we use 1.0.b2 here since later versions of Gradle don't support
 # using the relocated version
 xmlApisVersion=1.0.b2
 
 # sync with Tika/POI
-xmlbeansVersion=5.0.3
+xmlbeansVersion=5.1.1


### PR DESCRIPTION
#### Rationale
Latest versions are best

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3826

#### Changes
* Upgrade Tika 2.3.0 -> 2.6.0
* Upgrade ASM 9.2 -> 9.4
* Upgrade Commons Compress 1.21 -> 1.22
* Upgrade PDFBox 2.0.25 -> 2.0.27
* Upgrade POI 5.2.0 -> 5.2.3
* Upgrade SLF4J 1.7.33 -> 2.0.3
* Upgrade XercesImpl 2.12.1 -> 2.12.2
* Upgrade XMLBeans 5.0.3 -> 5.1.1