### PR TITLE
Update gradle plugins to 1.40.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -58,8 +58,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.21.0
 gradleNodePluginVersion=3.0.1
-#gradlePluginsVersion=1.39.1
-gradlePluginsVersion=1.40.0
+gradlePluginsVersion=1.40.1
 owaspDependencyCheckPluginVersion=5.2.1
 versioningPluginVersion=1.1.0
 


### PR DESCRIPTION
#### Rationale
[Issue 47370: Patched API module doesn't get named correctly on feature branches](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=47370)

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/167

#### Changes
* Update gradle plugins to 1.40.1
