### PR TITLE
Only use hitachivantara maven repository for relevant artifacts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -163,6 +163,7 @@ allprojects {
                             includeGroup "org.pentaho"
                             includeGroup "org.olap4j"
                             includeGroup "javacup"
+                        }
                     }
                 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,8 @@ import org.labkey.gradle.task.PurgeNpmAlphaVersions
 import org.labkey.gradle.task.ShowDiscrepancies
 import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.GroupNames
+import org.labkey.gradle.plugin.NpmRun
+import org.labkey.gradle.task.PurgeNpmAlphaVersions
 
 plugins {
     id "com.jfrog.artifactory" version "${artifactoryPluginVersion}" apply false

--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,6 @@ import org.labkey.gradle.task.PurgeNpmAlphaVersions
 import org.labkey.gradle.task.ShowDiscrepancies
 import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.GroupNames
-import org.labkey.gradle.plugin.NpmRun
-import org.labkey.gradle.task.PurgeNpmAlphaVersions
 
 plugins {
     id "com.jfrog.artifactory" version "${artifactoryPluginVersion}" apply false
@@ -157,10 +155,12 @@ allprojects {
                     maven {
                         // Mondrian dependencies are available via this repository. It's a direct dependency of the Query
                         // module but is declared here as many modules depend on Query and therefore need it as well.
-                    	url "https://repo.orl.eng.hitachivantara.com/artifactory/pnt-mvn"
+                        url "https://repo.orl.eng.hitachivantara.com/artifactory/pnt-mvn"
                         content {
-                            excludeGroupByRegex "org\\.labkey.*"
-                        }
+                            includeGroup "pentaho"
+                            includeGroup "org.pentaho"
+                            includeGroup "org.olap4j"
+                            includeGroup "javacup"
                     }
                 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -163,6 +163,7 @@ allprojects {
                             includeGroup "org.pentaho"
                             includeGroup "org.olap4j"
                             includeGroup "javacup"
+                            includeGroup "eigenbase"
                         }
                     }
                 }


### PR DESCRIPTION
#### Rationale
Builds occasionally fail when attempting to get nodejs from the wrong repository.
```
08:39:04              > Could not resolve org.nodejs:node:16.19.1.
08:39:04                 > Could not get resource 'https://repo.orl.eng.hitachivantara.com/artifactory/pnt-mvn/org/nodejs/node/16.19.1/node-16.19.1.pom'.
08:39:04                    > Could not GET 'https://repo.orl.eng.hitachivantara.com/artifactory/pnt-mvn/org/nodejs/node/16.19.1/node-16.19.1.pom'.
08:39:04                       > Read timed out
```

#### Related Pull Requests
* N/A

#### Changes
* Only check hitachivantara maven repository for particular artifacts
