### PR TITLE
bump tomcat jdbc connection pool from 20 to 50

### DIFF
--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -155,7 +155,7 @@ public class LabKeyServer
                     dataSourceResource.setProperty("password", props.getPassword().get(i));
                     dataSourceResource.setProperty("username", props.getUsername().get(i));
                     // TODO : 8021 move this properties to application.properties
-                    dataSourceResource.setProperty("maxTotal", "20");
+                    dataSourceResource.setProperty("maxTotal", "50");
                     dataSourceResource.setProperty("maxIdle", "10");
                     dataSourceResource.setProperty("maxWaitMillis", "120000");
                     dataSourceResource.setProperty("accessToUnderlyingConnectionAllowed", "true");


### PR DESCRIPTION
#### Rationale
default tomcat connection pool is sized at 20. 
Recommended LabKey setting is 50. 


#### Changes
* Updated dataSourceResource.setProperty("maxTotal") value from 20 to 50 to allow for improved LKSM DB performance. 
