### PR TITLE
Update labkeyClientApiVersion

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ buildFromSource=true
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
 labkeyVersion=23.1-SNAPSHOT
-labkeyClientApiVersion=4.0.0
+labkeyClientApiVersion=4.1.0-freezerToStorage-SNAPSHOT
 
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ buildFromSource=true
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
 labkeyVersion=23.1-SNAPSHOT
-labkeyClientApiVersion=4.1.0-freezerToStorage-SNAPSHOT
+labkeyClientApiVersion=4.1.0
 
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.


### PR DESCRIPTION
#### Rationale
We have a few changes pending for the next version of labkey-client-api. This includes an update to allow for the use of "Primary Storage" as a location type in the storage API to make support of non-freezer storage more apparent.

#### Related Pull Requests
- https://github.com/LabKey/labkey-api-java/pull/44
- https://github.com/LabKey/inventory/pull/648

#### Changes
* Update labkeyClientApiVersion.
