### PR TITLE
Remove internal module and references to labkey-api-sas project path

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -59,7 +59,7 @@ windowsProteomicsBinariesVersion=1.0
 artifactoryPluginVersion=4.21.0
 gradleNodePluginVersion=3.0.1
 #gradlePluginsVersion=1.39.1
-gradlePluginsVersion=1.40.0-removeInternal-SNAPSHOT
+gradlePluginsVersion=1.40.0
 owaspDependencyCheckPluginVersion=5.2.1
 versioningPluginVersion=1.1.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -58,7 +58,8 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.21.0
 gradleNodePluginVersion=3.0.1
-gradlePluginsVersion=1.39.1
+#gradlePluginsVersion=1.39.1
+gradlePluginsVersion=1.40.0-removeInternal-SNAPSHOT
 owaspDependencyCheckPluginVersion=5.2.1
 versioningPluginVersion=1.1.0
 

--- a/gradle/settings/all.gradle
+++ b/gradle/settings/all.gradle
@@ -51,8 +51,3 @@ if (new File(getRootDir(), BuildUtils.convertPathToRelativeDir(BuildUtils.getRem
 {
     include BuildUtils.getRemoteApiProjectPath(gradle)
 }
-
-if (new File(getRootDir(), BuildUtils.convertPathToRelativeDir(BuildUtils.getSasApiProjectPath(gradle))).exists())
-{
-    include BuildUtils.getSasApiProjectPath(gradle)
-}

--- a/settings.gradle
+++ b/settings.gradle
@@ -50,7 +50,6 @@ buildscript {
 //        classpath "org.apache.commons:commons-lang3:${commonsLang3Version}"
 //        classpath "org.apache.commons:commons-text:1.9"
 //        classpath "commons-io:commons-io:${commonsIoVersion}"
-//        classpath "com.yahoo.platform.yui:yuicompressor:2.4.8a"
 //        classpath "org.apache.httpcomponents:httpclient:${httpclientVersion}"
 //        classpath "org.json:json:20210307"
 //        classpath "com.fasterxml.jackson.core:jackson-databind:2.12.2"


### PR DESCRIPTION
#### Rationale
The guts of the internal module were moved elsewhere with [platform PR #4015](https://github.com/LabKey/platform/pull/4015). Here we update the build plugin version to remove references to the module in the build (along with a few other clean up measures).

#### Related Pull Requests
- https://github.com/LabKey/gradlePlugin/pull/166

#### Changes
* Gradle plugins version update
* remove reference to now-obsolete sasApiProjectPath
