### PR TITLE
Adopt the latest Spring Boot and Tomcat releases

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -100,7 +100,7 @@ apacheDirectoryVersion=2.1.3
 apacheMinaVersion=2.2.1
 
 # Keep in sync with springBootTomcatVersion below
-apacheTomcatVersion=9.0.80
+apacheTomcatVersion=9.0.82
 
 # (mothership) -> json-path -> json-smart -> accessor-smart
 # (core) -> graalvm
@@ -276,10 +276,10 @@ slf4jLog4jApiVersion=2.0.7
 # This is a dependency for HTSJDK. Force to avoid a deserialization problem. Remove once HTSJDK bumps its preferred version
 snappyJavaVersion=1.1.10.4
 
-springBootVersion=2.7.16
+springBootVersion=2.7.17
 # This MUST match the Tomcat version dictated by springBootVersion
 # Also, keep this in sync with apacheTomcatVersion above
-springBootTomcatVersion=9.0.80
+springBootTomcatVersion=9.0.82
 
 springVersion=5.3.28
 


### PR DESCRIPTION
#### Rationale
Latest is greatest (except when Tomcat 9.0.81 was the latest)

#### Changes
* Keep Spring Boot and Tomcat versions in sync