### PR TITLE
Issue 48426: Complaints from embedded Tomcat about work directory

### DIFF
--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -30,6 +30,7 @@ context.validationQuery[0]=SELECT 1
 #context.webAppLocation=@@pathToServer@@/build/deploy/labkeyWebapp
 context.encryptionKey=@@encryptionKey@@
 #context.serverGUID=
+#context.workDirLocation=/path/to/desired/workDir
 
 mail.smtpHost=@@smtpHost@@
 mail.smtpPort=@@smtpPort@@

--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -105,6 +105,13 @@ public class LabKeyServer
                     // tomcat requires a unique context path other than root here
                     // can not set context path as "" because em tomcat complains "Child name [] is not unique"
                     StandardContext context = (StandardContext) tomcat.addWebapp("/labkey", webAppLocation);
+
+                    // Issue 48426: Allow config for desired work directory
+                    if (contextProperties.getWorkDirLocation() != null)
+                    {
+                        context.setWorkDir(contextProperties.getWorkDirLocation());
+                    }
+
                     // set the root path to the context explicitly
                     context.setPath("");
 
@@ -349,6 +356,7 @@ public class LabKeyServer
         private List<String> driverClassName;
 
         private String webAppLocation;
+        private String workDirLocation;
         @NotNull (message = "Must provide encryptionKey")
         private String encryptionKey;
         private String serverGUID;
@@ -416,6 +424,16 @@ public class LabKeyServer
         public void setWebAppLocation(String webAppLocation)
         {
             this.webAppLocation = webAppLocation;
+        }
+
+        public String getWorkDirLocation()
+        {
+            return workDirLocation;
+        }
+
+        public void setWorkDirLocation(String workDirLocation)
+        {
+            this.workDirLocation = workDirLocation;
         }
 
         public String getEncryptionKey()


### PR DESCRIPTION
#### Rationale
Embedded Tomcat is choosing a work directory at a path that isn't available on cloud instances. Add a way to configure it.

#### Changes
* Support for a new `context.workDirLocation` property to override defaults