### PR TITLE
Update LabKey dependencies

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -223,6 +223,8 @@ log4j2Version=2.19.0
 
 lombokVersion=1.18.24
 
+luceneVersion=9.4.2
+
 mysqlDriverVersion=8.0.32
 
 mssqlJdbcVersion=12.2.0.jre11


### PR DESCRIPTION
As-is, luceneVersion is set in the search module's build.gradle. This PR moves it to the top-level, so other modules can share it. 

See also: https://github.com/LabKey/platform/pull/4368