### PR TITLE
Synchronize Google API versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -221,6 +221,8 @@ allprojects {
                         force "xml-apis:xml-apis:${xmlApisVersion}"
                     // cloud and SequenceAnalysis bring this in as a transitive dependency. We resolve to the later version here to keep things consistent
                     force "com.google.code.gson:gson:${gsonVersion}"
+                    // Google HTTP Client Library and Guava bring in different versions; force the latest
+                    force "com.google.errorprone:error_prone_annotations:${googleErrorProneAnnotationsVersion}"
                     // different google APIs bring in different versions; force the latest
                     force "com.google.http-client:google-http-client-gson:${googleHttpClientGsonVersion}"
                     // workflow (Activiti) brings in older versions of these libraries, so we need to force these versions

--- a/gradle.properties
+++ b/gradle.properties
@@ -145,6 +145,7 @@ fopVersion=2.7
 
 googleApiClientVersion=2.2.0
 # Force latest for consistency
+googleErrorProneAnnotationsVersion=2.18.0
 googleHttpClientGsonVersion=1.42.2
 googleHttpClientVersion=1.43.2
 googleOauthClientVersion=1.34.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -143,11 +143,10 @@ flyingsaucerVersion=R8
 # Apache FOP -- linked to Apache Batik version above
 fopVersion=2.7
 
-googleApiServicesCalendarVersion=v3-rev411-1.25.0
-googleApiClientVersion=2.0.0
+googleApiClientVersion=2.2.0
 # Force latest for consistency
 googleHttpClientGsonVersion=1.42.2
-googleHttpClientVersion=1.42.2
+googleHttpClientVersion=1.43.2
 googleOauthClientVersion=1.34.1
 googleProtocolBufVersion=3.21.5
 


### PR DESCRIPTION
#### Rationale
There's an incompatibility between the versions of googleApiClientVersion and the Google Drive and Google Calendar libraries.

#### Changes
* Upgrade library versions and move one dependency used in single module to that repo
