### PR TITLE
Update to latest SQLite version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -279,7 +279,7 @@ springBootTomcatVersion=9.0.74
 
 springVersion=5.3.27
 
-sqliteJdbcVersion=3.7.2
+sqliteJdbcVersion=3.42.0.0
 
 # NLP and SAML bring stax2-api in as a transitive dependency but with very different versions. We force the later version.
 stax2ApiVersion=4.2.1


### PR DESCRIPTION
#### Rationale
There's a newer release for the Xerial SQLite JDBC driver

#### Changes
* Move to 3.42.0.0