### PR TITLE
Use artifactory repos that don't proxy for third-party repos

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,11 +10,12 @@ import org.labkey.gradle.task.PurgeNpmAlphaVersions
 buildscript {
     repositories {
         mavenCentral()
+        gradlePluginPortal()
         maven {
             url "https://plugins.gradle.org/m2"
         }
         maven {
-            url "${artifactory_contextUrl}/plugins-release"
+            url "${artifactory_contextUrl}/plugins-release-no-proxy"
         }
         if (gradlePluginsVersion.contains("SNAPSHOT") || versioningPluginVersion.contains("SNAPSHOT"))
         {
@@ -121,7 +122,7 @@ allprojects {
                     }
                     maven {
 
-                        url "${artifactory_contextUrl}/libs-release"
+                        url "${artifactory_contextUrl}/libs-release-no-proxy"
 
                         if (project.hasProperty('artifactory_user') && project.hasProperty('artifactory_password'))
                         {
@@ -135,7 +136,7 @@ allprojects {
                         }
                     }
                     maven {
-                        url "${artifactory_contextUrl}/libs-snapshot"
+                        url "${artifactory_contextUrl}/libs-snapshot-no-proxy"
 
                         if (project.hasProperty('artifactory_user') && project.hasProperty('artifactory_password'))
                         {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,8 +1,10 @@
 
 pluginManagement {
     repositories {
+        mavenCentral()
+        gradlePluginPortal()
         maven {
-            url "${artifactory_contextUrl}/plugins-release"
+            url "${artifactory_contextUrl}/plugins-release-no-proxy"
         }
         if (gradlePluginsVersion.contains("SNAPSHOT") || versioningPluginVersion.contains("SNAPSHOT")) {
             maven {
@@ -33,8 +35,10 @@ pluginManagement {
 
 buildscript {
     repositories {
+        mavenCentral()
+        gradlePluginPortal()
         maven {
-            url "${artifactory_contextUrl}/plugins-release"
+            url "${artifactory_contextUrl}/plugins-release-no-proxy"
         }
         if (gradlePluginsVersion.contains("SNAPSHOT")) {
             maven {


### PR DESCRIPTION
#### Rationale
When we proxy for third-party repos, many of the artifacts that are available from mavenCentral get cached in and served from our Artifactory instance.  We want to avoid this to reduce costs.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/468
* https://github.com/LabKey/tutorialModules/pull/145
* https://github.com/LabKey/wnprc-modules/pull/306

#### Changes
* Use non-proxying repos
