### PR TITLE
Update to Spring Boot 2.7.11

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -96,7 +96,7 @@ apacheDirectoryVersion=2.1.3
 apacheMinaVersion=2.2.1
 
 # Keep in sync with springBootTomcatVersion below
-apacheTomcatVersion=9.0.73
+apacheTomcatVersion=9.0.74
 
 # (mothership) -> json-path -> json-smart -> accessor-smart
 # (core) -> graalvm
@@ -268,10 +268,10 @@ slf4jLog4j12Version=2.0.3
 # this version is forced for compatibility with api, LDK, and workflow
 slf4jLog4jApiVersion=2.0.3
 
-springBootVersion=2.7.10
+springBootVersion=2.7.11
 # This MUST match the Tomcat version dictated by springBootVersion
 # Also, keep this in sync with apacheTomcatVersion above
-springBootTomcatVersion=9.0.73
+springBootTomcatVersion=9.0.74
 
 springVersion=5.3.27
 

--- a/server/embedded/build.gradle
+++ b/server/embedded/build.gradle
@@ -32,9 +32,6 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-actuator:${springBootVersion}"
     implementation "org.springframework.boot:spring-boot-starter-validation:${springBootVersion}"
     
-    // Specify a version to get the latest hotfix for a CVE. Can revert once Spring Boot updates
-    implementation "org.springframework:spring-expression:${springVersion}"
-
     // This is a transitive dependency from spring-boot-starter that we're forcing to pick up CVE hotfixes. We're not
     // vulnerable since we're not accepting untrusted Spring Boot config files, but this cleans up the reporting.
     // At some point Spring Boot should update its preferred version and we can yank this


### PR DESCRIPTION
#### Rationale
There's a new version of Spring Boot, which also means we don't need to pin its Spring framework version to 5.3.27

#### Changes
* Update Spring Boot and Tomcat