### PR TITLE
Adjust gradle memory and processor settings to work better on CI

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,8 +9,9 @@ org.gradle.caching=true
 # comment out or use --no-parallel to turn off parallel execution
 org.gradle.parallel=true
 # Gradle will attempt to determine the optimal number of executor threads to use.
-# Uncomment or add to global gradle properties to specify. Leaving default could be memory-intensive
-#org.gradle.workers.max=3
+# comment out and Gradle will attempt to determine the optimal number of executor threads to use
+# (this could be memory-intensive)
+org.gradle.workers.max=3
 # Default to using 4GB of memory for the JVM.
 org.gradle.jvmargs=-Xmx4g -XX:+UseParallelGC
 # Uncomment to restrict the number of concurrent npm build tasks. Useful for systems with limited resources.

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,6 @@ org.gradle.vfs.watch=true
 org.gradle.caching=true
 # comment out or use --no-parallel to turn off parallel execution
 org.gradle.parallel=true
-# Gradle will attempt to determine the optimal number of executor threads to use.
 # comment out and Gradle will attempt to determine the optimal number of executor threads to use
 # (this could be memory-intensive)
 org.gradle.workers.max=3

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,11 +8,11 @@ org.gradle.vfs.watch=true
 org.gradle.caching=true
 # comment out or use --no-parallel to turn off parallel execution
 org.gradle.parallel=true
-# comment out and Gradle will attempt to determine the optimal number of executor threads to use
-# (this could be memory-intensive)
-org.gradle.workers.max=3
-# Default to using 2GB of memory for the JVM.
-org.gradle.jvmargs=-Xmx2048m -XX:+UseParallelGC
+# Gradle will attempt to determine the optimal number of executor threads to use.
+# Uncomment or add to global gradle properties to specify. Leaving default could be memory-intensive
+#org.gradle.workers.max=3
+# Default to using 4GB of memory for the JVM.
+org.gradle.jvmargs=-Xmx4g -XX:+UseParallelGC
 # Uncomment to restrict the number of concurrent npm build tasks. Useful for systems with limited resources.
 #npmRunLimit=2
 


### PR DESCRIPTION
#### Rationale
Installers have been failing since the addition of the `-XX:+UseParallelGC` JVM arg.
The new TC agents have fewer processors but lots of RAM. Increasing Gradle's memory allowance and leaving `org.gradle.workers.max` unset seems to make the build happy without removing the parallel GC flag. It also makes the build a bit faster.

#### Related Pull Requests
* #497

#### Changes
* Adjust gradle memory and processor settings to work better on CI
