### PR TITLE
Update gradlePluginsVersion to 1.41.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -62,7 +62,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.31.9
 gradleNodePluginVersion=3.5.1
-gradlePluginsVersion=1.41.1-dependencyVersion-SNAPSHOT
+gradlePluginsVersion=1.41.1
 owaspDependencyCheckPluginVersion=8.2.1
 versioningPluginVersion=1.1.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -62,7 +62,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.31.9
 gradleNodePluginVersion=3.5.1
-gradlePluginsVersion=1.41.0
+gradlePluginsVersion=1.41.1-dependencyVersion-SNAPSHOT
 owaspDependencyCheckPluginVersion=8.2.1
 versioningPluginVersion=1.1.0
 


### PR DESCRIPTION
#### Rationale
The gradle plugin can cause us to apply the wrong version to module dependencies and attempt to pull non-existent dependencies from Artifactory.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/178

#### Changes
* Update gradle plugin
