### PR TITLE
Add mavenLocal repository to buildscripts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,39 +5,13 @@ import org.labkey.gradle.task.ShowDiscrepancies
 import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.GroupNames
 
-buildscript {
-    repositories {
-        mavenCentral()
-        maven {
-            url "https://plugins.gradle.org/m2"
-        }
-        maven {
-            url "${artifactory_contextUrl}/plugins-release"
-        }
-        if (gradlePluginsVersion.contains("SNAPSHOT") || versioningPluginVersion.contains("SNAPSHOT"))
-        {
-            maven {
-                url "${artifactory_contextUrl}/plugins-snapshot-local"
-            }
-
-        }
-    }
-    dependencies {
-        classpath "org.labkey.build:versioning:${versioningPluginVersion}"
-    }
-    configurations.configureEach {
-        // Check for updates every build for SNAPSHOT dependencies
-        resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
-    }
-
-}
-
 plugins {
     id "com.jfrog.artifactory" version "${artifactoryPluginVersion}" apply false
     id "com.github.node-gradle.node" version "${gradleNodePluginVersion}" apply false
     id "org.owasp.dependencycheck" version "${owaspDependencyCheckPluginVersion}" apply false
 //    id "com.github.ben-manes.versions" version "0.39.0"
     id "org.labkey.build.multiGit"
+    id 'org.labkey.versioning' apply false // Need this for our 'base' plugin version specified in settings.gradle
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
     id "org.owasp.dependencycheck" version "${owaspDependencyCheckPluginVersion}" apply false
 //    id "com.github.ben-manes.versions" version "0.39.0"
     id "org.labkey.build.multiGit"
-    id 'org.labkey.versioning' apply false // Need this for our 'base' plugin version specified in settings.gradle
+    id 'org.labkey.versioning' apply false // Need this for our 'base' plugin to get the version specified in settings.gradle
 }
 
 allprojects {

--- a/gradle.properties
+++ b/gradle.properties
@@ -58,7 +58,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.21.0
 gradleNodePluginVersion=3.0.1
-gradlePluginsVersion=1.40.3
+gradlePluginsVersion=1.40.5
 owaspDependencyCheckPluginVersion=5.2.1
 versioningPluginVersion=1.1.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -131,8 +131,6 @@ commonsLoggingVersion=1.2
 commonsMath3Version=3.6.1
 commonsNetVersion=3.9.0
 commonsPoolVersion=1.6
-# used in gradle plugins; included here for use in testing changes locally
-commonsTextVersion=1.10.0
 commonsValidatorVersion=1.7
 
 datadogVersion=0.108.1
@@ -157,8 +155,6 @@ googleOauthClientVersion=1.34.1
 googleProtocolBufVersion=3.21.9
 
 graalVersion=20.0.0
-# used in gradle plugins; included here for use in testing changes locally
-grgitGradleVersion=5.0.0
 
 # Cloud and SequenceAnalysis bring gson in as a transitive dependency.
 # We resolve to the later version here to keep things consistent

--- a/gradle.properties
+++ b/gradle.properties
@@ -58,7 +58,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.21.0
 gradleNodePluginVersion=3.0.1
-gradlePluginsVersion=1.40.3
+gradlePluginsVersion=1.41.0-moreAvoidance-SNAPSHOT
 owaspDependencyCheckPluginVersion=5.2.1
 versioningPluginVersion=1.1.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -58,7 +58,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.21.0
 gradleNodePluginVersion=3.0.1
-gradlePluginsVersion=1.41.0-moreAvoidance-SNAPSHOT
+gradlePluginsVersion=1.40.3
 owaspDependencyCheckPluginVersion=5.2.1
 versioningPluginVersion=1.1.0
 

--- a/gradle/settings/all.gradle
+++ b/gradle/settings/all.gradle
@@ -5,25 +5,13 @@ buildscript {
         }
         if (gradlePluginsVersion.contains("SNAPSHOT"))
         {
+            mavenLocal()
             maven {
                 url "${artifactory_contextUrl}/plugins-snapshot-local"
             }
 
         }
     }
-    // For testing changes to the gradle plugins, uncomment the dependencies block below and reference the location
-    // of your gradlePlugin enlistment.  Then comment out the following dependencies
-    // block.  You will need to build the gradlePlugins jar file manually to pick up new changes.
-//    dependencies {
-//        classpath files("../gradlePlugin/build/libs/gradlePlugin-${gradlePluginsVersion}.jar")
-//        classpath "org.apache.commons:commons-lang3:${commonsLang3Version}"
-//        classpath "org.apache.commons:commons-text:${commonsTextVersion}"
-//        classpath "commons-io:commons-io:${commonsIoVersion}"
-//        classpath "org.apache.httpcomponents:httpclient:${httpclientVersion}"
-//        classpath "org.json:json:${orgJsonVersion}"
-//        classpath "com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}"
-//        classpath "org.ajoberstar.grgit:grgit-gradle:${grgitGradleVersion}"
-//    }
     dependencies {
         classpath "org.labkey.build:gradlePlugins:${gradlePluginsVersion}"
     }

--- a/gradle/settings/base.gradle
+++ b/gradle/settings/base.gradle
@@ -4,26 +4,3 @@
 // - The test modules (all modules in /server/test/modules plus devtools)
 //
 // To exclude the test modules, comment out this line in settings.gradle: BuildUtils.includeTestModules(this.settings, rootDir)
-
-buildscript {
-    repositories {
-        maven {
-            url "${artifactory_contextUrl}/plugins-release"
-        }
-        if (gradlePluginsVersion.contains("SNAPSHOT"))
-        {
-            mavenLocal()
-            maven {
-                url "${artifactory_contextUrl}/plugins-snapshot-local"
-            }
-
-        }
-    }
-    dependencies {
-        classpath "org.labkey.build:gradlePlugins:${gradlePluginsVersion}"
-    }
-    configurations.configureEach {
-        // Check for updates every build for SNAPSHOT dependencies
-        resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
-    }
-}

--- a/gradle/settings/base.gradle
+++ b/gradle/settings/base.gradle
@@ -12,6 +12,7 @@ buildscript {
         }
         if (gradlePluginsVersion.contains("SNAPSHOT"))
         {
+            mavenLocal()
             maven {
                 url "${artifactory_contextUrl}/plugins-snapshot-local"
             }

--- a/gradle/settings/community.gradle
+++ b/gradle/settings/community.gradle
@@ -6,6 +6,7 @@ buildscript {
         }
         if (gradlePluginsVersion.contains("SNAPSHOT"))
         {
+            mavenLocal()
             maven {
                 url "${artifactory_contextUrl}/plugins-snapshot-local"
             }

--- a/gradle/settings/community.gradle
+++ b/gradle/settings/community.gradle
@@ -1,38 +1,11 @@
 
-buildscript {
-    repositories {
-        maven {
-            url "${artifactory_contextUrl}/plugins-release"
-        }
-        if (gradlePluginsVersion.contains("SNAPSHOT"))
-        {
-            mavenLocal()
-            maven {
-                url "${artifactory_contextUrl}/plugins-snapshot-local"
-            }
-
-        }
-    }
-    dependencies {
-        classpath "org.labkey.build:gradlePlugins:${gradlePluginsVersion}"
-    }
-    configurations.configureEach {
-        // Check for updates every build for SNAPSHOT dependencies
-        resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
-    }
-}
-
-import org.labkey.gradle.util.BuildUtils
-
-BuildUtils.includeBaseModules(this.settings)
+// Base modules will be included automatically by `settings.gradle`
 include ":server:modules:platform:announcements"
 include ":server:modules:platform:assay"
 include ":server:modules:platform:issues"
 include ":server:modules:platform:list"
-include ":server:modules:commonAssays:ms2"
 include ":server:modules:platform:search"
 include ":server:modules:platform:study"
 include ":server:modules:platform:survey"
-include ":server:modules:targetedms"
 include ":server:modules:platform:visualization"
 include ":server:modules:platform:wiki"

--- a/gradle/settings/distributions.gradle
+++ b/gradle/settings/distributions.gradle
@@ -5,25 +5,13 @@ buildscript {
         }
         if (gradlePluginsVersion.contains("SNAPSHOT"))
         {
+            mavenLocal()
             maven {
                 url "${artifactory_contextUrl}/plugins-snapshot-local"
             }
 
         }
     }
-    // For testing changes to the gradle plugins, uncomment the dependencies block below and reference the location
-    // of your gradlePlugin enlistment.  Then comment out the following dependencies
-    // block.  You will need to build the gradlePlugins jar file manually to pick up new changes.
-//    dependencies {
-//        classpath files("../gradlePlugin/build/libs/gradlePlugin-${gradlePluginsVersion}.jar")
-//        classpath "org.apache.commons:commons-lang3:${commonsLang3Version}"
-//        classpath "org.apache.commons:commons-text:${commonsTextVersion}"
-//        classpath "commons-io:commons-io:${commonsIoVersion}"
-//        classpath "org.apache.httpcomponents:httpclient:${httpclientVersion}"
-//        classpath "org.json:json:${orgJsonVersion}"
-//        classpath "com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}"
-//        classpath "org.ajoberstar.grgit:grgit-gradle:${grgitGradleVersion}"
-//    }
     dependencies {
         classpath "org.labkey.build:gradlePlugins:${gradlePluginsVersion}"
     }

--- a/gradle/settings/ehr.gradle
+++ b/gradle/settings/ehr.gradle
@@ -5,6 +5,7 @@ buildscript {
         }
         if (gradlePluginsVersion.contains("SNAPSHOT"))
         {
+            mavenLocal()
             maven {
                 url "${artifactory_contextUrl}/plugins-snapshot-local"
             }

--- a/gradle/settings/parameters.gradle
+++ b/gradle/settings/parameters.gradle
@@ -10,4 +10,5 @@ gradle.ext.remoteApiProjectPath=":remoteapi:labkey-api-java"
 gradle.ext.jdbcApiProjectPath=":remoteapi:labkey-api-jdbc"
 gradle.ext.schemasProjectPath=":server:modules:platform:api"
 gradle.ext.testProjectPath=":server:testAutomation"
+gradle.ext.minificationProjectPath=":server:minification"
 gradle.ext.nodeBinProjectPath=":" // The npm and node executables downloaded into this project's build directory will be the target of the links created by the synlinkNode task

--- a/gradle/settings/starterArtifacts.gradle
+++ b/gradle/settings/starterArtifacts.gradle
@@ -1,2 +1,1 @@
 include ":server:testAutomation:buildTestModules:starterArtifacts"
-include ":server:minification"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,35 +1,30 @@
 
 pluginManagement {
-    // This doesn't seem necessary. Remove?
-//    repositories {
-//        maven {
-//            url "${artifactory_contextUrl}/plugins-release"
-//        }
-//        if (gradlePluginsVersion.contains("SNAPSHOT") || versioningPluginVersion.contains("SNAPSHOT")) {
-//            mavenLocal()
-//            maven {
-//                url "${artifactory_contextUrl}/plugins-snapshot-local"
-//            }
-//        }
-//    }
-    plugins {
-        id 'org.labkey.build.antlr' version "${gradlePluginsVersion}" apply false
-        id 'org.labkey.build.api' version "${gradlePluginsVersion}" apply false
-        id 'org.labkey.build.applyLicenses' version "${gradlePluginsVersion}" apply false
-        id 'org.labkey.build.base' version "${gradlePluginsVersion}" apply false
-        id 'org.labkey.build.distribution' version "${gradlePluginsVersion}" apply false
-        id 'org.labkey.build.fileModule' version "${gradlePluginsVersion}" apply false
-        id 'org.labkey.build.javaModule' version "${gradlePluginsVersion}" apply false
-        id 'org.labkey.build.jsdoc' version "${gradlePluginsVersion}" apply false
-        id 'org.labkey.build.module' version "${gradlePluginsVersion}" apply false
-        id 'org.labkey.build.multiGit' version "${gradlePluginsVersion}" apply false
-        id 'org.labkey.build.npmRun' version "${gradlePluginsVersion}" apply false
-        id 'org.labkey.build.serverDeploy' version "${gradlePluginsVersion}" apply false
-        id 'org.labkey.build.teamCity' version "${gradlePluginsVersion}" apply false
-        id 'org.labkey.build.testRunner' version "${gradlePluginsVersion}" apply false
-        id 'org.labkey.build.tomcat' version "${gradlePluginsVersion}" apply false
-        id 'org.labkey.build.xsddoc' version "${gradlePluginsVersion}" apply false
-        id 'org.labkey.versioning' version "${versioningPluginVersion}" apply false
+    repositories {
+        maven {
+            url "${artifactory_contextUrl}/plugins-release"
+        }
+        if (gradlePluginsVersion.contains("SNAPSHOT") || versioningPluginVersion.contains("SNAPSHOT"))
+        {
+            mavenLocal()
+            maven {
+                url "${artifactory_contextUrl}/plugins-snapshot-local"
+            }
+        }
+    }
+    resolutionStrategy {
+        eachPlugin {
+            if (requested.id.id == 'org.labkey.versioning')
+            {
+                // Versioning isn't published with plugin markers
+                useModule("org.labkey.build:versioning:${versioningPluginVersion}")
+            }
+            else if (requested.id.namespace == 'org.labkey.build')
+            {
+                // This doesn't really do anything. The jar on the classpath will take precedence
+                useVersion("${gradlePluginsVersion}")
+            }
+        }
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,15 +1,17 @@
 
 pluginManagement {
-    repositories {
-        maven {
-            url "${artifactory_contextUrl}/plugins-release"
-        }
-        if (gradlePluginsVersion.contains("SNAPSHOT") || versioningPluginVersion.contains("SNAPSHOT")) {
-            maven {
-                url "${artifactory_contextUrl}/plugins-snapshot-local"
-            }
-        }
-    }
+    // This doesn't seem necessary. Remove?
+//    repositories {
+//        maven {
+//            url "${artifactory_contextUrl}/plugins-release"
+//        }
+//        if (gradlePluginsVersion.contains("SNAPSHOT") || versioningPluginVersion.contains("SNAPSHOT")) {
+//            mavenLocal()
+//            maven {
+//                url "${artifactory_contextUrl}/plugins-snapshot-local"
+//            }
+//        }
+//    }
     plugins {
         id 'org.labkey.build.antlr' version "${gradlePluginsVersion}" apply false
         id 'org.labkey.build.api' version "${gradlePluginsVersion}" apply false
@@ -37,24 +39,15 @@ buildscript {
             url "${artifactory_contextUrl}/plugins-release"
         }
         if (gradlePluginsVersion.contains("SNAPSHOT")) {
+            // For testing changes to the gradle plugins. Publish 'gradlePlugins' locally using 'publishToMavenLocal'.
+            // Update 'gradlePluginsVersion' to match the plugin SNAPSHOT version.
+            // You will need to rerun the publish task to pick up new changes.
+            mavenLocal()
             maven {
                 url "${artifactory_contextUrl}/plugins-snapshot-local"
             }
         }
     }
-    // For testing changes to the gradle plugins, uncomment the dependencies block below and reference the location
-    // of your gradlePlugin enlistment.  Then comment out the following dependencies
-    // block.  You will need to build the gradlePlugins jar file manually to pick up new changes.
-//    dependencies {
-//        classpath files("../gradlePlugin/build/libs/gradlePlugin-${gradlePluginsVersion}.jar")
-//        classpath "org.apache.commons:commons-lang3:${commonsLang3Version}"
-//        classpath "org.apache.commons:commons-text:1.9"
-//        classpath "commons-io:commons-io:${commonsIoVersion}"
-//        classpath "org.apache.httpcomponents:httpclient:${httpclientVersion}"
-//        classpath "org.json:json:20210307"
-//        classpath "com.fasterxml.jackson.core:jackson-databind:2.12.2"
-//        classpath "org.ajoberstar.grgit:grgit-gradle:4.1.0"
-//    }
     dependencies {
         classpath "org.labkey.build:gradlePlugins:${gradlePluginsVersion}"
     }


### PR DESCRIPTION
#### Rationale
Including `mavenLocal` allows one to more easily test gradle plugin changes.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/171

#### Changes
* Add mavenLocal() repository to buildscripts
* Update gradle plugin to improve task configuration performance
