### PR TITLE
Update embedded Tomcat to Spring 5.3.27

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ allprojects {
                     enabled = false
                 }
             }
-            skipConfigurations = ['dedupe', 'gwtCompileClasspath', 'gwtRuntimeClasspath']
+            skipConfigurations = ['dedupe', 'gwtCompileClasspath', 'gwtRuntimeClasspath', 'developmentOnly']
             skipProjects = [':server:testAutomation']
         }
     }

--- a/server/embedded/build.gradle
+++ b/server/embedded/build.gradle
@@ -31,6 +31,9 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-web:${springBootVersion}"
     implementation "org.springframework.boot:spring-boot-starter-actuator:${springBootVersion}"
     implementation "org.springframework.boot:spring-boot-starter-validation:${springBootVersion}"
+    
+    // Specify a version to get the latest hotfix for a CVE. Can revert once Spring Boot updates
+    implementation "org.springframework:spring-expression:${springVersion}"
 
     // This is a transitive dependency from spring-boot-starter that we're forcing to pick up CVE hotfixes. We're not
     // vulnerable since we're not accepting untrusted Spring Boot config files, but this cleans up the reporting.


### PR DESCRIPTION
#### Rationale
Embedded Tomcat doesn't automatically pick up the main Spring version from the web application

#### Changes
* Point to 5.3.27 here too