### PR TITLE
Avoid NPE in embedded tomcat startup

### DIFF
--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -160,30 +160,36 @@ public class LabKeyServer
                     dataSourceResource.setProperty("password", props.getPassword().get(i));
                     dataSourceResource.setProperty("username", props.getUsername().get(i));
 
-                    String maxTotal = props.getMaxTotal().get(i);
-                    maxTotal = maxTotal != null ? maxTotal.trim() : MAX_TOTAL_CONNECTIONS_DEFAULT;
+                    String maxTotal = getOptionalProperty(props.getMaxTotal(), i, MAX_TOTAL_CONNECTIONS_DEFAULT);
                     dataSourceResource.setProperty("maxTotal", maxTotal);
 
-                    String maxIdle = props.getMaxIdle().get(i);
-                    maxIdle = maxIdle != null ? maxIdle.trim() : MAX_IDLE_DEFAULT;
+                    String maxIdle = getOptionalProperty(props.getMaxIdle(), i, MAX_IDLE_DEFAULT);
                     dataSourceResource.setProperty("maxIdle", maxIdle);
 
-                    String maxWait = props.getMaxWaitMillis().get(i);
-                    maxWait = maxWait != null ? maxWait.trim() : MAX_WAIT_MILLIS_DEFAULT;
+                    String maxWait = getOptionalProperty(props.getMaxWaitMillis(), i, MAX_WAIT_MILLIS_DEFAULT);
                     dataSourceResource.setProperty("maxWaitMillis", maxWait);
 
-                    String allowAccess = props.getAccessToUnderlyingConnectionAllowed().get(i);
-                    allowAccess = allowAccess != null ? allowAccess : ACCESS_TO_CONNECTION_ALLOWED_DEFAULT;
+                    String allowAccess = getOptionalProperty(props.getAccessToUnderlyingConnectionAllowed(), i, ACCESS_TO_CONNECTION_ALLOWED_DEFAULT);
                     dataSourceResource.setProperty("accessToUnderlyingConnectionAllowed", allowAccess);
 
-                    String validationQuery = props.getValidationQuery().get(i);
-                    validationQuery = validationQuery != null ? validationQuery.trim() : VALIDATION_QUERY_DEFAULT;
+                    String validationQuery = getOptionalProperty(props.getValidationQuery(), i, VALIDATION_QUERY_DEFAULT);
                     dataSourceResource.setProperty("validationQuery", validationQuery);
 
                     dataSourceResources.add(dataSourceResource);
                 }
 
                 return  dataSourceResources;
+            }
+
+            private static String getOptionalProperty(List<String> propList, int i, String defaultValue)
+            {
+                String value = null;
+                if (propList != null && propList.size() > i)
+                {
+                    value = propList.get(i);
+                }
+
+                return value != null ? value : defaultValue;
             }
 
             private ContextResource getMailResource()


### PR DESCRIPTION
#### Rationale
Seeing startup errors on our embedded container builds:
```
java.lang.NullPointerException: Cannot invoke "java.util.List.get(int)" because the return value of "org.labkey.embedded.LabKeyServer$ContextProperties.getMaxTotal()" is null
     at org.labkey.embedded.LabKeyServer$1.getDataSourceResources(LabKeyServer.java:163) ~[classes!/:na]
     at org.labkey.embedded.LabKeyServer$1.getTomcatWebServer(LabKeyServer.java:111) ~[classes!/:na]
     at org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory.getWebServer(TomcatServletWebServerFactory.java:211) ~[spring-boot-2.7.13.jar!/:2.7.13]
     at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.createWebServer(ServletWebServerApplicationContext.java:184) ~[spring-boot-2.7.13.jar!/:2.7.13]
     at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.onRefresh(ServletWebServerApplicationContext.java:162) ~[spring-boot-2.7.13.jar!/:2.7.13]
```

#### Related Pull Requests
* #529

#### Changes
* Avoid NPE when fetching connection properties
