### PR TITLE
Downgrade sqlite-jdbc to 3.42.0.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -289,7 +289,7 @@ springBootTomcatVersion=9.0.82
 
 springVersion=5.3.30
 
-sqliteJdbcVersion=3.43.2.0
+sqliteJdbcVersion=3.42.0.1
 
 # NLP and SAML bring stax2-api in as a transitive dependency but with very different versions. We force the later version.
 stax2ApiVersion=4.2.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -289,6 +289,7 @@ springBootTomcatVersion=9.0.82
 
 springVersion=5.3.30
 
+# Do not upgrade until BaseDaoImpl stops calling getGeneratedKeys()
 sqliteJdbcVersion=3.42.0.1
 
 # NLP and SAML bring stax2-api in as a transitive dependency but with very different versions. We force the later version.


### PR DESCRIPTION
#### Rationale
sqlite-jdbc v3.43.0.0 removed support for `Statement.getGeneratedKeys()` claiming it's unreliable, https://github.com/xerial/sqlite-jdbc/releases/tag/3.43.0.0. TargetedMS class `BaseDaoImpl` calls this method so many tests failed after I attempted an upgrade to the latest. For now I'm downgrading to 3.42.0.1, the last version that included support for this method. I haven't investigated alternatives, such as adding `RETURNING` to the `INSERT` queries. I'll add comments to discourage upgrading this dependency in the future. @vagisha FYI

#### Related Pull Requests
* https://github.com/LabKey/server/pull/595