### PR TITLE
Issue 48868: Change Encryption Key doesn't work with embedded Tomcat

### DIFF
--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -29,9 +29,9 @@ context.validationQuery[0]=SELECT 1
 
 #context.webAppLocation=@@pathToServer@@/build/deploy/labkeyWebapp
 context.encryptionKey=@@encryptionKey@@
-context.oldEncryptionKey=oldKey
-context.requiredModules=rM
-context.pipelineConfig=pC
+#context.oldEncryptionKey=
+#context.requiredModules=
+#context.pipelineConfig=/path/to/pipeline/config/dir
 #context.serverGUID=
 #context.workDirLocation=/path/to/desired/workDir
 

--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -29,6 +29,9 @@ context.validationQuery[0]=SELECT 1
 
 #context.webAppLocation=@@pathToServer@@/build/deploy/labkeyWebapp
 context.encryptionKey=@@encryptionKey@@
+context.oldEncryptionKey=oldKey
+context.requiredModules=rM
+context.pipelineConfig=pC
 #context.serverGUID=
 #context.workDirLocation=/path/to/desired/workDir
 

--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -129,6 +129,19 @@ public class LabKeyServer
 
                     // And the master encryption key
                     context.addParameter("EncryptionKey", contextProperties.getEncryptionKey());
+                    if (contextProperties.getOldEncryptionKey() != null)
+                    {
+                        context.addParameter("OldEncryptionKey", contextProperties.getOldEncryptionKey());
+                    }
+
+                    if (contextProperties.getRequiredModules() != null)
+                    {
+                        context.addParameter("requiredModules", contextProperties.getRequiredModules());
+                    }
+                    if (contextProperties.getPipelineConfig() != null)
+                    {
+                        context.addParameter("org.labkey.api.pipeline.config", contextProperties.getPipelineConfig());
+                    }
 
                     // Add serverGUID for mothership - it tells mothership that 2 instances of a server should be considered the same for metrics gathering purposes.
                     if (null != contextProperties.getServerGUID())
@@ -442,6 +455,9 @@ public class LabKeyServer
         private String workDirLocation;
         @NotNull (message = "Must provide encryptionKey")
         private String encryptionKey;
+        private String oldEncryptionKey;
+        private String pipelineConfig;
+        private String requiredModules;
         private String serverGUID;
         private Map<Integer, String> maxTotal;
         private Map<Integer, String> maxIdle;
@@ -527,6 +543,36 @@ public class LabKeyServer
         public void setEncryptionKey(String encryptionKey)
         {
             this.encryptionKey = encryptionKey;
+        }
+
+        public String getOldEncryptionKey()
+        {
+            return oldEncryptionKey;
+        }
+
+        public void setOldEncryptionKey(String oldEncryptionKey)
+        {
+            this.oldEncryptionKey = oldEncryptionKey;
+        }
+
+        public String getPipelineConfig()
+        {
+            return pipelineConfig;
+        }
+
+        public void setPipelineConfig(String pipelineConfig)
+        {
+            this.pipelineConfig = pipelineConfig;
+        }
+
+        public String getRequiredModules()
+        {
+            return requiredModules;
+        }
+
+        public void setRequiredModules(String requiredModules)
+        {
+            this.requiredModules = requiredModules;
         }
 
         public String getServerGUID()


### PR DESCRIPTION
#### Rationale
We need to pipe through each parameter from the embedded Tomcat configuration into its equivalent spot in the server context

#### Changes
* Propagate `context.oldEncryptionKey` and a couple of other, unrelated parameters we haven't yet added
* Add to the `application.properties` template