### PR TITLE
Update node and npm to pull in package-lock fix

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -65,8 +65,8 @@ versioningPluginVersion=1.1.0
 # Versions of node and npm to use during the build. If set, these versions
 # will be downloaded and used. If not set, the existing local installations will be use
 # The version of npm corresponds to the given version of node
-npmVersion=8.1.2
-nodeVersion=16.13.1
+npmVersion=8.19.3
+nodeVersion=16.19.0
 nodeRepo=https://nodejs.org/dist
 # Directory in a project's build directory where the node binary will be placed
 nodeWorkDirectory=.node


### PR DESCRIPTION
#### Rationale
This updates NodeJS to v16.19.0 along with the paired NPM v8.19.3. Specifically, we're going this to address an issue we're seeing in the Node docker containers in CI when attempting to build our module packages. https://github.com/npm/cli/issues/2701

#### Related Pull Requests
- https://github.com/LabKey/server/pull/161 (Last NodeJS Update)

#### Changes
* Update node and npm to pull in package-lock fix
