### PR TITLE
Update to node 16.19.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -63,10 +63,10 @@ owaspDependencyCheckPluginVersion=5.2.1
 versioningPluginVersion=1.1.0
 
 # Versions of node and npm to use during the build. If set, these versions
-# will be downloaded and used. If not set, the existing local installations will be use
+# will be downloaded and used. If not set, the existing local installations will be used
 # The version of npm corresponds to the given version of node
 npmVersion=8.19.3
-nodeVersion=16.19.0
+nodeVersion=16.19.1
 nodeRepo=https://nodejs.org/dist
 # Directory in a project's build directory where the node binary will be placed
 nodeWorkDirectory=.node


### PR DESCRIPTION
#### Rationale
16.19.1 is the latest version for node 16 and may have better availability than 16.19.0.


#### Changes
* Update to node 16.19.1
