### PR TITLE
Issue 43420: Swap jTidy --> jSoup

### DIFF
--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -214,14 +214,4 @@
         <packageUrl regex="true">^pkg:maven/org\.sharegov/mjson@.*$</packageUrl>
         <vulnerabilityName>CVE-2023-34611</vulnerabilityName>
     </suppress>
-
-    <!-- This is a patched version of jTidy but the OWASP checker is confused about the different version numbering schemes -->
-    <suppress>
-        <notes><![CDATA[
-   file name: jtidy-1.0.4.jar
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/com\.github\.jtidy/jtidy@.*$</packageUrl>
-        <cve>CVE-2023-34623</cve>
-    </suppress>
-
 </suppressions>

--- a/gradle.properties
+++ b/gradle.properties
@@ -218,6 +218,8 @@ jsr305Version=3.0.2
 
 orgJsonVersion=20230227
 
+jsoupVersion=1.16.1
+
 jtidyVersion=r918
 
 junitVersion=4.13.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -220,8 +220,6 @@ orgJsonVersion=20230618
 
 jsoupVersion=1.16.1
 
-jtidyVersion=1.0.4
-
 junitVersion=4.13.2
 
 jxlVersion=2.6.3


### PR DESCRIPTION
#### Rationale
jTidy appears abandoned and doesn't support common HTML5 tag elements

[Issue #43420: Replace jTidy with jSoup...or similar](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43420)

#### Changes
* Swapped jSoup library in place of jTidy