### PR TITLE
Update gradle plugins version and use better configuration patterns

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ buildscript {
     dependencies {
         classpath "org.labkey.build:versioning:${versioningPluginVersion}"
     }
-    configurations.all {
+    configurations.configureEach {
         // Check for updates every build for SNAPSHOT dependencies
         resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
     }
@@ -53,7 +53,7 @@ allprojects {
     {
         apply plugin: 'com.jfrog.artifactory'
     }
-    project.tasks.withType(JavaCompile) {
+    project.tasks.withType(JavaCompile).configureEach {
         JavaCompile compile ->
             compile.options.incremental = true  // Gradle 3.4
             compile.options.encoding = 'UTF-8'
@@ -74,7 +74,7 @@ allprojects {
                 utilities
             }
     // exclude log4j, which may come in transitively, from all configurations to avoid its potential vulnerabilities
-    configurations.all {
+    configurations.configureEach {
         exclude group: "log4j", module:"log4j"
     }
     configurations.driver.setDescription("Dependencies used for SqlUtils")
@@ -99,7 +99,7 @@ allprojects {
 
 
     tasks.withType(JavaCompile)
-            {
+            .configureEach {
                 sourceCompatibility = project.ext.sourceCompatibility
                 targetCompatibility = project.ext.targetCompatibility
             }
@@ -154,12 +154,12 @@ allprojects {
                 }
 
             }
-    configurations.all
+    configurations.configureEach
             {
                 // Check for updates every build for SNAPSHOT dependencies
                 resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
             }
-    configurations.all
+    configurations.configureEach
             {Configuration config ->
                 resolutionStrategy {
                     // we force this version because we have compilation problems with version 1.9.2 of commons-beanutils, which is the version
@@ -314,18 +314,27 @@ if (BuildUtils.shouldPublish(project) || BuildUtils.shouldPublishDistribution(pr
 }
 
 subprojects {
-    task("showRepos", group: "Help", description: "Show the list of repositories currently in use.").doLast({
-        repositories.each {
-            println "repository: ${it.name} (${it.hasProperty("url") ? it.url : it.getDirs()})"
-        }
-    })
-    project.task("showConfigs", group: "help", description: "Show all the configurations available in the project and their published artifacts")
-        .doLast({
-            project.configurations.forEach({
-                Configuration config ->
-                    println(config.name + ": (${config.getDescription()})")
+    project.tasks.register("showRepos", DefaultTask) {
+        task ->
+            task.group = "Help"
+            task.description = "Show the list of repositories currently in use."
+            task..doLast({
+                repositories.each {
+                    println "repository: ${it.name} (${it.hasProperty("url") ? it.url : it.getDirs()})"
+                }
             })
-        })
+    }
+    project.tasks.register("showConfigs") {
+        task ->
+            task.group = GroupNames.HELP
+            task.description = "Show all the configurations available in the project and their published artifacts"
+            task.doLast({
+                project.configurations.forEach({
+                    Configuration config ->
+                        println(config.name + ": (${config.getDescription()})")
+                })
+            })
+    }
     
     project.tasks.register("allDepInsight", DependencyInsightReportTask) {
             DependencyInsightReportTask t -> 
@@ -333,80 +342,88 @@ subprojects {
                 t.description = "Displays the insight into a specific dependency across all projects"
                 t.showingAllVariants=false
     }
-    task("allDependencies",
-            type: DependencyReportTask,
-            group: "Help",
-            description: "Displays the dependencies for all projects")
+    project.tasks.register("allDependencies", DependencyReportTask) {
+        task ->
+            task.group = GroupNames.HELP
+            task.description = "Displays the dependencies for all projects"
+    }
 }
 
-project.task("showDiscrepancies",
-        group: "Help",
-        type: ShowDiscrepancies,
-        description: "Report external dependencies that have more than one version referenced in the modules in this build"
-)
+project.tasks.register("showDiscrepancies", ShowDiscrepancies) {
+    task ->
+        task.group = "Help"
+        task.description = "Report external dependencies that have more than one version referenced in the modules in this build"
+}
 
-project.task(
-        'getModulesManifest',
-        group: GroupNames.DISTRIBUTION,
-        description: "Creates a csv file with a list of the modules for each distribution. By default it will be " +
+project.tasks.register('getModulesManifest', DefaultTask) {
+    task ->
+        task.group = GroupNames.DISTRIBUTION
+        task.description = "Creates a csv file with a list of the modules for each distribution. By default it will be " +
                 "placed in a directory called manifests in the root of this labkey installation. Specify another " +
                 "directory by using \"-PmanifestDir\". The default file name is distributionModules.csv; specify " +
                 "another name using \"-PmanifestFileName\"."
-).doLast({
-    String manifestDir = "${project.getRootProject().getProjectDir()}/manifests"
-    String manifestFileName = "distributionModules.csv"
+        task.doLast({
+            String manifestDir = "${project.getRootProject().getProjectDir()}/manifests"
+            String manifestFileName = "distributionModules.csv"
 
-    if (project.hasProperty("manifestDir")) {
-        manifestDir = project.manifestDir
-    }
-
-    if (project.hasProperty("manifestFileName")) {
-        manifestFileName = project.manifestFileName
-    }
-
-    project.mkdir(manifestDir)
-    File manifestFile = project.file("${manifestDir}/${manifestFileName}")
-
-    StringBuilder manifestString = new StringBuilder("distribution,moduleName\n")
-    project.allprojects({Project sp ->
-        if (sp.configurations.getNames().contains("distribution")) {
-            String distName
-            if (sp.getName().startsWith("test_")) {
-                // This is for the test_*prc case.
-                distName = sp.getName()
+            if (project.hasProperty("manifestDir"))
+            {
+                manifestDir = project.manifestDir
             }
-            else {
-                distName = sp.tasks.distribution.hasProperty("subDirName") ?
-                        sp.tasks.distribution.subDirName :
-                        sp.getName()
+
+            if (project.hasProperty("manifestFileName"))
+            {
+                manifestFileName = project.manifestFileName
             }
-            sp.configurations.distribution
-                    .getAllDependencies()
-                    .withType(ProjectDependency)
-                    .each({dep ->
-                manifestString.append("${distName},${dep.name}\n")
+
+            project.mkdir(manifestDir)
+            File manifestFile = project.file("${manifestDir}/${manifestFileName}")
+
+            StringBuilder manifestString = new StringBuilder("distribution,moduleName\n")
+            project.allprojects({ Project sp ->
+                if (sp.configurations.getNames().contains("distribution"))
+                {
+                    String distName
+                    if (sp.getName().startsWith("test_"))
+                    {
+                        // This is for the test_*prc case.
+                        distName = sp.getName()
+                    }
+                    else
+                    {
+                        distName = sp.tasks.distribution.hasProperty("subDirName") ?
+                                sp.tasks.distribution.subDirName :
+                                sp.getName()
+                    }
+                    sp.configurations.distribution
+                            .getAllDependencies()
+                            .withType(ProjectDependency)
+                            .each({ dep ->
+                                manifestString.append("${distName},${dep.name}\n")
+                            })
+                }
             })
-        }
-    })
-    manifestFile.text = manifestString.toString()
-})
+            manifestFile.text = manifestString.toString()
+        })
+}
 
-project.task(
-    'listNpmProjects',
-    group: GroupNames.NPM_RUN,
-    description:"List all projects that employ npm in their build"
-).doLast({
-    List<String> npmProjects = []
-    project.allprojects({Project p ->
-        if (p.getPlugins().hasPlugin(NpmRun.class))
-            npmProjects.add("${p.path} (${NpmRun.useYarn(p) ? 'yarn' : 'npm'})")
-    })
-    if (npmProjects.size == 0)
-        println("No projects found containing ${NpmRun.NPM_PROJECT_FILE}")
-    else {
-        println("The following projects use NPM in their builds:\n\t${npmProjects.join("\n\t")}\n")
-    }
-})
+project.tasks.register('listNpmProjects', DefaultTask) {
+    task ->
+        task.group = GroupNames.NPM_RUN
+        task.description ="List all projects that employ npm in their build"
+        task.doLast({
+            List<String> npmProjects = []
+            project.allprojects({Project p ->
+                if (p.getPlugins().hasPlugin(NpmRun.class))
+                    npmProjects.add("${p.path} (${NpmRun.useYarn(p) ? 'yarn' : 'npm'})")
+            })
+            if (npmProjects.size() == 0)
+                println("No projects found containing ${NpmRun.NPM_PROJECT_FILE}")
+            else {
+                println("The following projects use NPM in their builds:\n\t${npmProjects.join("\n\t")}\n")
+            }
+        })
+}
 
 project.tasks.register('ijWorkspaceSetup', Copy) {
     Copy copy ->

--- a/build.gradle
+++ b/build.gradle
@@ -318,7 +318,7 @@ subprojects {
         task ->
             task.group = "Help"
             task.description = "Show the list of repositories currently in use."
-            task..doLast({
+            task.doLast({
                 repositories.each {
                     println "repository: ${it.name} (${it.hasProperty("url") ? it.url : it.getDirs()})"
                 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -59,7 +59,7 @@ windowsProteomicsBinariesVersion=1.0
 artifactoryPluginVersion=4.21.0
 gradleNodePluginVersion=3.0.1
 #gradlePluginsVersion=1.39.1
-gradlePluginsVersion=1.40.0
+gradlePluginsVersion=1.41.0-gradle8-SNAPSHOT
 owaspDependencyCheckPluginVersion=5.2.1
 versioningPluginVersion=1.1.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -132,6 +132,8 @@ commonsLoggingVersion=1.2
 commonsMath3Version=3.6.1
 commonsNetVersion=3.9.0
 commonsPoolVersion=1.6
+# used in gradle plugins; included here for use in testing changes locally
+commonsTextVersion=1.10.0
 commonsValidatorVersion=1.7
 
 datadogVersion=0.108.1
@@ -156,6 +158,8 @@ googleOauthClientVersion=1.34.1
 googleProtocolBufVersion=3.21.9
 
 graalVersion=20.0.0
+# used in gradle plugins; included here for use in testing changes locally
+grgitGradleVersion=5.0.0
 
 # Cloud and SequenceAnalysis bring gson in as a transitive dependency.
 # We resolve to the later version here to keep things consistent

--- a/gradle.properties
+++ b/gradle.properties
@@ -58,8 +58,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.21.0
 gradleNodePluginVersion=3.0.1
-#gradlePluginsVersion=1.39.1
-gradlePluginsVersion=1.41.0-gradle8-SNAPSHOT
+gradlePluginsVersion=1.40.2
 owaspDependencyCheckPluginVersion=5.2.1
 versioningPluginVersion=1.1.0
 

--- a/gradle/settings/all.gradle
+++ b/gradle/settings/all.gradle
@@ -11,15 +11,18 @@ buildscript {
 
         }
     }
+    // For testing changes to the gradle plugins, uncomment the dependencies block below and reference the location
+    // of your gradlePlugin enlistment.  Then comment out the following dependencies
+    // block.  You will need to build the gradlePlugins jar file manually to pick up new changes.
 //    dependencies {
-//        classpath files("../../../gradlePlugin/build/libs/gradlePlugin-${gradlePluginsVersion}.jar")
+//        classpath files("../gradlePlugin/build/libs/gradlePlugin-${gradlePluginsVersion}.jar")
 //        classpath "org.apache.commons:commons-lang3:${commonsLang3Version}"
-//        classpath "org.apache.commons:commons-text:1.9"
+//        classpath "org.apache.commons:commons-text:${commonsTextVersion}"
 //        classpath "commons-io:commons-io:${commonsIoVersion}"
 //        classpath "org.apache.httpcomponents:httpclient:${httpclientVersion}"
-//        classpath "org.json:json:20210307"
-//        classpath "com.fasterxml.jackson.core:jackson-databind:2.12.2"
-//        classpath "org.ajoberstar.grgit:grgit-gradle:4.1.0"
+//        classpath "org.json:json:${orgJsonVersion}"
+//        classpath "com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}"
+//        classpath "org.ajoberstar.grgit:grgit-gradle:${grgitGradleVersion}"
 //    }
     dependencies {
         classpath "org.labkey.build:gradlePlugins:${gradlePluginsVersion}"

--- a/gradle/settings/all.gradle
+++ b/gradle/settings/all.gradle
@@ -11,10 +11,20 @@ buildscript {
 
         }
     }
+//    dependencies {
+//        classpath files("../../../gradlePlugin/build/libs/gradlePlugin-${gradlePluginsVersion}.jar")
+//        classpath "org.apache.commons:commons-lang3:${commonsLang3Version}"
+//        classpath "org.apache.commons:commons-text:1.9"
+//        classpath "commons-io:commons-io:${commonsIoVersion}"
+//        classpath "org.apache.httpcomponents:httpclient:${httpclientVersion}"
+//        classpath "org.json:json:20210307"
+//        classpath "com.fasterxml.jackson.core:jackson-databind:2.12.2"
+//        classpath "org.ajoberstar.grgit:grgit-gradle:4.1.0"
+//    }
     dependencies {
         classpath "org.labkey.build:gradlePlugins:${gradlePluginsVersion}"
     }
-    configurations.all {
+    configurations.configureEach {
         // Check for updates every build for SNAPSHOT dependencies
         resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
     }

--- a/gradle/settings/base.gradle
+++ b/gradle/settings/base.gradle
@@ -21,7 +21,7 @@ buildscript {
     dependencies {
         classpath "org.labkey.build:gradlePlugins:${gradlePluginsVersion}"
     }
-    configurations.all {
+    configurations.configureEach {
         // Check for updates every build for SNAPSHOT dependencies
         resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
     }

--- a/gradle/settings/community.gradle
+++ b/gradle/settings/community.gradle
@@ -15,7 +15,7 @@ buildscript {
     dependencies {
         classpath "org.labkey.build:gradlePlugins:${gradlePluginsVersion}"
     }
-    configurations.all {
+    configurations.configureEach {
         // Check for updates every build for SNAPSHOT dependencies
         resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
     }

--- a/gradle/settings/distributions.gradle
+++ b/gradle/settings/distributions.gradle
@@ -11,15 +11,18 @@ buildscript {
 
         }
     }
+    // For testing changes to the gradle plugins, uncomment the dependencies block below and reference the location
+    // of your gradlePlugin enlistment.  Then comment out the following dependencies
+    // block.  You will need to build the gradlePlugins jar file manually to pick up new changes.
 //    dependencies {
-//        classpath files("../../../gradlePlugin/build/libs/gradlePlugin-${gradlePluginsVersion}.jar")
+//        classpath files("../gradlePlugin/build/libs/gradlePlugin-${gradlePluginsVersion}.jar")
 //        classpath "org.apache.commons:commons-lang3:${commonsLang3Version}"
-//        classpath "org.apache.commons:commons-text:1.9"
+//        classpath "org.apache.commons:commons-text:${commonsTextVersion}"
 //        classpath "commons-io:commons-io:${commonsIoVersion}"
 //        classpath "org.apache.httpcomponents:httpclient:${httpclientVersion}"
-//        classpath "org.json:json:20210307"
-//        classpath "com.fasterxml.jackson.core:jackson-databind:2.12.2"
-//        classpath "org.ajoberstar.grgit:grgit-gradle:4.1.0"
+//        classpath "org.json:json:${orgJsonVersion}"
+//        classpath "com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}"
+//        classpath "org.ajoberstar.grgit:grgit-gradle:${grgitGradleVersion}"
 //    }
     dependencies {
         classpath "org.labkey.build:gradlePlugins:${gradlePluginsVersion}"

--- a/gradle/settings/distributions.gradle
+++ b/gradle/settings/distributions.gradle
@@ -11,10 +11,20 @@ buildscript {
 
         }
     }
+//    dependencies {
+//        classpath files("../../../gradlePlugin/build/libs/gradlePlugin-${gradlePluginsVersion}.jar")
+//        classpath "org.apache.commons:commons-lang3:${commonsLang3Version}"
+//        classpath "org.apache.commons:commons-text:1.9"
+//        classpath "commons-io:commons-io:${commonsIoVersion}"
+//        classpath "org.apache.httpcomponents:httpclient:${httpclientVersion}"
+//        classpath "org.json:json:20210307"
+//        classpath "com.fasterxml.jackson.core:jackson-databind:2.12.2"
+//        classpath "org.ajoberstar.grgit:grgit-gradle:4.1.0"
+//    }
     dependencies {
         classpath "org.labkey.build:gradlePlugins:${gradlePluginsVersion}"
     }
-    configurations.all {
+    configurations.configureEach {
         // Check for updates every build for SNAPSHOT dependencies
         resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
     }

--- a/gradle/settings/ehr.gradle
+++ b/gradle/settings/ehr.gradle
@@ -14,7 +14,7 @@ buildscript {
     dependencies {
         classpath "org.labkey.build:gradlePlugins:${gradlePluginsVersion}"
     }
-    configurations.all {
+    configurations.configureEach {
         // Check for updates every build for SNAPSHOT dependencies
         resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
     }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -196,12 +196,15 @@ project.tasks.register("cleanDocs", DefaultTask) {
         })
 }
 
-task('createModule', type: CreateModule, group: "Module",
-        description: "Creates a new module. Use moduleName property to specify the name of the module to be created. " +
-                "Use moduleDestination to specify the full path to destination" +
-                "Use createFiles to control which subdirectories are created.  Include some subset of api, test, and/or schema " +
-                    "in a comma delimited list to create those subdirectories in the new module. If none are required, still " +
-                    "include -PcreateFiles with no value to avoid being prompted." )
+tasks.register('createModule', CreateModule) {
+    task ->
+        task.group = GroupNames.MODULE
+        task.description = "Creates a new module. Use moduleName property to specify the name of the module to be created. " +
+            "Use moduleDestination to specify the full path to destination" +
+            "Use createFiles to control which subdirectories are created.  Include some subset of api, test, and/or schema " +
+            "in a comma delimited list to create those subdirectories in the new module. If none are required, still " +
+            "include -PcreateFiles with no value to avoid being prompted."
+}
 
 // We add this configuration here so we have a single location to link to for the npm and node executables.
 // Each project that requires node will have its own downloaded version of node and npm, but for the symlinkNode


### PR DESCRIPTION
#### Rationale
The update to Gralde 8 requires an update to the gradle plugins for our artifactory publishing from TeamCity. I take this opportunity to also update some of the task and configuration usages to the preferred pattern for more efficient configuration.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/168

#### Changes
* Gradle plugin version
* updates in root `build.gradle` and server `build.gradle` for task registration and project configuration syntax
