### PR TITLE
force snappy java to 1.1.10.4 for CVE-2023-43642

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -304,7 +304,7 @@ allprojects {
                     // Force consistency between pipeline's ActiveMQ  and cloud's jClouds dependencies
                     force "javax.annotation:javax.annotation-api:${javaxAnnotationVersion}"
 
-                    // Force snappy-java version for CVE-2023-43642
+                    // Force snappy-java version for CVE-2023-43642. Remove once HTSJDK bumps its preferred version.
                     force "org.xerial.snappy:snappy-java:${snappyJavaVersion}"
 
                     dependencySubstitution {

--- a/build.gradle
+++ b/build.gradle
@@ -304,6 +304,9 @@ allprojects {
                     // Force consistency between pipeline's ActiveMQ  and cloud's jClouds dependencies
                     force "javax.annotation:javax.annotation-api:${javaxAnnotationVersion}"
 
+                    // Force snappy-java version for CVE-2023-43642
+                    force "org.xerial.snappy:snappy-java:${snappyJavaVersion}"
+
                     dependencySubstitution {
                         // Because the client api artifact name is not the same as the directory structure, we use
                         // Gradle's dependency substitution so the dependency will appear correctly in the pom files that

--- a/gradle.properties
+++ b/gradle.properties
@@ -279,6 +279,9 @@ slf4jLog4j12Version=2.0.7
 # this version is forced for compatibility with api, LDK, and workflow
 slf4jLog4jApiVersion=2.0.7
 
+# Force snappy-java version for CVE-2023-43642
+snappyJavaVersion=1.1.10.4
+
 springBootVersion=2.7.16
 # This MUST match the Tomcat version dictated by springBootVersion
 # Also, keep this in sync with apacheTomcatVersion above
@@ -316,6 +319,3 @@ xmlApisVersion=1.0.b2
 
 # sync with Tika/POI
 xmlbeansVersion=5.1.1
-
-# Force snappy-java version for CVE-2023-43642
-snappyJavaVersion=1.1.10.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -316,3 +316,6 @@ xmlApisVersion=1.0.b2
 
 # sync with Tika/POI
 xmlbeansVersion=5.1.1
+
+# Force snappy-java version for CVE-2023-43642
+snappyJavaVersion=1.1.10.4


### PR DESCRIPTION
#### Rationale
this forces snappy-java to the patched version

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
