### PR TITLE
Checker fixes

### DIFF
--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -249,7 +249,7 @@
     </suppress>
 
     <!--
-    Looks like because Netty doesn't turn on cert checking by default this gets flagged periodically. per the discussion
+    Netty doesn't turn on cert checking by default, so this gets flagged periodically. per the linked discussion
     this should be handled/enabled when configuring the client to use https.
      For more info see: https://github.com/jeremylong/DependencyCheck/issues/5912#issuecomment-1699363391 and the subsequent rabbit-hole.
     -->

--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -247,4 +247,29 @@
         <packageUrl regex="true">^pkg:maven/org\.postgresql/postgresql@.*$</packageUrl>
         <vulnerabilityName>CVE-2020-21469</vulnerabilityName>
     </suppress>
+
+    <!--
+    Looks like because Netty doesn't turn on cert checking by default this gets flagged periodically. per the discussion
+    this should be handled/enabled when configuring the client to use https.
+     For more info see: https://github.com/jeremylong/DependencyCheck/issues/5912#issuecomment-1699363391 and the subsequent rabbit-hole.
+    -->
+    <suppress>
+        <notes><![CDATA[
+   file name: netty-handler-4.1.94.Final.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-handler@.*$</packageUrl>
+        <vulnerabilityName>CVE-2023-4586</vulnerabilityName>
+    </suppress>
+
+    <!--
+    Faulted immport module is archived. Can be remediated by forcing to an `okio` version >= 3.5.0 or corresponding version
+     of `commons-vfs` which brings it in.
+    -->
+    <suppress>
+        <notes><![CDATA[
+   file name: okio-jvm-2.8.0.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.squareup\.okio/okio@.*$</packageUrl>
+        <cve>CVE-2023-3635</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
#### Rationale
https://teamcity.labkey.org/viewLog.html?buildId=2612120&buildTypeId=LabKey_Trunk_Premium_InternalSuites_OwaspDependencyCheck&tab=buildLog&branch_LabKey_Trunk_Premium_InternalSuites=%3Cdefault%3E

Suppressing two CVE's 1 as a false positive per linked discussion. And other as it is triggered by an archived (read-only) module.

#### Changes
* Added suppression nodes to dependency xml.
