### PR TITLE
Use artifactory repos that don't proxy for third-party repos

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,7 +105,7 @@ allprojects {
                     }
                     maven {
 
-                        url "${artifactory_contextUrl}/libs-release"
+                        url "${artifactory_contextUrl}/libs-release-no-proxy"
 
                         if (project.hasProperty('artifactory_user') && project.hasProperty('artifactory_password'))
                         {
@@ -119,7 +119,7 @@ allprojects {
                         }
                     }
                     maven {
-                        url "${artifactory_contextUrl}/libs-snapshot"
+                        url "${artifactory_contextUrl}/libs-snapshot-no-proxy"
 
                         if (project.hasProperty('artifactory_user') && project.hasProperty('artifactory_password'))
                         {

--- a/gradle/settings/all.gradle
+++ b/gradle/settings/all.gradle
@@ -1,7 +1,11 @@
 buildscript {
     repositories {
+        mavenCentral()
         maven {
-            url "${artifactory_contextUrl}/plugins-release"
+            url "https://plugins.gradle.org/m2"
+        }
+        maven {
+            url "${artifactory_contextUrl}/plugins-release-no-proxy"
         }
         if (gradlePluginsVersion.contains("SNAPSHOT"))
         {

--- a/gradle/settings/all.gradle
+++ b/gradle/settings/all.gradle
@@ -1,9 +1,7 @@
 buildscript {
     repositories {
         mavenCentral()
-        maven {
-            url "https://plugins.gradle.org/m2"
-        }
+        gradlePluginPortal()
         maven {
             url "${artifactory_contextUrl}/plugins-release-no-proxy"
         }

--- a/gradle/settings/distributions.gradle
+++ b/gradle/settings/distributions.gradle
@@ -1,7 +1,11 @@
 buildscript {
     repositories {
+        mavenCentral()
         maven {
-            url "${artifactory_contextUrl}/plugins-release"
+            url "https://plugins.gradle.org/m2"
+        }
+        maven {
+            url "${artifactory_contextUrl}/plugins-release-no-proxy"
         }
         if (gradlePluginsVersion.contains("SNAPSHOT"))
         {

--- a/gradle/settings/distributions.gradle
+++ b/gradle/settings/distributions.gradle
@@ -1,9 +1,7 @@
 buildscript {
     repositories {
         mavenCentral()
-        maven {
-            url "https://plugins.gradle.org/m2"
-        }
+        gradlePluginPortal()
         maven {
             url "${artifactory_contextUrl}/plugins-release-no-proxy"
         }

--- a/gradle/settings/ehr.gradle
+++ b/gradle/settings/ehr.gradle
@@ -1,7 +1,11 @@
 buildscript {
     repositories {
+        mavenCentral()
         maven {
-            url "${artifactory_contextUrl}/plugins-release"
+            url "https://plugins.gradle.org/m2"
+        }
+        maven {
+            url "${artifactory_contextUrl}/plugins-release-no-proxy"
         }
         if (gradlePluginsVersion.contains("SNAPSHOT"))
         {

--- a/gradle/settings/ehr.gradle
+++ b/gradle/settings/ehr.gradle
@@ -1,9 +1,7 @@
 buildscript {
     repositories {
         mavenCentral()
-        maven {
-            url "https://plugins.gradle.org/m2"
-        }
+        gradlePluginPortal()
         maven {
             url "${artifactory_contextUrl}/plugins-release-no-proxy"
         }

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,9 +2,7 @@
 pluginManagement {
     repositories {
         mavenCentral()
-        maven {
-            url "https://plugins.gradle.org/m2"
-        }
+        gradlePluginPortal()
         maven {
             url "${artifactory_contextUrl}/plugins-release-no-proxy"
         }
@@ -35,9 +33,7 @@ pluginManagement {
 buildscript {
     repositories {
         mavenCentral()
-        maven {
-            url "https://plugins.gradle.org/m2"
-        }
+        gradlePluginPortal()
         maven {
             url "${artifactory_contextUrl}/plugins-release-no-proxy"
         }
@@ -54,7 +50,7 @@ buildscript {
     dependencies {
         classpath "org.labkey.build:gradlePlugins:${gradlePluginsVersion}"
     }
-    configurations.all {
+    configurations.configureEach {
         // Check for updates every build for SNAPSHOT dependencies
         resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
     }
@@ -114,10 +110,10 @@ else if (hasProperty('moduleSet'))
         {
             throw new FileNotFoundException("No module set definitions found in '<labkey>/gradle/settings/'")
         }
-        List<String> moduleSets = new ArrayList<>();
+        List<String> moduleSets = new ArrayList<>()
         for (File file : files)
         {
-            moduleSets.add(file.getName().replace(".gradle", ""));
+            moduleSets.add(file.getName().replace(".gradle", ""))
         }
         throw new FileNotFoundException(String.format("Module set '${moduleSet}' does not exist. Choose one of: %s (e.g. '-PmoduleSet=%s')", moduleSets.join(", "), moduleSets.get(0)))
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,8 +1,12 @@
 
 pluginManagement {
     repositories {
+        mavenCentral()
         maven {
-            url "${artifactory_contextUrl}/plugins-release"
+            url "https://plugins.gradle.org/m2"
+        }
+        maven {
+            url "${artifactory_contextUrl}/plugins-release-no-proxy"
         }
         if (gradlePluginsVersion.contains("SNAPSHOT") || versioningPluginVersion.contains("SNAPSHOT"))
         {
@@ -30,8 +34,12 @@ pluginManagement {
 
 buildscript {
     repositories {
+        mavenCentral()
         maven {
-            url "${artifactory_contextUrl}/plugins-release"
+            url "https://plugins.gradle.org/m2"
+        }
+        maven {
+            url "${artifactory_contextUrl}/plugins-release-no-proxy"
         }
         if (gradlePluginsVersion.contains("SNAPSHOT")) {
             // For testing changes to the gradle plugins. Publish 'gradlePlugins' locally using 'publishToMavenLocal'.


### PR DESCRIPTION
#### Rationale
When we proxy for third-party repos, many of the artifacts that are available from mavenCentral get cached in and served from our Artifactory instance.  We want to avoid this to reduce costs.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/461
* https://github.com/LabKey/wnprc-modules/pull/299
* https://github.com/LabKey/tutorialModules/pull/144
* https://github.com/LabKey/labkey-api-jdbc/pull/35
* https://github.com/LabKey/labkey-api-r/pull/90
* https://github.com/LabKey/labkey-api-java/pull/54

#### Changes
* Use non-proxying repos
* Update some syntax
