### PR TITLE
Update version and configuration of owasp dependency check plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,10 @@ allprojects {
         apply plugin: 'org.owasp.dependencycheck'
         dependencyCheck {
             outputDirectory = "${project.rootProject.buildDir}/reports/dependencyCheck/${project.path.replaceAll(':', '_').substring(1)}"
+            analyzers {
+                assemblyEnabled = false
+                nodeEnabled = false
+            }
         }
     }
     if (BuildUtils.shouldPublish(project) || BuildUtils.shouldPublishDistribution(project))

--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,8 @@ allprojects {
         dependencyCheck {
             outputDirectory = "${project.rootProject.buildDir}/reports/dependencyCheck/${project.path.replaceAll(':', '_').substring(1)}"
             analyzers {
-                assemblyEnabled = false
-                nodeEnabled = false
+                assemblyEnabled = false // Sets whether the .NET Assembly Analyzer should be used.
+                nodeEnabled = false // Sets whether the Node.js Analyzer should be used.
             }
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -59,7 +59,7 @@ windowsProteomicsBinariesVersion=1.0
 artifactoryPluginVersion=4.21.0
 gradleNodePluginVersion=3.0.1
 gradlePluginsVersion=1.40.5
-owaspDependencyCheckPluginVersion=5.2.1
+owaspDependencyCheckPluginVersion=8.2.1
 versioningPluginVersion=1.1.0
 
 # Versions of node and npm to use during the build. If set, these versions


### PR DESCRIPTION
#### Rationale
We're a little behind on our [org.owasp.dependencycheck](https://jeremylong.github.io/DependencyCheck/index.html) plugin version. It takes quite a while for the plugin to generate a report for our modules, but the report is quite extensive and there are many ways to configure this plugin and its [tasks ](http://jeremylong.github.io/DependencyCheck/dependency-check-gradle/configuration-aggregate.html) that we might consider to get best use of this plugin.

I've disabled a couple of the analyzers for current purposes. The node analyzer might be useful, but it fails locally with the following:

```
An unexpected error occurred during analysis of '/Users/susanhert/Development/labkey/root/server/modules/puppeteer/package-lock.json' (Node.js Package Analyzer): null

java.util.ConcurrentModificationException
        at java.base/java.util.TreeMap$PrivateEntryIterator.nextEntry(TreeMap.java:1486)
        at java.base/java.util.TreeMap$KeyIterator.next(TreeMap.java:1540)
        at java.base/java.lang.Iterable.forEach(Iterable.java:74)
        at java.base/java.util.Collections$UnmodifiableCollection.forEach(Collections.java:1092)
        at org.owasp.dependencycheck.analyzer.DependencyMergingAnalyzer.mergeDependencies(DependencyMergingAnalyzer.java:160)
        at org.owasp.dependencycheck.analyzer.NodePackageAnalyzer.processDependencies(NodePackageAnalyzer.java:465)
        at org.owasp.dependencycheck.analyzer.NodePackageAnalyzer.processDependencies(NodePackageAnalyzer.java:410)
        at org.owasp.dependencycheck.analyzer.NodePackageAnalyzer.analyzeDependency(NodePackageAnalyzer.java:270)
        at org.owasp.dependencycheck.analyzer.AbstractAnalyzer.analyze(AbstractAnalyzer.java:131)
        at org.owasp.dependencycheck.AnalysisTask.call(AnalysisTask.java:88)
        at org.owasp.dependencycheck.AnalysisTask.call(AnalysisTask.java:37)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:833)
```

#### Changes
* Update plugin version
* Disable assembly analyzer (since we don't have .NET)
* Disable node analyzer (for now, anyway)
