### PR TITLE
bump owasp plugin to 8.4.2 and disable failing retirejs analyzer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,9 @@ allprojects {
                 nodeAudit {
                     enabled = false
                 }
+                retirejs {
+                    enabled = false
+                }
             }
             formats = ['HTML', 'JUNIT']
             skipConfigurations = ['dedupe', 'gwtCompileClasspath', 'gwtRuntimeClasspath', 'developmentOnly']

--- a/gradle.properties
+++ b/gradle.properties
@@ -63,7 +63,7 @@ windowsProteomicsBinariesVersion=1.0
 artifactoryPluginVersion=4.31.9
 gradleNodePluginVersion=3.5.1
 gradlePluginsVersion=1.41.1
-owaspDependencyCheckPluginVersion=8.2.1
+owaspDependencyCheckPluginVersion=8.4.2
 versioningPluginVersion=1.1.2
 
 # Versions of node and npm to use during the build. If set, these versions


### PR DESCRIPTION
#### Rationale
* owasp check for the fix for activemq (in platform) is failing due to issue with retirejs. This disables that check for now.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
