### PR TITLE
Update JTidy

### DIFF
--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -215,4 +215,13 @@
         <vulnerabilityName>CVE-2023-34611</vulnerabilityName>
     </suppress>
 
+    <!-- This is a patched version of jTidy but the OWASP checker is confused about the different version numbering schemes -->
+    <suppress>
+        <notes><![CDATA[
+   file name: jtidy-1.0.4.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.github\.jtidy/jtidy@.*$</packageUrl>
+        <cve>CVE-2023-34623</cve>
+    </suppress>
+
 </suppressions>

--- a/gradle.properties
+++ b/gradle.properties
@@ -218,7 +218,7 @@ jsr305Version=3.0.2
 
 orgJsonVersion=20230227
 
-jtidyVersion=r918
+jtidyVersion=1.0.4
 
 junitVersion=4.13.2
 


### PR DESCRIPTION
#### Rationale
There's a newer version of JTidy maintained by a new set of developers

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4541

#### Changes
* Pull in their 1.0.4 release
