### PR TITLE
Upgrade Bouncy Castle 1.70 -> 1.72

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -237,9 +237,9 @@ allprojects {
                     force "org.codehaus.woodstox:stax2-api:${stax2ApiVersion}"
                     force "com.fasterxml.woodstox:woodstox-core:${woodstoxCoreVersion}"
                     // force consistency in docker and connectors, saml, nlp
-                    force "org.bouncycastle:bcprov-jdk15on:${bouncycastleVersion}"
+                    force "org.bouncycastle:bcprov-jdk18on:${bouncycastleVersion}"
                     // force consistency in docker and connectors and saml
-                    force "org.bouncycastle:bcpkix-jdk15on:${bouncycastleVersion}"
+                    force "org.bouncycastle:bcpkix-jdk18on:${bouncycastleVersion}"
                     // force consistency with netty jar files for docker and UserReg-WS
                     force "io.netty:netty-resolver:${nettyVersion}"
                     force "io.netty:netty-handler:${nettyVersion}"
@@ -260,10 +260,15 @@ allprojects {
                             substitute module('org.labkey:labkey-client-api') with project(BuildUtils.getRemoteApiProjectPath(gradle))
                         // mule and tika bring in different versions of bouncycastle package via transitive dependencies, but these versions
                         // result in a StackOverflow when starting tomcat so we substitute new libraries for both versions that are brought in.
-                        substitute module('bouncycastle:bcprov-jdk14:138') with module("org.bouncycastle:bcprov-jdk15on:${bouncycastleVersion}")
-                        substitute module('bouncycastle:bcmail-jdk14:138') with module("org.bouncycastle:bcpkix-jdk15on:${bouncycastleVersion}")
-                        substitute module('bouncycastle:bcprov-jdk15:1.45') with module("org.bouncycastle:bcprov-jdk15on:${bouncycastleVersion}")
-                        substitute module('bouncycastle:bcmail-jdk15:138') with module("org.bouncycastle:bcpkix-jdk15on:${bouncycastleVersion}")
+                        substitute module('bouncycastle:bcprov-jdk14:138') with module("org.bouncycastle:bcprov-jdk18on:${bouncycastleVersion}")
+                        substitute module('bouncycastle:bcmail-jdk14:138') with module("org.bouncycastle:bcpkix-jdk18on:${bouncycastleVersion}")
+                        substitute module('bouncycastle:bcprov-jdk15:1.45') with module("org.bouncycastle:bcprov-jdk18on:${bouncycastleVersion}")
+                        substitute module('bouncycastle:bcmail-jdk15:138') with module("org.bouncycastle:bcpkix-jdk18on:${bouncycastleVersion}")
+
+                        // Docker and SAML are bringing in older -jdk15on versions (more recent versions have been renamed with -jdk18on suffix)
+                        substitute module('org.bouncycastle:bcprov-jdk15on:1.54') with module("org.bouncycastle:bcprov-jdk18on:${bouncycastleVersion}")
+                        substitute module('org.bouncycastle:bcprov-jdk15on:1.64') with module("org.bouncycastle:bcprov-jdk18on:${bouncycastleVersion}")
+                        substitute module('org.bouncycastle:bcpkix-jdk15on:1.64') with module("org.bouncycastle:bcpkix-jdk18on:${bouncycastleVersion}")
 
                         // This JAR packages classes with the same names as commons-logging but forces them to use SLF4J instead
                         // of the normal routing decisions, and can result in very verbose output to STDOUT

--- a/gradle.properties
+++ b/gradle.properties
@@ -106,8 +106,9 @@ asmVersion=9.4
 # Apache Batik -- Batik version needs to be compatible with Apache FOP, but we need to pull in batik-codec separately
 batikVersion=1.16
 
-# sync with Tika version
-bouncycastleVersion=1.70
+# sync with Tika version (or later)
+bouncycastlePgpVersion=1.72.1
+bouncycastleVersion=1.72
 
 cglibNodepVersion=2.2.3
 


### PR DESCRIPTION
#### Rationale
Bouncy Castle was out-of-date

#### Changes
* Update version (1.70 to 1.72) and suffix (`-jdk15on` to `-jdk18on`)
* Use substitution to prevent `-jdk15on` transitive dependencies
* Add a PGP version property to allow pulling in a patch version of that JAR