### PR TITLE
updating netty version to 4.1.100 in suppression for CVE-2023-4586

### DIFF
--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -276,7 +276,7 @@
         <notes><![CDATA[
    file name: netty-handler-4.1.100.Final.jar
    ]]></notes>
-        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-handler@.*$</packageUrl>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty.*$</packageUrl>
         <vulnerabilityName>CVE-2023-4586</vulnerabilityName>
     </suppress>
 

--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -274,7 +274,7 @@
     -->
     <suppress>
         <notes><![CDATA[
-   file name: netty-handler-4.1.94.Final.jar
+   file name: netty-handler-4.1.100.Final.jar
    ]]></notes>
         <packageUrl regex="true">^pkg:maven/io\.netty/netty\-handler@.*$</packageUrl>
         <vulnerabilityName>CVE-2023-4586</vulnerabilityName>


### PR DESCRIPTION
#### Rationale
updating netty version to 4.1.100 in suppression for CVE-2023-4586

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
