### PR TITLE
Don't download proteomics binaries by default

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -50,6 +50,8 @@ labkeyClientApiVersion=1.5.0
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.
 windowsUtilsVersion=1.0
+# Uncomment the following line to download proteomics binaries
+#includeProteomicsBinaries
 linuxProteomicsBinariesVersion=2.0
 osxProteomicsBinariesVersion=1.0
 windowsProteomicsBinariesVersion=1.0

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -49,7 +49,7 @@ configurations
         }
 configurations.binaries.setDescription("Utility and proteomics binaries")
 
-if (!project.hasProperty('excludeProteomicsBinaries'))
+if (project.hasProperty('includeProteomicsBinaries'))
 {
     dependencies
     {


### PR DESCRIPTION
#### Rationale
Most tests don't need these. Stop wasting bandwidth downloading them for every single build on TeamCity.

#### Related Pull Requests
* N/A

#### Changes
* Don't download proteomics binaries unless requested
