### PR TITLE
backport json-java upgrade to 20231013 for CVE-2023-5072

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -216,7 +216,7 @@ jodaTimeVersion=2.8.1
 # brought in transitively from guava and other google packages. Need to resolve consistently
 jsr305Version=3.0.2
 
-orgJsonVersion=20230618
+orgJsonVersion=20231013
 
 jtidyVersion=1.0.4
 


### PR DESCRIPTION
#### Rationale
* backport json-java upgrade to 20231013 for CVE-2023-5072

#### Related Pull Requests
* https://github.com/LabKey/commonAssays/pull/658
* https://github.com/LabKey/platform/pull/4842

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
