### PR TITLE
Temporarily revert optimization configs for plugins repository

### DIFF
--- a/gradle/settings/all.gradle
+++ b/gradle/settings/all.gradle
@@ -11,7 +11,7 @@ buildscript {
             }
         }
         maven {
-            url "${artifactory_contextUrl}/plugins-release-no-proxy"
+            url "${artifactory_contextUrl}/plugins-release"
             mavenContent {
                 releasesOnly()
             }

--- a/gradle/settings/all.gradle
+++ b/gradle/settings/all.gradle
@@ -15,10 +15,10 @@ buildscript {
             mavenContent {
                 releasesOnly()
             }
-            content {
-                includeGroup "org.labkey.build"
-                includeGroup "org.labkey.versioning"
-            }
+//            content {
+//                includeGroup "org.labkey.build"
+//                includeGroup "org.labkey.versioning"
+//            }
         }
         if (gradlePluginsVersion.contains("SNAPSHOT"))
         {
@@ -28,10 +28,10 @@ buildscript {
                 mavenContent {
                     snapshotsOnly()
                 }
-                content {
-                    includeGroup "org.labkey.build"
-                    includeGroup "org.labkey.versioning"
-                }
+//                content {
+//                    includeGroup "org.labkey.build"
+//                    includeGroup "org.labkey.versioning"
+//                }
             }
 
         }

--- a/gradle/settings/distributions.gradle
+++ b/gradle/settings/distributions.gradle
@@ -11,10 +11,10 @@ buildscript {
             mavenContent {
                 releasesOnly()
             }
-            content {
-                includeGroup "org.labkey.build"
-                includeGroup "org.labkey.versioning"
-            }
+//            content {
+//                includeGroup "org.labkey.build"
+//                includeGroup "org.labkey.versioning"
+//            }
         }
         if (gradlePluginsVersion.contains("SNAPSHOT"))
         {
@@ -24,10 +24,10 @@ buildscript {
                 mavenContent {
                     snapshotsOnly()
                 }
-                content {
-                    includeGroup "org.labkey.build"
-                    includeGroup "org.labkey.versioning"
-                }
+//                content {
+//                    includeGroup "org.labkey.build"
+//                    includeGroup "org.labkey.versioning"
+//                }
             }
 
         }

--- a/gradle/settings/distributions.gradle
+++ b/gradle/settings/distributions.gradle
@@ -7,7 +7,7 @@ buildscript {
             }
         }
         maven {
-            url "${artifactory_contextUrl}/plugins-release-no-proxy"
+            url "${artifactory_contextUrl}/plugins-release"
             mavenContent {
                 releasesOnly()
             }

--- a/gradle/settings/ehr.gradle
+++ b/gradle/settings/ehr.gradle
@@ -11,10 +11,10 @@ buildscript {
             mavenContent {
                 releasesOnly()
             }
-            content {
-                includeGroup "org.labkey.build"
-                includeGroup "org.labkey.versioning"
-            }
+//            content {
+//                includeGroup "org.labkey.build"
+//                includeGroup "org.labkey.versioning"
+//            }
         }
         if (gradlePluginsVersion.contains("SNAPSHOT"))
         {
@@ -24,10 +24,10 @@ buildscript {
                 mavenContent {
                     snapshotsOnly()
                 }
-                content {
-                    includeGroup "org.labkey.build"
-                    includeGroup "org.labkey.versioning"
-                }
+//                content {
+//                    includeGroup "org.labkey.build"
+//                    includeGroup "org.labkey.versioning"
+//                }
             }
 
         }

--- a/gradle/settings/ehr.gradle
+++ b/gradle/settings/ehr.gradle
@@ -7,7 +7,7 @@ buildscript {
             }
         }
         maven {
-            url "${artifactory_contextUrl}/plugins-release-no-proxy"
+            url "${artifactory_contextUrl}/plugins-release"
             mavenContent {
                 releasesOnly()
             }

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,7 +8,7 @@ pluginManagement {
             }
         }
         maven {
-            url "${artifactory_contextUrl}/plugins-release-no-proxy"
+            url "${artifactory_contextUrl}/plugins-release"
             mavenContent {
                 releasesOnly()
             }
@@ -57,7 +57,7 @@ buildscript {
             }
         }
         maven {
-            url "${artifactory_contextUrl}/plugins-release-no-proxy"
+            url "${artifactory_contextUrl}/plugins-release"
             mavenContent {
                 releasesOnly()
             }

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,10 +12,10 @@ pluginManagement {
             mavenContent {
                 releasesOnly()
             }
-            content {
-                includeGroup "org.labkey.build"
-                includeGroup "org.labkey.versioning"
-            }
+//            content {
+//                includeGroup "org.labkey.build"
+//                includeGroup "org.labkey.versioning"
+//            }
         }
         if (gradlePluginsVersion.contains("SNAPSHOT") || versioningPluginVersion.contains("SNAPSHOT"))
         {
@@ -25,10 +25,10 @@ pluginManagement {
                 mavenContent {
                     snapshotsOnly()
                 }
-                content {
-                    includeGroup "org.labkey.build"
-                    includeGroup "org.labkey.versioning"
-                }
+//                content {
+//                    includeGroup "org.labkey.build"
+//                    includeGroup "org.labkey.versioning"
+//                }
             }
         }
     }


### PR DESCRIPTION
#### Rationale
The `org.ajoberstar.grgit:grgit-core:4.0.1` dependency of our fork of the `versioning` plugin has been removed from external repositories. We have it in our artifactory cache of the gradle-plugins repo, so need to use the repo that proxies for that repo and change the content config so Gradle will actually try to get that artifact from our repository.

This is a temporary fix while we evaluate whether we can use the `versioning` plugin we forked from or update our fork to remove the old dependencies.

#### Changes
* Remove content configuration for plugins repository.
* Use plugins repository that proxies for the global gradle plugins repository.
