### PR TITLE
Modifications for minification project handling

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -58,7 +58,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.21.0
 gradleNodePluginVersion=3.0.1
-gradlePluginsVersion=1.41.0-minifyProjectFix-SNAPSHOT
+gradlePluginsVersion=1.40.3
 owaspDependencyCheckPluginVersion=5.2.1
 versioningPluginVersion=1.1.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -58,7 +58,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.21.0
 gradleNodePluginVersion=3.0.1
-gradlePluginsVersion=1.40.1
+gradlePluginsVersion=1.41.0-minifyProjectFix-SNAPSHOT
 owaspDependencyCheckPluginVersion=5.2.1
 versioningPluginVersion=1.1.0
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -81,6 +81,8 @@ if (hasProperty("useEmbeddedTomcat"))
     include ":server:embedded"
 }
 
+include BuildUtils.getMinificationProjectPath(gradle)
+
 if (new File(getRootDir(), BuildUtils.convertPathToRelativeDir(BuildUtils.getPlatformProjectPath(gradle))).exists()
         && !hasProperty('excludeBaseModules'))
 {


### PR DESCRIPTION
#### Rationale
The minification project should be included even if there is no platform enlistment, so we separate it from the BaseModules in the new gradle plugin version. 

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/169

#### Changes
* include the minification project separately from the base modules (from platform)
* update gradle plugins version
