### PR TITLE
Avoid unnecessary Gradle task configuration

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -1,10 +1,10 @@
+import org.apache.commons.lang3.SystemUtils
+import org.labkey.gradle.plugin.JsDoc
+import org.labkey.gradle.plugin.XsdDoc
 import org.labkey.gradle.task.CreateModule
 import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.GroupNames
 import org.labkey.gradle.util.PomFileHelper
-import org.labkey.gradle.plugin.XsdDoc
-import org.labkey.gradle.plugin.JsDoc
-import org.apache.commons.lang3.SystemUtils
 
 plugins {
     id 'maven-publish'
@@ -214,4 +214,4 @@ project.node {
     npmWorkDir = project.file("${project.rootProject.buildDir}/.node")
     yarnWorkDir = project.file("${project.rootProject.buildDir}/.node")
 }
-project.tasks.deployApp.dependsOn(project.tasks.npmSetup)
+project.tasks.named('deployApp').configure { dependsOn(project.tasks.npmSetup) }


### PR DESCRIPTION
#### Rationale
Using [task configuration avoidance APIs](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html) can make builds more efficient.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/171

#### Changes
* Update gradle task references to avoid unnecessary configuration