### PR TITLE
Update NodeJS/NPM

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -70,7 +70,7 @@ versioningPluginVersion=1.1.2
 # will be downloaded and used. If not set, the existing local installations will be used
 # The version of npm corresponds to the given version of node
 npmVersion=8.19.3
-nodeVersion=16.19.0
+nodeVersion=18.16.0
 nodeRepo=https://nodejs.org/dist
 # Directory in a project's build directory where the node binary will be placed
 nodeWorkDirectory=.node

--- a/gradle.properties
+++ b/gradle.properties
@@ -70,7 +70,7 @@ versioningPluginVersion=1.1.2
 # will be downloaded and used. If not set, the existing local installations will be used
 # The version of npm corresponds to the given version of node
 npmVersion=8.19.3
-nodeVersion=16.19.1
+nodeVersion=18.13.0
 nodeRepo=https://nodejs.org/dist
 # Directory in a project's build directory where the node binary will be placed
 nodeWorkDirectory=.node

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,7 @@ org.gradle.workers.max=3
 org.gradle.jvmargs=-Xmx2048m -XX:+UseParallelGC
 # Uncomment to restrict the number of concurrent npm build tasks. Useful for systems with limited resources.
 #npmRunLimit=2
+#touch
 
 # Set the action to be performed when a version conflict between a dependency included from the build and one that already exists
 # is detected. Default behavior on detecting a conflict is to fail. Possible values are delete, fail, warn.

--- a/gradle.properties
+++ b/gradle.properties
@@ -69,7 +69,7 @@ versioningPluginVersion=1.1.2
 # Versions of node and npm to use during the build. If set, these versions
 # will be downloaded and used. If not set, the existing local installations will be used
 # The version of npm corresponds to the given version of node
-npmVersion=8.19.3
+npmVersion=9.5.1
 nodeVersion=18.16.0
 nodeRepo=https://nodejs.org/dist
 # Directory in a project's build directory where the node binary will be placed

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,6 @@ org.gradle.workers.max=3
 org.gradle.jvmargs=-Xmx2048m -XX:+UseParallelGC
 # Uncomment to restrict the number of concurrent npm build tasks. Useful for systems with limited resources.
 #npmRunLimit=2
-#touch
 
 # Set the action to be performed when a version conflict between a dependency included from the build and one that already exists
 # is detected. Default behavior on detecting a conflict is to fail. Possible values are delete, fail, warn.

--- a/gradle.properties
+++ b/gradle.properties
@@ -70,7 +70,7 @@ versioningPluginVersion=1.1.2
 # will be downloaded and used. If not set, the existing local installations will be used
 # The version of npm corresponds to the given version of node
 npmVersion=8.19.3
-nodeVersion=18.13.0
+nodeVersion=16.19.0
 nodeRepo=https://nodejs.org/dist
 # Directory in a project's build directory where the node binary will be placed
 nodeWorkDirectory=.node

--- a/gradle.properties
+++ b/gradle.properties
@@ -69,8 +69,8 @@ versioningPluginVersion=1.1.2
 # Versions of node and npm to use during the build. If set, these versions
 # will be downloaded and used. If not set, the existing local installations will be used
 # The version of npm corresponds to the given version of node
-npmVersion=9.5.1
-nodeVersion=18.16.0
+npmVersion=9.8.1
+nodeVersion=18.18.1
 nodeRepo=https://nodejs.org/dist
 # Directory in a project's build directory where the node binary will be placed
 nodeWorkDirectory=.node


### PR DESCRIPTION
#### Rationale
This updates our versions of NodeJS to the latest LTS releases. Our current version of NodeJS `v16+` reached it's EOL for support on 9/11/23. The following versions have been determined based on their pairing in [previous releases](https://nodejs.org/en/download/releases).

- NodeJS: `18.18.1`
- NPM: `9.8.1`

Note, that on 10/18/23 (five days from when I'm writing this) Node `v18+` will enter maintenance LTS. I considered preemptively going to Node `v20+` which will become the active LTS on 10/24/23, however, it seems more stable to move forward with the current LTS for now and we can update to v20 once it matures as the active LTS.

I don't believe we will be able to backport this to v23.07 of LKS due to the package updates involved. I have recently made package updates that make us compatible with `v18+` which are not included in LKS v23.07.

#### Changes
* Bump NodeJS to `v18.18.1`
* Bump NPM to `v9.8.1`
