### PR TITLE
mySqlDriver version 8.2.0 for CVE-2023-22102

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -232,7 +232,7 @@ lombokVersion=1.18.24
 
 luceneVersion=9.7.0
 
-mysqlDriverVersion=8.0.33
+mysqlDriverVersion=8.2.0
 
 mssqlJdbcVersion=12.2.0.jre11
 


### PR DESCRIPTION
#### Rationale
CVS-2023-22101 affects all versions of mysqlDriver up to v8.1.0. Fortunately there's an 8.2.0.

#### Changes
* Update `mysqlDriverVersion`