### PR TITLE
force netty to 4.1.100.Final for CVE-2023-4586

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -237,7 +237,7 @@ mysqlDriverVersion=8.0.33
 mssqlJdbcVersion=12.2.0.jre11
 
 # forced compatibility between docker and UserReg-WS
-nettyVersion=4.1.94.Final
+nettyVersion=4.1.100.Final
 
 objenesisVersion=1.0
 


### PR DESCRIPTION
#### Rationale
force netty to 4.1.100.Final for CVE-2023-4586

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
