### PR TITLE
Bump HTSJDK and Picard versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -217,7 +217,7 @@ allprojects {
                     force "xalan:xalan:${xalanVersion}"
                     // genotyping brings in a much older version of this, so we force a newer version for compatibility
                     force "org.apache.commons:commons-compress:${commonsCompressVersion}"
-                    // Transitive dependency of commons-compress -- Transitive dependency com.github.samtools:htsjdk:2.14.3 uses much older version
+                    // Transitive dependency of commons-compress -- Transitive dependency com.github.samtools:htsjdk which references an older version
                     force "org.tukaani:xz:${tukaaniXZVersion}"
                     // force version for api, LDK, pipeline, query, saml, but not for the xsdDoc configuration, which requires
                     // an older version for the docflex library we use
@@ -225,6 +225,8 @@ allprojects {
                         force "xml-apis:xml-apis:${xmlApisVersion}"
                     // cloud and SequenceAnalysis bring this in as a transitive dependency. We resolve to the later version here to keep things consistent
                     force "com.google.code.gson:gson:${gsonVersion}"
+                    // Google oauth2-http Library and api-common (via Picard) bring in different versions; force the latest
+                    force "com.google.auto.value:auto-value-annotations:${googleAutoValueAnnotationsVersion}"
                     // Google HTTP Client Library and Guava bring in different versions; force the latest
                     force "com.google.errorprone:error_prone_annotations:${googleErrorProneAnnotationsVersion}"
                     // different google APIs bring in different versions; force the latest
@@ -236,8 +238,6 @@ allprojects {
                     force "com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}"
                     // The version of picard we depend on brings in an older version of htsjdk, but SequenceAnalysis depends on a later version
                     force "com.github.samtools:htsjdk:${htsjdkVersion}"
-                    // This is a dependency for HTSJDK. Force to avoid a deserialization problem. Remove once HTSJDK bumps its preferred version
-                    force "org.xerial.snappy:snappy-java:${snappyJavaVersion}"
                     // Cloud module brings in earlier versions of this library, so we force the later one
                     force "org.apache.tika:tika-core:${tikaVersion}"
                     // OpenLDAPSync and premium have transitive dependency on a broken version of MINA

--- a/build.gradle
+++ b/build.gradle
@@ -225,12 +225,14 @@ allprojects {
                         force "xml-apis:xml-apis:${xmlApisVersion}"
                     // cloud and SequenceAnalysis bring this in as a transitive dependency. We resolve to the later version here to keep things consistent
                     force "com.google.code.gson:gson:${gsonVersion}"
-                    // Google oauth2-http Library and api-common (via Picard) bring in different versions; force the latest
+
+                    // Google oauth2-http Library and api-common (via Picard, and perhaps others) bring in different versions; force the latest
                     force "com.google.auto.value:auto-value-annotations:${googleAutoValueAnnotationsVersion}"
+                    force "com.google.http-client:google-http-client-apache-v2:${googleHttpClientVersion}"
+                    force "com.google.http-client:google-http-client-gson:${googleHttpClientVersion}"
+
                     // Google HTTP Client Library and Guava bring in different versions; force the latest
                     force "com.google.errorprone:error_prone_annotations:${googleErrorProneAnnotationsVersion}"
-                    // different google APIs bring in different versions; force the latest
-                    force "com.google.http-client:google-http-client-gson:${googleHttpClientGsonVersion}"
                     // Force patched version of GPRC, dependency of a number of Google service APIs in WNPRC and fileTransfer
                     force "io.grpc:grpc-context:${grpcVersion}"
                     // workflow (Activiti) brings in older versions of these libraries, so we need to force these versions

--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -205,16 +205,6 @@
         <vulnerabilityName>CVE-2023-35116</vulnerabilityName>
     </suppress>
 
-    <!-- No patched version of mjson available (the code hasn't changed in 3+ years). Checking uses in HTSJDK, which
-    pulls it in, it's only used for tests or to parse the results of an HTTP connection that HTSJDK initiates. -->
-    <suppress>
-        <notes><![CDATA[
-   file name: mjson-1.4.1.jar
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.sharegov/mjson@.*$</packageUrl>
-        <vulnerabilityName>CVE-2023-34611</vulnerabilityName>
-    </suppress>
-
     <!-- False positive. We're using MINA Core. The vulnerability is in MINA's SSHD-Core, which we don't use. -->
     <suppress>
         <notes><![CDATA[

--- a/gradle.properties
+++ b/gradle.properties
@@ -151,11 +151,12 @@ flyingsaucerVersion=R8
 fopVersion=2.8
 
 # Force latest for consistency
+googleAutoValueAnnotationsVersion=1.10.2
 googleErrorProneAnnotationsVersion=2.19.1
 googleHttpClientGsonVersion=1.43.2
-googleHttpClientVersion=1.43.2
+googleHttpClientVersion=1.43.3
 googleOauthClientVersion=1.34.1
-googleProtocolBufVersion=3.21.9
+googleProtocolBufVersion=3.23.2
 
 graalVersion=23.0.1
 
@@ -272,9 +273,6 @@ servletApiVersion=4.0.1
 slf4jLog4j12Version=2.0.7
 # this version is forced for compatibility with api, LDK, and workflow
 slf4jLog4jApiVersion=2.0.7
-
-# This is a dependency for HTSJDK. Force to avoid a deserialization problem. Remove once HTSJDK bumps its preferred version
-snappyJavaVersion=1.1.10.1
 
 springBootVersion=2.7.13
 # This MUST match the Tomcat version dictated by springBootVersion

--- a/gradle.properties
+++ b/gradle.properties
@@ -153,7 +153,6 @@ fopVersion=2.8
 # Force latest for consistency
 googleAutoValueAnnotationsVersion=1.10.2
 googleErrorProneAnnotationsVersion=2.19.1
-googleHttpClientGsonVersion=1.43.2
 googleHttpClientVersion=1.43.3
 googleOauthClientVersion=1.34.1
 googleProtocolBufVersion=3.23.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -176,7 +176,7 @@ gwtBrowser=gwt-user-chrome
 hamcrestVersion=1.3
 
 # Note: if changing this, we might need to match with the picard version in the SequenceAnalysis module build.gradle
-htsjdkVersion=3.0.1
+htsjdkVersion=4.0.0
 
 httpclient5Version=5.2.1
 httpcore5Version=5.2.1


### PR DESCRIPTION
#### Rationale
There's a new HTSJDK version. Among other updates, it no longer depends on MJSON.

#### Changes
* Update to the latest HTSJDK
* Drop the suppression on the now-defunct MJSON dependency