### PR TITLE
Upgrade to latest Java remote API

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ buildFromSource=true
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
 labkeyVersion=23.2-SNAPSHOT
-labkeyClientApiVersion=5.0.1-fix_fixup-SNAPSHOT
+labkeyClientApiVersion=5.0.1
 
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ buildFromSource=true
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
 labkeyVersion=23.2-SNAPSHOT
-labkeyClientApiVersion=5.0.0
+labkeyClientApiVersion=5.0.1-fix_fixup-SNAPSHOT
 
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.


### PR DESCRIPTION
#### Rationale
v5.0.1 includes a data fix-up fix

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-java/pull/49