### PR TITLE
Configure repository content for faster searching for dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,7 +103,9 @@ allprojects {
                     maven {
                         url "${artifactory_contextUrl}/ext-tools-local"
                         content {
-                            includeGroup "org.labkey.tools"
+                            includeGroup "org.labkey.tools.windows"
+                            includeGroup "org.labkey.tools.linux"
+                            includeGroup "org.labkey.tools.osx"
                         }
                     }
                     maven {

--- a/build.gradle
+++ b/build.gradle
@@ -102,9 +102,11 @@ allprojects {
                 {
                     maven {
                         url "${artifactory_contextUrl}/ext-tools-local"
+                        content {
+                            includeGroup "org.labkey.tools"
+                        }
                     }
                     maven {
-
                         url "${artifactory_contextUrl}/libs-release-no-proxy"
 
                         if (project.hasProperty('artifactory_user') && project.hasProperty('artifactory_password'))
@@ -116,6 +118,9 @@ allprojects {
                             authentication {
                                 basic(BasicAuthentication)
                             }
+                        }
+                        mavenContent {
+                            releasesOnly()
                         }
                     }
                     maven {
@@ -131,7 +136,16 @@ allprojects {
                                 basic(BasicAuthentication)
                             }
                         }
+                        mavenContent {
+                            snapshotsOnly()
+                        }
+                        content {
+                            includeGroup "org.labkey"
+                            includeGroup "org.labkey.api"
+                            includeGroup "org.labkey.module"
+                        }
                     }
+
 // Temporarily uncomment the block below and update the four-digit number to allow building with Tomcat versions that
 // haven't been released yet. The "VOTE" emails sent to the Tomcat dev email list include a staging repo URL. In
 // addition to updating the url to match, you'll also need to update apacheTomcatVersion in gradle.properties.
@@ -142,6 +156,9 @@ allprojects {
                         // Mondrian dependencies are available via this repository. It's a direct dependency of the Query
                         // module but is declared here as many modules depend on Query and therefore need it as well.
                     	url "https://repo.orl.eng.hitachivantara.com/artifactory/pnt-mvn"
+                        content {
+                            excludeGroupByRegex "org\\.labkey.*"
+                        }
                     }
                 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -145,7 +145,6 @@ allprojects {
                             includeGroup "org.labkey"
                             includeGroup "org.labkey.api"
                             includeGroup "org.labkey.module"
-                            includeGroup "org.maccosslab"
                         }
                     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -143,6 +143,7 @@ allprojects {
                             includeGroup "org.labkey"
                             includeGroup "org.labkey.api"
                             includeGroup "org.labkey.module"
+                            includeGroup "org.maccosslab"
                         }
                     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -60,7 +60,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.31.9
 gradleNodePluginVersion=3.5.1
-gradlePluginsVersion=1.40.6
+gradlePluginsVersion=1.41.0-repoOptimizations-SNAPSHOT
 owaspDependencyCheckPluginVersion=8.2.1
 versioningPluginVersion=1.1.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ org.gradle.parallel=true
 # (this could be memory-intensive)
 org.gradle.workers.max=3
 # Default to using 2GB of memory for the JVM.
-org.gradle.jvmargs=-Xmx2048m
+org.gradle.jvmargs=-Xmx2048m -XX:+UseParallelGC
 
 # Set the action to be performed when a version conflict between a dependency included from the build and one that already exists
 # is detected. Default behavior on detecting a conflict is to fail. Possible values are delete, fail, warn.

--- a/gradle.properties
+++ b/gradle.properties
@@ -60,7 +60,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.31.9
 gradleNodePluginVersion=3.5.1
-gradlePluginsVersion=1.41.0-repoOptimizations-SNAPSHOT
+gradlePluginsVersion=1.41.0
 owaspDependencyCheckPluginVersion=8.2.1
 versioningPluginVersion=1.1.0
 

--- a/gradle/settings/all.gradle
+++ b/gradle/settings/all.gradle
@@ -1,15 +1,37 @@
 buildscript {
     repositories {
-        mavenCentral()
-        gradlePluginPortal()
+        mavenCentral {
+            content {
+                excludeGroupByRegex "org\\.labkey.*"
+            }
+        }
+        gradlePluginPortal {
+            content {
+                excludeGroupByRegex "org\\.labkey.*"
+            }
+        }
         maven {
             url "${artifactory_contextUrl}/plugins-release-no-proxy"
+            mavenContent {
+                releasesOnly()
+            }
+            content {
+                includeGroup "org.labkey.build"
+                includeGroup "org.labkey.versioning"
+            }
         }
         if (gradlePluginsVersion.contains("SNAPSHOT"))
         {
             mavenLocal()
             maven {
                 url "${artifactory_contextUrl}/plugins-snapshot-local"
+                mavenContent {
+                    snapshotsOnly()
+                }
+                content {
+                    includeGroup "org.labkey.build"
+                    includeGroup "org.labkey.versioning"
+                }
             }
 
         }

--- a/gradle/settings/distributions.gradle
+++ b/gradle/settings/distributions.gradle
@@ -1,15 +1,33 @@
 buildscript {
     repositories {
         mavenCentral()
-        gradlePluginPortal()
+        gradlePluginPortal {
+            content {
+                excludeGroupByRegex "org\\.labkey.*"
+            }
+        }
         maven {
             url "${artifactory_contextUrl}/plugins-release-no-proxy"
+            mavenContent {
+                releasesOnly()
+            }
+            content {
+                includeGroup "org.labkey.build"
+                includeGroup "org.labkey.versioning"
+            }
         }
         if (gradlePluginsVersion.contains("SNAPSHOT"))
         {
             mavenLocal()
             maven {
                 url "${artifactory_contextUrl}/plugins-snapshot-local"
+                mavenContent {
+                    snapshotsOnly()
+                }
+                content {
+                    includeGroup "org.labkey.build"
+                    includeGroup "org.labkey.versioning"
+                }
             }
 
         }

--- a/gradle/settings/ehr.gradle
+++ b/gradle/settings/ehr.gradle
@@ -1,15 +1,33 @@
 buildscript {
     repositories {
         mavenCentral()
-        gradlePluginPortal()
+        gradlePluginPortal {
+            content {
+                excludeGroupByRegex "org\\.labkey.*"
+            }
+        }
         maven {
             url "${artifactory_contextUrl}/plugins-release-no-proxy"
+            mavenContent {
+                releasesOnly()
+            }
+            content {
+                includeGroup "org.labkey.build"
+                includeGroup "org.labkey.versioning"
+            }
         }
         if (gradlePluginsVersion.contains("SNAPSHOT"))
         {
             mavenLocal()
             maven {
                 url "${artifactory_contextUrl}/plugins-snapshot-local"
+                mavenContent {
+                    snapshotsOnly()
+                }
+                content {
+                    includeGroup "org.labkey.build"
+                    includeGroup "org.labkey.versioning"
+                }
             }
 
         }

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,15 +2,33 @@
 pluginManagement {
     repositories {
         mavenCentral()
-        gradlePluginPortal()
+        gradlePluginPortal {
+            content {
+                excludeGroupByRegex "org\\.labkey.*"
+            }
+        }
         maven {
             url "${artifactory_contextUrl}/plugins-release-no-proxy"
+            mavenContent {
+                releasesOnly()
+            }
+            content {
+                includeGroup "org.labkey.build"
+                includeGroup "org.labkey.versioning"
+            }
         }
         if (gradlePluginsVersion.contains("SNAPSHOT") || versioningPluginVersion.contains("SNAPSHOT"))
         {
             mavenLocal()
             maven {
                 url "${artifactory_contextUrl}/plugins-snapshot-local"
+                mavenContent {
+                    snapshotsOnly()
+                }
+                content {
+                    includeGroup "org.labkey.build"
+                    includeGroup "org.labkey.versioning"
+                }
             }
         }
     }
@@ -33,9 +51,16 @@ pluginManagement {
 buildscript {
     repositories {
         mavenCentral()
-        gradlePluginPortal()
+        gradlePluginPortal {
+            content {
+                excludeGroupByRegex "org\\.labkey.*"
+            }
+        }
         maven {
             url "${artifactory_contextUrl}/plugins-release-no-proxy"
+            mavenContent {
+                releasesOnly()
+            }
         }
         if (gradlePluginsVersion.contains("SNAPSHOT")) {
             // For testing changes to the gradle plugins. Publish 'gradlePlugins' locally using 'publishToMavenLocal'.
@@ -44,6 +69,9 @@ buildscript {
             mavenLocal()
             maven {
                 url "${artifactory_contextUrl}/plugins-snapshot-local"
+                mavenContent {
+                    snapshotsOnly()
+                }
             }
         }
     }


### PR DESCRIPTION
#### Rationale
By default, every repository that is declared is searched for dependencies, which can be wasteful when we know that some repositories will never contain certain dependencies.  Gradle has introduced ways to [configure repositories](https://docs.gradle.org/current/userguide/declaring_repositories.html#sec:repository-content-filtering) to filter the content that is served from them, reducing search time and traffic to the repo server when looking for a dependency.  Might as well take advantage of that. 

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/177
* https://github.com/LabKey/tutorialModules/pull/154
* https://github.com/LabKey/labkey-api-r/pull/94
* https://github.com/LabKey/labkey-api-jdbc/pull/36
* https://github.com/LabKey/labkey-api-java/pull/58

#### Changes
* Designate repos as either snapshot-only or release-only
* Filter to known groups for tool repository and snapshot repository
* Use parallel garbage collection 

