### PR TITLE
Suppress false positive CVE match on Apache MINA SSHD library

### DIFF
--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -224,4 +224,13 @@
         <cve>CVE-2023-34623</cve>
     </suppress>
 
+    <!-- False positive. We're using MINA Core. The vulnerability is in MINA's SSHD-Core, which we don't use. -->
+    <suppress>
+        <notes><![CDATA[
+   file name: mina-core-2.2.1.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.mina/mina\-core@.*$</packageUrl>
+        <cve>CVE-2023-35887</cve>
+    </suppress>
+
 </suppressions>


### PR DESCRIPTION
#### Rationale
Our dependency checker is incorrectly matching MINA Core with MINA SSHD Core

#### Changes
* Suppress single CVE false positive