### PR TITLE
Upgrade Java remote API to v5.2.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ buildFromSource=true
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
 labkeyVersion=23.6-SNAPSHOT
-labkeyClientApiVersion=5.1.0
+labkeyClientApiVersion=5.2.0
 
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.


### PR DESCRIPTION
#### Rationale
Upgrade to the latest Java remote API version (v5.2.0), which adds the ability to rename containers.

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-java/pull/55

#### Changes
* Update version
