### PR TITLE
Upgrade Java remote API to v4.3.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ buildFromSource=true
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
 labkeyVersion=23.2-SNAPSHOT
-labkeyClientApiVersion=4.3.1-selectrows_fix-SNAPSHOT
+labkeyClientApiVersion=4.3.1
 
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ buildFromSource=true
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
 labkeyVersion=23.2-SNAPSHOT
-labkeyClientApiVersion=4.3.0
+labkeyClientApiVersion=4.3.1-selectrows_fix-SNAPSHOT
 
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.


### PR DESCRIPTION
#### Rationale
It's the new thing

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-java/pull/47