### PR TITLE
force snappy-java version for CVE-2023-43642 for 23.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -251,7 +251,7 @@ allprojects {
                     force "com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}"
                     // The version of picard we depend on brings in an older version of htsjdk, but SequenceAnalysis depends on a later version
                     force "com.github.samtools:htsjdk:${htsjdkVersion}"
-                    // This is a dependency for HTSJDK. Force to avoid a deserialization problem. Remove once HTSJDK bumps its preferred version
+                    // This is a dependency for HTSJDK. Force to avoid a deserialization problem. Remove once HTSJDK bumps its preferred version.
                     force "org.xerial.snappy:snappy-java:${snappyJavaVersion}"
                     // Cloud module brings in earlier versions of this library, so we force the later one
                     force "org.apache.tika:tika-core:${tikaVersion}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -274,7 +274,7 @@ slf4jLog4j12Version=2.0.7
 slf4jLog4jApiVersion=2.0.7
 
 # This is a dependency for HTSJDK. Force to avoid a deserialization problem. Remove once HTSJDK bumps its preferred version
-snappyJavaVersion=1.1.10.1
+snappyJavaVersion=1.1.10.4
 
 springBootVersion=2.7.16
 # This MUST match the Tomcat version dictated by springBootVersion


### PR DESCRIPTION
#### Rationale

this forces snappy-java to the patched version, for 23.7

the "." added to the build.gradle comment is just to ensure this gets noticed in a merge conflict and re-added to 23.10 and develop.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
