### PR TITLE
Bump to latest BouncyCastle version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -111,8 +111,8 @@ asmVersion=9.5
 batikVersion=1.16
 
 # sync with Tika version (or later)
-bouncycastlePgpVersion=1.73
-bouncycastleVersion=1.73
+bouncycastlePgpVersion=1.74
+bouncycastleVersion=1.74
 
 cglibNodepVersion=2.2.3
 


### PR DESCRIPTION
#### Rationale
There's a new BC release, 1.74

#### Changes
* Switch to the latest version