### PR TITLE
Bump to Gradle plugin 1.41.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -60,7 +60,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.21.0
 gradleNodePluginVersion=3.0.1
-gradlePluginsVersion=1.40.6
+gradlePluginsVersion=1.41.1
 owaspDependencyCheckPluginVersion=5.2.1
 versioningPluginVersion=1.1.2
 


### PR DESCRIPTION
#### Rationale
Update to the new plugin to avoid looking for artifacts associated with feature branches that don't exist in that repo

#### Changes
* Use the newest LabKey Gradle plugin release