### PR TITLE
Adopt Tomcat 9.0.82

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -103,7 +103,7 @@ apacheDirectoryVersion=2.1.3
 apacheMinaVersion=2.2.1
 
 # Keep in sync with springBootTomcatVersion below
-apacheTomcatVersion=9.0.80
+apacheTomcatVersion=9.0.82
 
 # (mothership) -> json-path -> json-smart -> accessor-smart
 # (core) -> graalvm
@@ -285,7 +285,7 @@ snappyJavaVersion=1.1.10.4
 springBootVersion=2.7.16
 # This MUST match the Tomcat version dictated by springBootVersion
 # Also, keep this in sync with apacheTomcatVersion above
-springBootTomcatVersion=9.0.80
+springBootTomcatVersion=9.0.82
 
 springVersion=5.3.28
 

--- a/server/embedded/build.gradle
+++ b/server/embedded/build.gradle
@@ -31,7 +31,38 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-web:${springBootVersion}"
     implementation "org.springframework.boot:spring-boot-starter-actuator:${springBootVersion}"
     implementation "org.springframework.boot:spring-boot-starter-validation:${springBootVersion}"
-    
+
+    // Force to the latest Tomcat version until Spring Boot 2.7.17 is released and we can adopt it
+    implementation('org.apache.tomcat.embed:tomcat-embed-core') {
+        version {
+            strictly "${springBootTomcatVersion}"
+        }
+    }
+    implementation('org.apache.tomcat.embed:tomcat-embed-el') {
+        version {
+            strictly "${springBootTomcatVersion}"
+        }
+    }
+    implementation('org.apache.tomcat.embed:tomcat-embed-websocket') {
+        version {
+            strictly "${springBootTomcatVersion}"
+        }
+    }
+    implementation('org.apache.tomcat:tomcat-annotations-api') {
+        version {
+            strictly "${springBootTomcatVersion}"
+        }
+    }
+    implementation('org.apache.tomcat:tomcat-jsp-api') {
+        version {
+            strictly "${springBootTomcatVersion}"
+        }
+    }
+//
+//    force ":${springBootTomcatVersion}"
+//    force "org.apache.tomcat.embed:tomcat-embed-el:"
+//    force "org.apache.tomcat.embed:tomcat-embed-websocket:${springBootTomcatVersion}"
+
     // This is a transitive dependency from spring-boot-starter that we're forcing to pick up CVE hotfixes. We're not
     // vulnerable since we're not accepting untrusted Spring Boot config files, but this cleans up the reporting.
     // At some point Spring Boot should update its preferred version and we can yank this

--- a/server/embedded/build.gradle
+++ b/server/embedded/build.gradle
@@ -58,10 +58,6 @@ dependencies {
             strictly "${springBootTomcatVersion}"
         }
     }
-//
-//    force ":${springBootTomcatVersion}"
-//    force "org.apache.tomcat.embed:tomcat-embed-el:"
-//    force "org.apache.tomcat.embed:tomcat-embed-websocket:${springBootTomcatVersion}"
 
     // This is a transitive dependency from spring-boot-starter that we're forcing to pick up CVE hotfixes. We're not
     // vulnerable since we're not accepting untrusted Spring Boot config files, but this cleans up the reporting.


### PR DESCRIPTION
#### Rationale
There are some bug fixes in the latest Tomcat release that we want to pick up ahead of its adoption in the upcoming Spring Boot 2.7.17. We can back out the forcing to the version when the new Spring Boot is available

#### Changes
* Force to the latest Tomcat