### PR TITLE
Add property to restrict the number of concurrent npm build tasks

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 #moduleSet=all
 #ideaIncludeAllModules=true
-# Uncomment the following line to turn on Gradle's file watching, which may improve efficiency
-# https://blog.gradle.org/introducing-file-system-watching
-#org.gradle.vfs.watch=true
+# This controls Gradle's file system watching, which improves efficiency of incremental builds
+# https://docs.gradle.org/current/userguide/file_system_watching.html
+org.gradle.vfs.watch=true
 # This controls Gradle's build cache, which improves efficiency.
 # https://docs.gradle.org/current/userguide/build_cache.html
 org.gradle.caching=true
@@ -13,6 +13,8 @@ org.gradle.parallel=true
 org.gradle.workers.max=3
 # Default to using 2GB of memory for the JVM.
 org.gradle.jvmargs=-Xmx2048m
+# Uncomment to restrict the number of concurrent npm build tasks. Useful for systems with limited resources.
+#npmRunLimit=2
 
 # Set the action to be performed when a version conflict between a dependency included from the build and one that already exists
 # is detected. Default behavior on detecting a conflict is to fail. Possible values are delete, fail, warn.
@@ -60,7 +62,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.31.9
 gradleNodePluginVersion=3.5.1
-gradlePluginsVersion=1.40.6
+gradlePluginsVersion=1.41.0-npmRunLimit-SNAPSHOT
 owaspDependencyCheckPluginVersion=8.2.1
 versioningPluginVersion=1.1.0
 


### PR DESCRIPTION
#### Rationale
Add a commented out property to set the limit on parallel execution of `npmRunBuild` tasks.
Also uncomment `org.gradle.vfs.watch` and update its comment; file system watching is now [enabled by default](https://docs.gradle.org/current/userguide/file_system_watching.html#enable) on most modern OSs.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/176

#### Changes
* Add commented `npmRunLimit` property
* Update comment and property for `org.gradle.vfs.watch`
