### PR TITLE
Backport upgraded grpc version to 23.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -231,6 +231,21 @@ allprojects {
                     force "com.google.http-client:google-http-client-gson:${googleHttpClientGsonVersion}"
                     // Force patched version of GPRC, dependency of a number of Google service APIs in WNPRC and fileTransfer
                     force "io.grpc:grpc-context:${grpcVersion}"
+
+                    // TODO Remove these when the Picard version brought in by the SequenceAnalysis module is upgraded to use a version >=1.57.2
+                    force "io.grpc:grpc-alts:${grpcVersion}"
+                    force "io.grpc:grpc-auth:${grpcVersion}"
+                    force "io.grpc:grpc-core:${grpcVersion}"
+                    force "io.grpc:grpc-googleapis:${grpcVersion}"
+                    force "io.grpc:grpc-grpclb:${grpcVersion}"
+                    force "io.grpc:grpc-netty-shaded:${grpcVersion}"
+                    force "io.grpc:grpc-protobuf:${grpcVersion}"
+                    force "io.grpc:grpc-protobuf-lite:${grpcVersion}"
+                    force "io.grpc:grpc-rls:${grpcVersion}"
+                    force "io.grpc:grpc-services:${grpcVersion}"
+                    force "io.grpc:grpc-stub:${grpcVersion}"
+                    force "io.grpc:grpc-xds:${grpcVersion}"
+
                     // workflow (Activiti) brings in older versions of these libraries, so we need to force these versions
                     force "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
                     force "com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -165,7 +165,7 @@ graalVersion=23.0.1
 # "java.lang.NoSuchMethodError: 'void com.google.gson.internal.ConstructorConstructor.<init>(java.util.Map)'" errors
 gsonVersion=2.8.9
 
-grpcVersion=1.56.0
+grpcVersion=1.57.2
 
 guavaVersion=32.0.1-jre
 gwtVersion=2.10.0


### PR DESCRIPTION
#### Rationale
https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Premium_InternalSuites_OwaspDependencyCheck/2592993?buildTab=overview&hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildTestsSection=true&expandBuildChangesSection=true#%2FdependencyCheck.tar.gz

#### Related
* develop: https://github.com/LabKey/server/pull/550

#### Changes
* Cherry picked changes from https://github.com/LabKey/server/pull/550
