### PR TITLE
Gradle 8.2.1 and revert temporary change

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -62,7 +62,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.31.9
 gradleNodePluginVersion=3.5.1
-gradlePluginsVersion=1.42.0-dupeStrategy-SNAPSHOT
+gradlePluginsVersion=1.41.2
 owaspDependencyCheckPluginVersion=8.2.1
 versioningPluginVersion=1.1.2
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -62,7 +62,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.31.9
 gradleNodePluginVersion=3.5.1
-gradlePluginsVersion=1.41.1
+gradlePluginsVersion=1.42.0-dupeStrategy-SNAPSHOT
 owaspDependencyCheckPluginVersion=8.2.1
 versioningPluginVersion=1.1.2
 

--- a/gradle/settings/all.gradle
+++ b/gradle/settings/all.gradle
@@ -11,14 +11,14 @@ buildscript {
             }
         }
         maven {
-            url "${artifactory_contextUrl}/plugins-release"
+            url "${artifactory_contextUrl}/plugins-release-no-proxy"
             mavenContent {
                 releasesOnly()
             }
-//            content {
-//                includeGroup "org.labkey.build"
-//                includeGroup "org.labkey.versioning"
-//            }
+            content {
+                includeGroup "org.labkey.build"
+                includeGroup "org.labkey.versioning"
+            }
         }
         if (gradlePluginsVersion.contains("SNAPSHOT"))
         {
@@ -28,10 +28,10 @@ buildscript {
                 mavenContent {
                     snapshotsOnly()
                 }
-//                content {
-//                    includeGroup "org.labkey.build"
-//                    includeGroup "org.labkey.versioning"
-//                }
+                content {
+                    includeGroup "org.labkey.build"
+                    includeGroup "org.labkey.versioning"
+                }
             }
 
         }

--- a/gradle/settings/distributions.gradle
+++ b/gradle/settings/distributions.gradle
@@ -7,14 +7,14 @@ buildscript {
             }
         }
         maven {
-            url "${artifactory_contextUrl}/plugins-release"
+            url "${artifactory_contextUrl}/plugins-release-no-proxy"
             mavenContent {
                 releasesOnly()
             }
-//            content {
-//                includeGroup "org.labkey.build"
-//                includeGroup "org.labkey.versioning"
-//            }
+            content {
+                includeGroup "org.labkey.build"
+                includeGroup "org.labkey.versioning"
+            }
         }
         if (gradlePluginsVersion.contains("SNAPSHOT"))
         {
@@ -24,10 +24,10 @@ buildscript {
                 mavenContent {
                     snapshotsOnly()
                 }
-//                content {
-//                    includeGroup "org.labkey.build"
-//                    includeGroup "org.labkey.versioning"
-//                }
+                content {
+                    includeGroup "org.labkey.build"
+                    includeGroup "org.labkey.versioning"
+                }
             }
 
         }

--- a/gradle/settings/ehr.gradle
+++ b/gradle/settings/ehr.gradle
@@ -7,14 +7,14 @@ buildscript {
             }
         }
         maven {
-            url "${artifactory_contextUrl}/plugins-release"
+            url "${artifactory_contextUrl}/plugins-release-no-proxy"
             mavenContent {
                 releasesOnly()
             }
-//            content {
-//                includeGroup "org.labkey.build"
-//                includeGroup "org.labkey.versioning"
-//            }
+            content {
+                includeGroup "org.labkey.build"
+                includeGroup "org.labkey.versioning"
+            }
         }
         if (gradlePluginsVersion.contains("SNAPSHOT"))
         {
@@ -24,10 +24,10 @@ buildscript {
                 mavenContent {
                     snapshotsOnly()
                 }
-//                content {
-//                    includeGroup "org.labkey.build"
-//                    includeGroup "org.labkey.versioning"
-//                }
+                content {
+                    includeGroup "org.labkey.build"
+                    includeGroup "org.labkey.versioning"
+                }
             }
 
         }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,14 +8,14 @@ pluginManagement {
             }
         }
         maven {
-            url "${artifactory_contextUrl}/plugins-release"
+            url "${artifactory_contextUrl}/plugins-release-no-proxy"
             mavenContent {
                 releasesOnly()
             }
-//            content {
-//                includeGroup "org.labkey.build"
-//                includeGroup "org.labkey.versioning"
-//            }
+            content {
+                includeGroup "org.labkey.build"
+                includeGroup "org.labkey.versioning"
+            }
         }
         if (gradlePluginsVersion.contains("SNAPSHOT") || versioningPluginVersion.contains("SNAPSHOT"))
         {
@@ -25,10 +25,10 @@ pluginManagement {
                 mavenContent {
                     snapshotsOnly()
                 }
-//                content {
-//                    includeGroup "org.labkey.build"
-//                    includeGroup "org.labkey.versioning"
-//                }
+                content {
+                    includeGroup "org.labkey.build"
+                    includeGroup "org.labkey.versioning"
+                }
             }
         }
     }


### PR DESCRIPTION
#### Rationale

- Gradle 8.2.1 is the latest
- We're now using a new version of the versioning plugin that avoids a dependency that disappeared, so we can revert the changes that were required to pick up that old version from our Artifactory cache
- Gradle apparently now wants you to tell it explicitly what DuplicatesStrategy to use for copy tasks, so we'll do that in a new version of the gradlePlugins.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/179

#### Changes
* See above
