### PR TITLE
bump json-java to 20231013 for CVE-2023-5072

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -222,7 +222,7 @@ jodaTimeVersion=2.8.1
 # brought in transitively from guava and other google packages. Need to resolve consistently
 jsr305Version=3.0.2
 
-orgJsonVersion=20230618
+orgJsonVersion=20231013
 
 jsoupVersion=1.16.1
 


### PR DESCRIPTION
#### Rationale
* bump json-java to 20231013 for CVE-2023-5072
* 
#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
