### PR TITLE
Upgrade PostgreSQL JDBC driver to 42.5.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -250,7 +250,7 @@ poiVersion=5.2.3
 
 pollingWatchVersion=0.2.0
 
-postgresqlDriverVersion=42.5.2
+postgresqlDriverVersion=42.5.3
 
 quartzVersion=2.3.2
 


### PR DESCRIPTION
#### Rationale
42.5.2 had a couple regressions that are fixed by 42.5.3: https://jdbc.postgresql.org/changelogs/2023-02-03-42.5.3-release/

See also https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47208

#### Related Pull Requests
* https://github.com/LabKey/server/pull/394
