### PR TITLE
Upgrade dependencies to the latest versions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -96,7 +96,7 @@ apacheDirectoryVersion=1.0.3
 apacheMinaVersion=2.0.19
 
 # Keep in sync with springBootTomcatVersion below
-apacheTomcatVersion=9.0.69
+apacheTomcatVersion=9.0.70
 
 # (mothership) -> json-path -> json-smart -> accessor-smart
 # (core) -> graalvm
@@ -129,7 +129,7 @@ commonsLangVersion=2.6
 commonsLang3Version=3.12.0
 commonsLoggingVersion=1.2
 commonsMath3Version=3.6.1
-commonsNetVersion=3.8.0
+commonsNetVersion=3.9.0
 commonsPoolVersion=1.6
 commonsValidatorVersion=1.7
 
@@ -142,10 +142,10 @@ ehcacheCoreVersion=2.6.8
 flyingsaucerVersion=R8
 
 # Apache FOP -- linked to Apache Batik version above
-fopVersion=2.7
+fopVersion=2.8
 
 googleApiServicesCalendarVersion=v3-rev411-1.25.0
-googleApiClientVersion=2.0.1
+googleApiClientVersion=2.1.2
 # Force latest for consistency
 googleErrorProneAnnotationsVersion=2.16
 # Force latest for consistency
@@ -175,7 +175,7 @@ hamcrestVersion=1.3
 htsjdkVersion=2.24.1
 
 httpclient5Version=5.2.1
-httpcore5Version=5.2
+httpcore5Version=5.2.1
 
 # Not used directly, but these are widely used transitive dependencies
 httpclientVersion=4.5.14
@@ -267,12 +267,12 @@ slf4jLog4j12Version=2.0.3
 # this version is forced for compatibility with api, LDK, and workflow
 slf4jLog4jApiVersion=2.0.3
 
-springBootVersion=2.7.6
+springBootVersion=2.7.7
 # This MUST match the Tomcat version dictated by springBootVersion
 # Also, keep this in sync with apacheTomcatVersion above
-springBootTomcatVersion=9.0.69
+springBootTomcatVersion=9.0.70
 
-springVersion=5.3.24
+springVersion=5.3.25
 
 sqliteJdbcVersion=3.7.2
 


### PR DESCRIPTION
#### Rationale
Tomcat, Spring, Spring Boot, Commons Net, FOP, HttpCore, and Google API Client all have more recent versions
