### PR TITLE
Postgres 21469

### DIFF
--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -255,4 +255,15 @@
         <cve>CVE-2023-39017</cve>
         <cpe>cpe:/a:softwareag:quartz</cpe>
     </suppress>
+
+    <!--
+    The CVE has a low impact (DDOS) and targets older versions of Postgres (<= v12.2)
+    -->
+    <suppress>
+        <notes><![CDATA[
+   file name: postgresql-42.6.0.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.postgresql/postgresql@.*$</packageUrl>
+        <vulnerabilityName>CVE-2020-21469</vulnerabilityName>
+    </suppress>
 </suppressions>

--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -257,7 +257,7 @@
     </suppress>
 
     <!--
-    The CVE has a low impact (DDOS) and targets older versions of Postgres (<= v12.2)
+    The CVE has a low impact (DDOS) and targets older versions of Postgres (<= v12.2), not the JDBC driver itself.
     -->
     <suppress>
         <notes><![CDATA[


### PR DESCRIPTION
#### Rationale
https://teamcity.labkey.org/viewLog.html?buildId=2600232&buildTypeId=LabKey_Trunk_Premium_InternalSuites_OwaspDependencyCheck&tab=buildResultsDiv&branch_LabKey_Trunk_Premium_InternalSuites=%3Cdefault%3E

Postgres 12.2 allows a potential DDOS attack. Newer versions are not susceptible. Notice is triggered by the jdbc driver which isn't directly susceptible.

#### Changes
Added CVE to supression since we already recommend and deploy newer versions of Postgres