### PR TITLE
Issue 48565: allow for JSON-formatted access logs in embedded tomcat

### DIFF
--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -57,3 +57,14 @@ management.endpoints.web.exposure.include=*
 
 # Don't show the Spring banner on startup
 spring.main.banner-mode=off
+
+
+# Turn on JSON-formatted HTTP access logging to stdout. See issue 48565
+# https://tomcat.apache.org/tomcat-9.0-doc/config/valve.html#JSON_Access_Log_Valve
+#jsonaccesslog.enabled=true
+
+# Optional configuration, modeled on the non-JSON Spring Boot properties
+# https://docs.spring.io/spring-boot/docs/current/reference/html/application-properties.html#application-properties.server.server.tomcat.accesslog.buffered
+#jsonaccesslog.pattern=%h %t %m %U %s %b %D %S "%{Referer}i" "%{User-Agent}i" %{LABKEY.username}s
+#jsonaccesslog.condition-if=attributeName
+#jsonaccesslog.condition-unless=attributeName

--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -3,6 +3,7 @@ package org.labkey.embedded;
 import org.apache.catalina.core.StandardContext;
 import org.apache.catalina.loader.WebappLoader;
 import org.apache.catalina.startup.Tomcat;
+import org.apache.catalina.valves.JsonAccessLogValve;
 import org.apache.tomcat.util.descriptor.web.ContextResource;
 import org.labkey.bootstrap.ConfigException;
 import org.springframework.boot.SpringApplication;
@@ -73,6 +74,16 @@ public class LabKeyServer
             @Override
             protected TomcatWebServer getTomcatWebServer(Tomcat tomcat)
             {
+                var v = new JsonAccessLogValve();
+                v.setPrefix("stdout");
+                v.setDirectory("/dev");
+                v.setBuffered(false);
+                v.setContainer(tomcat.getHost());
+                v.setSuffix("");
+                v.setFileDateFormat("");
+                v.setPattern("%h %l %u %t \"%r\" %s %b");
+                tomcat.getEngine().getPipeline().addValve(v);
+
                 tomcat.enableNaming();
 
                 // Get the context properties from Spring injection
@@ -135,6 +146,7 @@ public class LabKeyServer
                     loader.setLoaderClass(LabKeySpringBootClassLoader.class.getName());
                     context.setLoader(loader);
                     context.setParentClassLoader(this.getClass().getClassLoader());
+
                 }
                 catch (ConfigException e)
                 {


### PR DESCRIPTION
#### Rationale
We want to use JSON-structured HTTP logging to stdout for our containerized deployments. Spring Boot/embedded Tomcat don't support that with their own config today.

#### Changes
* Support four new `application.properties` values to configure JSON HTTP access logging
* Pipe values into Tomcat's config