### PR TITLE
Backport supression of netty CVE

### DIFF
--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -255,4 +255,17 @@
         <cve>CVE-2023-39017</cve>
         <cpe>cpe:/a:softwareag:quartz</cpe>
     </suppress>
+
+    <!--
+    Netty doesn't turn on cert checking by default, so this gets flagged periodically. per the linked discussion
+    this should be handled/enabled when configuring the client to use https.
+     For more info see: https://github.com/jeremylong/DependencyCheck/issues/5912#issuecomment-1699363391 and the subsequent rabbit-hole.
+    -->
+    <suppress>
+        <notes><![CDATA[
+   file name: netty-handler-4.1.94.Final.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-handler@.*$</packageUrl>
+        <vulnerabilityName>CVE-2023-4586</vulnerabilityName>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
#### Rationale
23.7 is still active.

#### Related Pull Requests
* #561 

#### Changes
* Suppress warning for CVE-2023-4586
