### PR TITLE
Preparing for Gradle 8 - update "with" to "using"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -259,7 +259,7 @@ allprojects {
                         // are generated. Because dependency substitution does not understand the use of classifiers, we cannot
                         // use this mechanism in general (plus, it's very slow for our many-module build).
                         if (project.findProject(BuildUtils.getRemoteApiProjectPath(gradle)) && BuildUtils.shouldBuildFromSource(project.project(BuildUtils.getRemoteApiProjectPath(gradle))))
-                            substitute module('org.labkey:labkey-client-api') with project(BuildUtils.getRemoteApiProjectPath(gradle))
+                            substitute module('org.labkey:labkey-client-api') using project(BuildUtils.getRemoteApiProjectPath(gradle))
                         // mule and tika bring in different versions of bouncycastle package via transitive dependencies, but these versions
                         // result in a StackOverflow when starting tomcat so we substitute new libraries for both versions that are brought in.
                         substitute module('bouncycastle:bcprov-jdk14:138') using module("org.bouncycastle:bcprov-jdk18on:${bouncycastleVersion}")

--- a/build.gradle
+++ b/build.gradle
@@ -262,25 +262,25 @@ allprojects {
                             substitute module('org.labkey:labkey-client-api') with project(BuildUtils.getRemoteApiProjectPath(gradle))
                         // mule and tika bring in different versions of bouncycastle package via transitive dependencies, but these versions
                         // result in a StackOverflow when starting tomcat so we substitute new libraries for both versions that are brought in.
-                        substitute module('bouncycastle:bcprov-jdk14:138') with module("org.bouncycastle:bcprov-jdk18on:${bouncycastleVersion}")
-                        substitute module('bouncycastle:bcmail-jdk14:138') with module("org.bouncycastle:bcpkix-jdk18on:${bouncycastleVersion}")
-                        substitute module('bouncycastle:bcprov-jdk15:1.45') with module("org.bouncycastle:bcprov-jdk18on:${bouncycastleVersion}")
-                        substitute module('bouncycastle:bcmail-jdk15:138') with module("org.bouncycastle:bcpkix-jdk18on:${bouncycastleVersion}")
+                        substitute module('bouncycastle:bcprov-jdk14:138') using module("org.bouncycastle:bcprov-jdk18on:${bouncycastleVersion}")
+                        substitute module('bouncycastle:bcmail-jdk14:138') using module("org.bouncycastle:bcpkix-jdk18on:${bouncycastleVersion}")
+                        substitute module('bouncycastle:bcprov-jdk15:1.45') using module("org.bouncycastle:bcprov-jdk18on:${bouncycastleVersion}")
+                        substitute module('bouncycastle:bcmail-jdk15:138') using module("org.bouncycastle:bcpkix-jdk18on:${bouncycastleVersion}")
 
                         // Docker and SAML are bringing in older -jdk15on versions (more recent versions have been renamed with -jdk18on suffix)
-                        substitute module('org.bouncycastle:bcprov-jdk15on:1.54') with module("org.bouncycastle:bcprov-jdk18on:${bouncycastleVersion}")
-                        substitute module('org.bouncycastle:bcprov-jdk15on:1.64') with module("org.bouncycastle:bcprov-jdk18on:${bouncycastleVersion}")
-                        substitute module('org.bouncycastle:bcpkix-jdk15on:1.64') with module("org.bouncycastle:bcpkix-jdk18on:${bouncycastleVersion}")
+                        substitute module('org.bouncycastle:bcprov-jdk15on:1.54') using module("org.bouncycastle:bcprov-jdk18on:${bouncycastleVersion}")
+                        substitute module('org.bouncycastle:bcprov-jdk15on:1.64') using module("org.bouncycastle:bcprov-jdk18on:${bouncycastleVersion}")
+                        substitute module('org.bouncycastle:bcpkix-jdk15on:1.64') using module("org.bouncycastle:bcpkix-jdk18on:${bouncycastleVersion}")
 
                         // This JAR packages classes with the same names as commons-logging but forces them to use SLF4J instead
                         // of the normal routing decisions, and can result in very verbose output to STDOUT
-                        substitute module('org.slf4j:jcl-over-slf4j') with module("commons-logging:commons-logging:${commonsLoggingVersion}")
+                        substitute module('org.slf4j:jcl-over-slf4j') using module("commons-logging:commons-logging:${commonsLoggingVersion}")
 
                         // jdk5 backport of guava has significant conflicts with guava 18+
-                        substitute module('com.google.guava:guava-jdk5') with module("com.google.guava:guava:${guavaVersion}")
+                        substitute module('com.google.guava:guava-jdk5') using module("com.google.guava:guava:${guavaVersion}")
 
                         // This library was renamed
-                        substitute module('org.codehaus.woodstox:woodstox-core-asl') with module("com.fasterxml.woodstox:woodstox-core:${woodstoxCoreVersion}")
+                        substitute module('org.codehaus.woodstox:woodstox-core-asl') using module("com.fasterxml.woodstox:woodstox-core:${woodstoxCoreVersion}")
                     }
                 }
             }


### PR DESCRIPTION
#### Rationale
It seems I may have missed a memo somewhere about a syntax change for dependency substitution. As of Gradle 8, instead of `substitute module ... with ...`, it's now `substitute module ... using ...`

#### Related Pull Requests
* https://github.com/LabKey/cloud/pull/122

#### Changes
* "with" becomes "using"
