### PR TITLE
Update more third-party dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -241,7 +241,11 @@ allprojects {
                     force "io.netty:netty-codec-http:${nettyVersion}"
                     force "io.netty:netty-transport-native-epoll:${nettyVersion}"
                     force "io.netty:netty-transport-native-kqueue:${nettyVersion}"
+
+                    // Force consistency for dependencies from pipeline and query
                     force "org.dom4j:dom4j:${dom4jVersion}"
+                    // Force consistency across pipeline, SequenceAnalysis, and query
+                    force "javax.xml.bind:jaxb-api:${jaxbApiVersion}"
 
                     dependencySubstitution {
                         // Because the client api artifact name is not the same as the directory structure, we use

--- a/build.gradle
+++ b/build.gradle
@@ -252,6 +252,9 @@ allprojects {
                     // Force consistency across pipeline, SequenceAnalysis, and query
                     force "javax.xml.bind:jaxb-api:${jaxbApiVersion}"
 
+                    // Force consistency between pipeline's ActiveMQ  and cloud's jClouds dependencies
+                    force "javax.annotation:javax.annotation-api:${javaxAnnotationVersion}"
+
                     dependencySubstitution {
                         // Because the client api artifact name is not the same as the directory structure, we use
                         // Gradle's dependency substitution so the dependency will appear correctly in the pom files that

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,9 @@ allprojects {
             analyzers {
                 assemblyEnabled = false // Sets whether the .NET Assembly Analyzer should be used.
                 nodeEnabled = false // Sets whether the Node.js Analyzer should be used.
+                nodeAudit {
+                    enabled = false
+                }
             }
             skipConfigurations = ['dedupe', 'gwtCompileClasspath', 'gwtRuntimeClasspath']
             skipProjects = [':server:testAutomation']

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ allprojects {
         apply plugin: 'org.owasp.dependencycheck'
         dependencyCheck {
             outputDirectory = "${project.rootProject.buildDir}/reports/dependencyCheck/${project.path.replaceAll(':', '_').substring(1)}"
+            suppressionFile = "${project.rootProject.rootDir}/dependencyCheckSupression.xml"
             analyzers {
                 assemblyEnabled = false // Sets whether the .NET Assembly Analyzer should be used.
                 nodeEnabled = false // Sets whether the Node.js Analyzer should be used.

--- a/build.gradle
+++ b/build.gradle
@@ -21,11 +21,13 @@ allprojects {
         apply plugin: 'org.owasp.dependencycheck'
         dependencyCheck {
             outputDirectory = "${project.rootProject.buildDir}/reports/dependencyCheck/${project.path.replaceAll(':', '_').substring(1)}"
-            suppressionFile = "${project.rootProject.rootDir}/dependencyCheckSupression.xml"
+            suppressionFile = "${project.rootProject.rootDir}/dependencyCheckSuppression.xml"
             analyzers {
                 assemblyEnabled = false // Sets whether the .NET Assembly Analyzer should be used.
                 nodeEnabled = false // Sets whether the Node.js Analyzer should be used.
             }
+            skipConfigurations = ['dedupe', 'gwtCompileClasspath', 'gwtRuntimeClasspath']
+            skipProjects = [':server:testAutomation']
         }
     }
     if (BuildUtils.shouldPublish(project) || BuildUtils.shouldPublishDistribution(project))
@@ -237,6 +239,9 @@ allprojects {
                     force "io.netty:netty-codec:${nettyVersion}"
                     force "io.netty:netty-common:${nettyVersion}"
                     force "io.netty:netty-codec-http:${nettyVersion}"
+                    force "io.netty:netty-transport-native-epoll:${nettyVersion}"
+                    force "io.netty:netty-transport-native-kqueue:${nettyVersion}"
+                    force "org.dom4j:dom4j:${dom4jVersion}"
 
                     dependencySubstitution {
                         // Because the client api artifact name is not the same as the directory structure, we use

--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -145,12 +145,6 @@
         <cve>CVE-2006-5391</cve>
     </suppress>
 
-    <!-- Suppress all NPM, since we're focused on server-side Java library reporting here -->
-    <suppress>
-        <packageUrl regex="true">^pkg:npm/.*</packageUrl>
-        <vulnerabilityName regex="true">.*</vulnerabilityName>
-    </suppress>
-
     <!-- Checker is confusing this library and the WNPRC GoogleDrive module with the OSX Desktop Google Drive application -->
     <suppress>
         <notes><![CDATA[

--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -47,4 +47,39 @@
         <packageUrl regex="true">^pkg:maven/com\.google\.guava/guava@.*$</packageUrl>
         <vulnerabilityName>CVE-2020-8908</vulnerabilityName>
     </suppress>
+
+    <!--
+    Actually packages MINA 2.2.1 but dependency check confuses the version number.
+    https://search.maven.org/artifact/org.apache.directory.api/api-parent/2.1.3/jar?eh=
+     -->
+    <suppress>
+        <notes><![CDATA[
+   file name: api-all-2.1.3.jar (shaded: org.apache.directory.api:api-ldap-net-mina:2.1.3)
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.directory\.api/api\-ldap\-net\-mina@.*$</packageUrl>
+        <cve>CVE-2021-41973</cve>
+    </suppress>
+
+    <!-- Tangled CVEs. See https://github.com/jeremylong/DependencyCheck/issues/4614 and https://github.com/OSSIndex/vulns/issues/316 -->
+    <suppress>
+        <notes><![CDATA[
+   file name: xercesImpl-2.12.2.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/xerces/xercesImpl@.*$</packageUrl>
+        <vulnerabilityName>CVE-2017-10355</vulnerabilityName>
+    </suppress>
+
+
+    <!--
+     We don't use any classes from org.springframework.remoting.httpinvoker like HttpInvokerServiceExporter
+     https://github.com/spring-projects/spring-framework/issues/24434
+     The unsafe classes are slated for complete removal in Spring 6.x
+     -->
+    <suppress>
+        <notes><![CDATA[
+   file name: spring-web-5.3.26.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-web@.*$</packageUrl>
+        <vulnerabilityName>CVE-2016-1000027</vulnerabilityName>
+    </suppress>
 </suppressions>

--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -151,12 +151,19 @@
         <vulnerabilityName regex="true">.*</vulnerabilityName>
     </suppress>
 
-    <!-- Checker is confusing this library with the OSX Desktop Google Drive application -->
+    <!-- Checker is confusing this library and the WNPRC GoogleDrive module with the OSX Desktop Google Drive application -->
     <suppress>
         <notes><![CDATA[
    file name: google-api-services-drive-v3-rev197-1.25.0.jar
    ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.google\.apis/google\-api\-services\-drive@.*$</packageUrl>
+        <cve>CVE-2022-3421</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: GoogleDrive_api-23.5-SNAPSHOT.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.labkey/GoogleDrive@.*$</packageUrl>
         <cve>CVE-2022-3421</cve>
     </suppress>
 
@@ -173,4 +180,18 @@
         <packageUrl regex="true">^pkg:maven/org\.apache\.sanselan/sanselan@.*$</packageUrl>
         <vulnerabilityName>CVE-2018-17201</vulnerabilityName>
     </suppress>
+
+    <!--
+    This is a transitive dependency from spring-boot-starter that we're forcing to get CVE hotfixes. We're not
+    vulnerable since we're not accepting untrusted Spring Boot config files. See more details at
+    https://bitbucket.org/snakeyaml/snakeyaml/wiki/CVE-2022-1471
+    -->
+    <suppress>
+        <notes><![CDATA[
+   file name: snakeyaml-1.33.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
+        <cve>CVE-2022-1471</cve>
+    </suppress>
+
 </suppressions>

--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -82,4 +82,17 @@
         <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-web@.*$</packageUrl>
         <vulnerabilityName>CVE-2016-1000027</vulnerabilityName>
     </suppress>
+
+
+    <!--
+    For our purposes, Random is good enough, and not worth publishing our own version of the artifact that uses
+    SecureRandom. https://github.com/penggle/kaptcha/issues/3
+    -->
+    <suppress>
+        <notes><![CDATA[
+   file name: kaptcha-2.3.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.google\.code\.kaptcha/kaptcha@.*$</packageUrl>
+        <cve>CVE-2018-18531</cve>
+    </suppress>
 </suppressions>

--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -27,7 +27,10 @@
         <cve>CVE-2022-45688</cve>
     </suppress>
 
-    <!-- GWT uses Protobuf internally, meaning the handful of CVEs in 2.5.0 are not a concern. https://github.com/gwtproject/gwt/issues/9778 -->
+    <!--
+    GWT uses Protobuf internally but doesn't expose it, meaning the handful of CVEs in 2.5.0 are not a concern.
+    https://github.com/gwtproject/gwt/issues/9778
+    -->
     <suppress>
         <notes><![CDATA[
    file name: gwt-servlet-2.10.0.jar (shaded: com.google.protobuf:protobuf-java:2.5.0)
@@ -94,5 +97,57 @@
    ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.google\.code\.kaptcha/kaptcha@.*$</packageUrl>
         <cve>CVE-2018-18531</cve>
+    </suppress>
+
+    <!-- False positive - we're not bundling Struts as part of Mule -->
+    <suppress>
+        <notes><![CDATA[
+   file name: mule-module-builders-1.4.4e.jar (shaded: org.mule.modules:mule-module-ognl:1.4.4)
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.mule\.modules/mule\-module\-ognl@.*$</packageUrl>
+        <cve>CVE-2016-3093</cve>
+    </suppress>
+
+
+    <!-- False positive - we're not bundling Windows PGP -->
+    <suppress>
+        <notes><![CDATA[
+   file name: mule-module-builders-1.4.4e.jar (shaded: org.mule.modules:mule-module-pgp:1.4.4)
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.mule\.modules/mule\-module\-pgp@.*$</packageUrl>
+        <cve>CVE-2001-0265</cve>
+    </suppress>
+
+    <!-- No WebSockets for Mule, so no risk -->
+    <suppress>
+        <notes><![CDATA[
+   file name: mule-module-builders-1.4.4e.jar (shaded: org.mule.modules:mule-module-wssecurity:1.4.4)
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.mule\.modules/mule\-module\-wssecurity@.*$</packageUrl>
+        <cve>CVE-2021-4236</cve>
+    </suppress>
+
+    <!-- No FTP for Mule, so no risk -->
+    <suppress>
+        <notes><![CDATA[
+   file name: mule-module-builders-1.4.4e.jar (shaded: org.mule.transports:mule-transport-ftp:1.4.4)
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.mule\.transports/mule\-transport\-ftp@.*$</packageUrl>
+        <cve>CVE-2023-22551</cve>
+    </suppress>
+
+    <!-- False positive - different XFire, and we're certainly not opening UDP port 25777 -->
+    <suppress>
+        <notes><![CDATA[
+   file name: mule-module-builders-1.4.4e.jar (shaded: org.mule.transports:mule-transport-xfire:1.4.4)
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.mule\.transports/mule\-transport\-xfire@.*$</packageUrl>
+        <cve>CVE-2006-5391</cve>
+    </suppress>
+
+    <!-- Suppress all NPM, since we're focused on server-side Java library reporting here -->
+    <suppress>
+        <packageUrl regex="true">^pkg:npm/.*</packageUrl>
+        <vulnerabilityName regex="true">.*</vulnerabilityName>
     </suppress>
 </suppressions>

--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -150,4 +150,27 @@
         <packageUrl regex="true">^pkg:npm/.*</packageUrl>
         <vulnerabilityName regex="true">.*</vulnerabilityName>
     </suppress>
+
+    <!-- Checker is confusing this library with the OSX Desktop Google Drive application -->
+    <suppress>
+        <notes><![CDATA[
+   file name: google-api-services-drive-v3-rev197-1.25.0.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.google\.apis/google\-api\-services\-drive@.*$</packageUrl>
+        <cve>CVE-2022-3421</cve>
+    </suppress>
+
+
+    <!--
+    This is a dependency of Java-FPDF, used by the WNPRC billing module for PDF generation, which hasn't been updated
+    to reference the now-renamed Commons Imaging library instead of the old Sanselan incubator. The CVE is related
+    to file parsing, not generation so we're not vulnerable
+    -->
+    <suppress>
+        <notes><![CDATA[
+   file name: sanselan-0.97-incubator.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.sanselan/sanselan@.*$</packageUrl>
+        <vulnerabilityName>CVE-2018-17201</vulnerabilityName>
+    </suppress>
 </suppressions>

--- a/dependencyCheckSupression.xml
+++ b/dependencyCheckSupression.xml
@@ -38,7 +38,8 @@
         <vulnerabilityName>CVE-2021-22569</vulnerabilityName>
     </suppress>
 
-    <!-- Guava has deprecated the problematic com.google.common.io.Files.createTempDir(), the topic of this CVE, and we don't call it -->
+    <!-- Guava has deprecated the problematic com.google.common.io.Files.createTempDir(), the topic of this CVE,
+     and we don't call it. https://github.com/google/guava/issues/4011 -->
     <suppress>
         <notes><![CDATA[
    file name: guava-31.1-jre.jar

--- a/dependencyCheckSupression.xml
+++ b/dependencyCheckSupression.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <!-- Prevent match against unrelated "rengine" at https://github.com/yogeshojha/rengine -->
+    <suppress>
+        <notes><![CDATA[
+      file name: rengine-0.6-8.1.jar
+      ]]></notes>
+        <packageUrl regex="true">^pkg:maven/net\.rforge/rengine@.*$</packageUrl>
+        <cve>CVE-2022-1813</cve>
+        <cve>CVE-2021-39491</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: rserve-0.6-8.1.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/net\.rforge/rserve@.*$</packageUrl>
+        <cve>CVE-2022-1813</cve>
+        <cve>CVE-2021-39491</cve>
+    </suppress>
+
+    <!-- Prevent match against unrelated JSON library -->
+    <suppress>
+        <notes><![CDATA[
+   file name: json-20230227.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.json/json@.*$</packageUrl>
+        <cve>CVE-2022-45688</cve>
+    </suppress>
+
+    <!-- GWT uses Protobuf internally, meaning the handful of CVEs in 2.5.0 are not a concern. https://github.com/gwtproject/gwt/issues/9778 -->
+    <suppress>
+        <notes><![CDATA[
+   file name: gwt-servlet-2.10.0.jar (shaded: com.google.protobuf:protobuf-java:2.5.0)
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.google\.protobuf/protobuf\-java@.*$</packageUrl>
+        <cpe>cpe:/a:google:protobuf-java</cpe>
+        <vulnerabilityName>CVE-2022-3509</vulnerabilityName>
+        <vulnerabilityName>CVE-2021-22569</vulnerabilityName>
+    </suppress>
+
+    <!-- Guava has deprecated the problematic com.google.common.io.Files.createTempDir(), the topic of this CVE, and we don't call it -->
+    <suppress>
+        <notes><![CDATA[
+   file name: guava-31.1-jre.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.google\.guava/guava@.*$</packageUrl>
+        <vulnerabilityName>CVE-2020-8908</vulnerabilityName>
+    </suppress>
+</suppressions>

--- a/gradle.properties
+++ b/gradle.properties
@@ -251,7 +251,7 @@ postgresqlDriverVersion=42.5.3
 
 quartzVersion=2.3.2
 
-rforgeVersion=0.6-8
+rforgeVersion=0.6-8.1
 
 # sync with Tika version
 romeVersion=1.18.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -93,7 +93,7 @@ annotationsVersion=15.0
 #Unifying version used by DISCVR and Premium
 apacheDirectoryVersion=1.0.3
 #Transitive dependency of Apache directory: 2.0.18 contains some regressions
-apacheMinaVersion=2.0.19
+apacheMinaVersion=2.0.23
 
 # Keep in sync with springBootTomcatVersion below
 apacheTomcatVersion=9.0.73

--- a/gradle.properties
+++ b/gradle.properties
@@ -91,9 +91,9 @@ activationVersion=1.2.2
 annotationsVersion=15.0
 
 #Unifying version used by DISCVR and Premium
-apacheDirectoryVersion=1.0.3
+apacheDirectoryVersion=2.1.3
 #Transitive dependency of Apache directory: 2.0.18 contains some regressions
-apacheMinaVersion=2.0.23
+apacheMinaVersion=2.2.1
 
 # Keep in sync with springBootTomcatVersion below
 apacheTomcatVersion=9.0.73
@@ -228,7 +228,7 @@ mysqlDriverVersion=8.0.32
 mssqlJdbcVersion=12.2.0.jre11
 
 # forced compatibility between docker and UserReg-WS
-nettyVersion=4.1.48.Final
+nettyVersion=4.1.91.Final
 
 objenesisVersion=1.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -193,6 +193,7 @@ javassistVersion=3.20.0-GA
 javaMailVersion=1.6.7
 
 # No longer part of Java 10. Dependency for many modules.
+jaxbApiVersion=2.3.1
 jaxbVersion=2.3.3
 
 jaxrpcVersion=1.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -191,6 +191,7 @@ jamaVersion=1.0.3
 javassistVersion=3.20.0-GA
 
 javaMailVersion=1.6.7
+javaxAnnotationVersion=1.3.2
 
 # No longer part of Java 10. Dependency for many modules.
 jaxbApiVersion=2.3.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ org.gradle.jvmargs=-Xmx2048m
 versionConflictAction=delete
 
 # uncomment the following line for running the application with embedded tomcat
-useEmbeddedTomcat
+#useEmbeddedTomcat
 
 # uncomment the following line when using a local build of a server with embedded tomcat
 #useLocalBuild

--- a/gradle.properties
+++ b/gradle.properties
@@ -218,7 +218,7 @@ junitVersion=4.13.2
 
 jxlVersion=2.6.3
 
-kaptchaVersion=3.0.0
+kaptchaVersion=2.3
 
 log4j2Version=2.19.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ org.gradle.jvmargs=-Xmx2048m
 versionConflictAction=delete
 
 # uncomment the following line for running the application with embedded tomcat
-#useEmbeddedTomcat
+useEmbeddedTomcat
 
 # uncomment the following line when using a local build of a server with embedded tomcat
 #useLocalBuild

--- a/gradle.properties
+++ b/gradle.properties
@@ -287,7 +287,7 @@ tukaaniXZVersion=1.9
 validationApiVersion=1.1.0.Final
 
 # NLP and SAML bring woodstox-core in as a transitive dependency but with very different versions. We force the later version.
-woodstoxCoreVersion=6.2.1
+woodstoxCoreVersion=6.5.0
 
 # saml and query bring in different versions transitively; we force the later one
 xalanVersion=2.7.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -96,7 +96,7 @@ apacheDirectoryVersion=1.0.3
 apacheMinaVersion=2.0.19
 
 # Keep in sync with springBootTomcatVersion below
-apacheTomcatVersion=9.0.71
+apacheTomcatVersion=9.0.73
 
 # (mothership) -> json-path -> json-smart -> accessor-smart
 # (core) -> graalvm
@@ -135,7 +135,7 @@ commonsValidatorVersion=1.7
 
 datadogVersion=0.108.1
 
-dom4jVersion=1.6.1
+dom4jVersion=2.1.4
 
 ehcacheCoreVersion=2.6.8
 
@@ -163,8 +163,8 @@ graalVersion=22.3.1
 gsonVersion=2.8.9
 
 guavaVersion=31.1-jre
-gwtVersion=2.8.2
-gwtServletVersion=2.8.2
+gwtVersion=2.10.0
+gwtServletVersion=2.10.0
 # For dev builds, the targeted, single permutation browser. Can be either gwt-user-firefox, gwt-user-chrome, or gwt-user-ie
 gwtBrowser=gwt-user-chrome
 
@@ -217,7 +217,7 @@ junitVersion=4.13.2
 
 jxlVersion=2.6.3
 
-kaptchaVersion=2.3
+kaptchaVersion=3.0.0
 
 log4j2Version=2.19.0
 
@@ -264,12 +264,12 @@ slf4jLog4j12Version=2.0.3
 # this version is forced for compatibility with api, LDK, and workflow
 slf4jLog4jApiVersion=2.0.3
 
-springBootVersion=2.7.9
+springBootVersion=2.7.10
 # This MUST match the Tomcat version dictated by springBootVersion
 # Also, keep this in sync with apacheTomcatVersion above
-springBootTomcatVersion=9.0.71
+springBootTomcatVersion=9.0.73
 
-springVersion=5.3.25
+springVersion=5.3.26
 
 sqliteJdbcVersion=3.7.2
 

--- a/server/embedded/build.gradle
+++ b/server/embedded/build.gradle
@@ -32,6 +32,11 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-actuator:${springBootVersion}"
     implementation "org.springframework.boot:spring-boot-starter-validation:${springBootVersion}"
 
+    // This is a transitive dependency from spring-boot-starter that we're forcing to pick up CVE hotfixes. We're not
+    // vulnerable since we're not accepting untrusted Spring Boot config files, but this cleans up the reporting.
+    // At some point Spring Boot should update its preferred version and we can yank this
+    implementation "org.yaml:snakeyaml:1.33"
+
     runtimeOnly "org.apache.tomcat.embed:tomcat-embed-jasper:${springBootTomcatVersion}"
     runtimeOnly "javax.mail:javax.mail-api:1.6.2"
     runtimeOnly group: "com.sun.mail", name: "javax.mail", version: "1.6.0"

--- a/server/embedded/build.gradle
+++ b/server/embedded/build.gradle
@@ -35,7 +35,11 @@ dependencies {
     // This is a transitive dependency from spring-boot-starter that we're forcing to pick up CVE hotfixes. We're not
     // vulnerable since we're not accepting untrusted Spring Boot config files, but this cleans up the reporting.
     // At some point Spring Boot should update its preferred version and we can yank this
-    implementation "org.yaml:snakeyaml:1.33"
+    implementation('org.yaml:snakeyaml') {
+        version {
+            strictly '1.33'
+        }
+    }
 
     runtimeOnly "org.apache.tomcat.embed:tomcat-embed-jasper:${springBootTomcatVersion}"
     runtimeOnly "javax.mail:javax.mail-api:1.6.2"


### PR DESCRIPTION
#### Rationale
There are updated versions for a number of our Java library dependencies

#### Changes
* Update many dependencies
* Suppress false positives from OWASP Dependency Check