### PR TITLE
Upgrade a few dependencies and move Google client API version property

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -150,9 +150,8 @@ flyingsaucerVersion=R8
 # Apache FOP -- linked to Apache Batik version above
 fopVersion=2.8
 
-googleApiClientVersion=2.2.0
 # Force latest for consistency
-googleErrorProneAnnotationsVersion=2.18.0
+googleErrorProneAnnotationsVersion=2.19.1
 googleHttpClientGsonVersion=1.43.2
 googleHttpClientVersion=1.43.2
 googleOauthClientVersion=1.34.1
@@ -262,15 +261,15 @@ quartzVersion=2.3.2
 rforgeVersion=0.6-8.1
 
 # sync with Tika version
-romeVersion=1.18.0
+romeVersion=1.19.0
 
 # Tomcat 9 implements 4.x
 servletApiVersion=4.0.1
 
 # this version is forced for compatibility with pipeline and tika
-slf4jLog4j12Version=2.0.3
+slf4jLog4j12Version=2.0.7
 # this version is forced for compatibility with api, LDK, and workflow
-slf4jLog4jApiVersion=2.0.3
+slf4jLog4jApiVersion=2.0.7
 
 springBootVersion=2.7.12
 # This MUST match the Tomcat version dictated by springBootVersion


### PR DESCRIPTION
#### Rationale
A few libraries got missed in the latest Tika dependencies upgrades.

Also, Google client API dependency is used by a single client-specific module, so move its version property there. https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47993

#### Related Pull Requests
* https://github.com/LabKey/server/pull/499
* https://github.com/LabKey/wnprc-modules/pull/351