### PR TITLE
Indexed document loggers should be info level by default

### DIFF
--- a/webapps/log4j2.xml
+++ b/webapps/log4j2.xml
@@ -259,7 +259,7 @@
             <AppenderRef ref="LABKEYMemory"/>
         </Logger>
 
-        <Logger name="org.labkey.api.search.SearchService$SearchCategory" additivity="false" level="debug">
+        <Logger name="org.labkey.api.search.SearchService$SearchCategory" additivity="false" level="info">
             <AppenderRef ref="INDEXED_DOCUMENTS"/>
         </Logger>
 


### PR DESCRIPTION
#### Rationale
I didn't mean to log every indexed document. Switch to `INFO` level by default.