### PR TITLE
Upgrade Lucene and Tika + dependencies

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -109,8 +109,8 @@ asmVersion=9.5
 batikVersion=1.16
 
 # sync with Tika version (or later)
-bouncycastlePgpVersion=1.72.1
-bouncycastleVersion=1.72
+bouncycastlePgpVersion=1.73
+bouncycastleVersion=1.73
 
 cglibNodepVersion=2.2.3
 
@@ -123,7 +123,7 @@ commonsCollectionsVersion=3.2.2
 commonsCollections4Version=4.4
 commonsCodecVersion=1.15
 # sync with version Tika ships
-commonsCompressVersion=1.22
+commonsCompressVersion=1.23.0
 commonsDbcpVersion=1.4
 commonsDiscoveryVersion=0.2
 commonsDigesterVersion=1.8.1
@@ -229,7 +229,7 @@ log4j2Version=2.20.0
 
 lombokVersion=1.18.24
 
-luceneVersion=9.4.2
+luceneVersion=9.6.0
 
 mysqlDriverVersion=8.0.33
 
@@ -248,7 +248,7 @@ openTracingVersion=0.33.0
 oracleJdbcVersion=23.2.0.0
 
 # sync with version Tika ships
-pdfboxVersion=2.0.27
+pdfboxVersion=2.0.28
 
 # sync with version Tika ships
 poiVersion=5.2.3
@@ -287,7 +287,7 @@ stax2ApiVersion=4.2.1
 thumbnailatorVersion=0.4.8
 
 # used for tika-core in API and tika-parsers in search
-tikaVersion=2.6.0
+tikaVersion=2.8.0
 
 # sync with Tika
 tukaaniXZVersion=1.9


### PR DESCRIPTION
#### Rationale
Upgrade Lucene to 9.6.0 plus a few Tika dependencies

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4491