### PR TITLE
Make `ijConfigure` task compatible with Gradle 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -424,6 +424,7 @@ project.tasks.register("ijRunConfigurationsSetup", Copy) {
         copy.filter({ String line ->
             return line.replace("PATH_SEPARATOR", File.pathSeparator)
         })
+        copy.mustRunAfter(project.tasks.ijCodeSetup)
 }
 
 project.tasks.register("ijCodeSetup", Copy) {
@@ -439,9 +440,9 @@ project.tasks.register('ijConfigure') {
     DefaultTask task ->
         task.group = "IntelliJ"
         task.description = "Install IntelliJ template files as files for IntelliJ to use in .idea directory"
+        task.dependsOn(project.tasks.ijCodeSetup)
+        task.dependsOn(project.tasks.ijRunConfigurationsSetup)
 }
-
-project.tasks.ijConfigure.dependsOn(project.tasks.ijCodeSetup, project.tasks.ijRunConfigurationsSetup)
 
 project.tasks.register('purgeNpmAlphaVersions', PurgeNpmAlphaVersions) {
     group = GroupNames.NPM_RUN


### PR DESCRIPTION
#### Rationale
Trying to set up a new enlistment, I encountered this error:
```
A problem was found with the configuration of task ':ijRunConfigurationsSetup' (type 'Copy').
  - Gradle detected a problem with the following location: '/Users/treyc/development/labkey/23.4/.idea/runConfigurations/templates'.

    Reason: Task ':ijRunConfigurationsSetup' uses this output of task ':ijCodeSetup' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.

    Possible solutions:
      1. Declare task ':ijCodeSetup' as an input of ':ijRunConfigurationsSetup'.
      2. Declare an explicit dependency on ':ijCodeSetup' from ':ijRunConfigurationsSetup' using Task#dependsOn.
      3. Declare an explicit dependency on ':ijCodeSetup' from ':ijRunConfigurationsSetup' using Task#mustRunAfter.
```
Solution 3 does the trick

#### Related Pull Requests
* #66 

#### Changes
* Add explicit dependency between `ijCodeSetup` and `ijRunConfigurationsSetup` tasks
