### PR TITLE
Update versioning plugin to avoid missing grgit dependency

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -61,7 +61,7 @@ artifactoryPluginVersion=4.21.0
 gradleNodePluginVersion=3.0.1
 gradlePluginsVersion=1.34.4
 owaspDependencyCheckPluginVersion=5.2.1
-versioningPluginVersion=1.1.0
+versioningPluginVersion=1.1.2_gradle8-SNAPSHOT
 
 # Versions of node and npm to use during the build. If set, these versions
 # will be downloaded and used. If not set, the existing local installations will be use

--- a/gradle.properties
+++ b/gradle.properties
@@ -61,7 +61,7 @@ artifactoryPluginVersion=4.21.0
 gradleNodePluginVersion=3.0.1
 gradlePluginsVersion=1.34.4
 owaspDependencyCheckPluginVersion=5.2.1
-versioningPluginVersion=1.1.2_gradle8-SNAPSHOT
+versioningPluginVersion=1.1.2
 
 # Versions of node and npm to use during the build. If set, these versions
 # will be downloaded and used. If not set, the existing local installations will be use


### PR DESCRIPTION
#### Rationale
Versioning references a grgit version that has disappeared from the internet.

#### Related Pull Requests
* https://github.com/LabKey/versioning/pull/4

#### Changes
* Update versioning plugin
