### PR TITLE
Add `JUNIT` formatted report to dependency check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ allprojects {
                     enabled = false
                 }
             }
+            formats = ['HTML', 'JUNIT']
             skipConfigurations = ['dedupe', 'gwtCompileClasspath', 'gwtRuntimeClasspath', 'developmentOnly']
             skipProjects = [':server:testAutomation']
         }

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ allprojects {
                 }
             }
             formats = ['HTML', 'JUNIT']
-            skipConfigurations = ['dedupe', 'gwtCompileClasspath', 'gwtRuntimeClasspath']
+            skipConfigurations = ['dedupe', 'gwtCompileClasspath', 'gwtRuntimeClasspath', 'developmentOnly']
             skipProjects = [':server:testAutomation']
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ allprojects {
                 }
             }
             formats = ['HTML', 'JUNIT']
-            skipConfigurations = ['dedupe', 'gwtCompileClasspath', 'gwtRuntimeClasspath', 'developmentOnly']
+            skipConfigurations = ['dedupe', 'gwtCompileClasspath', 'gwtRuntimeClasspath']
             skipProjects = [':server:testAutomation']
         }
     }

--- a/server/embedded/build.gradle
+++ b/server/embedded/build.gradle
@@ -31,9 +31,6 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-web:${springBootVersion}"
     implementation "org.springframework.boot:spring-boot-starter-actuator:${springBootVersion}"
     implementation "org.springframework.boot:spring-boot-starter-validation:${springBootVersion}"
-    
-    // Specify a version to get the latest hotfix for a CVE. Can revert once Spring Boot updates
-    implementation "org.springframework:spring-expression:${springVersion}"
 
     // This is a transitive dependency from spring-boot-starter that we're forcing to pick up CVE hotfixes. We're not
     // vulnerable since we're not accepting untrusted Spring Boot config files, but this cleans up the reporting.

--- a/server/embedded/build.gradle
+++ b/server/embedded/build.gradle
@@ -31,6 +31,9 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-web:${springBootVersion}"
     implementation "org.springframework.boot:spring-boot-starter-actuator:${springBootVersion}"
     implementation "org.springframework.boot:spring-boot-starter-validation:${springBootVersion}"
+    
+    // Specify a version to get the latest hotfix for a CVE. Can revert once Spring Boot updates
+    implementation "org.springframework:spring-expression:${springVersion}"
 
     // This is a transitive dependency from spring-boot-starter that we're forcing to pick up CVE hotfixes. We're not
     // vulnerable since we're not accepting untrusted Spring Boot config files, but this cleans up the reporting.


### PR DESCRIPTION
#### Rationale
The OWASP dependencycheck can output a JUnit formatted XML file. TeamCity should be able to consume it: https://www.jetbrains.com/help/teamcity/xml-report-processing.html

#### Related Pull Requests
* #455

#### Changes
* Add `JUNIT` formatted report to dependency check
