### PR TITLE
Replace `buildDir` with `layout.buildDirectory` and add an `excludedModules` property

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ allprojects {
         // Comment in to enable the tasks for owasp dependency checking
         apply plugin: 'org.owasp.dependencycheck'
         dependencyCheck {
-            outputDirectory = "${project.rootProject.buildDir}/reports/dependencyCheck/${project.path.replaceAll(':', '_').substring(1)}"
+            outputDirectory = project.rootProject.layout.buildDirectory.file("reports/dependencyCheck/${project.path.replaceAll(':', '_').substring(1)}").get().asFile
             suppressionFile = "${project.rootProject.rootDir}/dependencyCheckSuppression.xml"
             analyzers {
                 assemblyEnabled = false // Sets whether the .NET Assembly Analyzer should be used.

--- a/gradle.properties
+++ b/gradle.properties
@@ -62,7 +62,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.31.9
 gradleNodePluginVersion=3.5.1
-gradlePluginsVersion=1.42.2
+gradlePluginsVersion=1.43.0-buildDirBeGone-SNAPSHOT
 owaspDependencyCheckPluginVersion=8.4.2
 versioningPluginVersion=1.1.2
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -62,7 +62,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.31.9
 gradleNodePluginVersion=3.5.1
-gradlePluginsVersion=1.43.0-buildDirBeGone-SNAPSHOT
+gradlePluginsVersion=1.43.0
 owaspDependencyCheckPluginVersion=8.4.2
 versioningPluginVersion=1.1.2
 

--- a/gradle/settings/all.gradle
+++ b/gradle/settings/all.gradle
@@ -55,8 +55,8 @@ if (hasProperty('gradleExcludeModuleDirs'))
 {
     excludedDirs.addAll("${gradleExcludeModuleDirs}".toLowerCase().split(","))
 }
-if (hasProperty('excludedModulePaths'))
-    exclusions.addAll("${excludedModulePaths}".split(","))
+if (hasProperty('excludedModules'))
+    exclusions.addAll("${excludedModules}".split(","))
 
 // Include ':server:embedded' unless explicitly excluded
 if (!exclusions.contains("embedded"))

--- a/gradle/settings/all.gradle
+++ b/gradle/settings/all.gradle
@@ -49,20 +49,22 @@ import org.labkey.gradle.util.BuildUtils
 /*
   This settings file include all currently enlisted modules and API projects (JDBC, Java, SAS).
  */
-List<String> excludedDirs = ["test"]
+List<String> exclusions = ["test"]
 
 if (hasProperty('gradleExcludeModuleDirs'))
 {
     excludedDirs.addAll("${gradleExcludeModuleDirs}".toLowerCase().split(","))
 }
+if (hasProperty('excludedModulePaths'))
+    exclusions.addAll("${excludedModulePaths}".split(","))
 
 // Include ':server:embedded' unless explicitly excluded
-if (!excludedDirs.contains("embedded"))
+if (!exclusions.contains("embedded"))
 {
     include BuildUtils.getEmbeddedProjectPath(gradle)
 }
 
-BuildUtils.includeModules(this.settings, rootDir, ["server/modules"], excludedDirs, true)
+BuildUtils.includeModules(this.settings, rootDir, ["server/modules"], exclusions, true)
 
 // include the test distribution, which is used to create an artifact for TeamCity to pass around to the agents
 include "${BuildUtils.getTestProjectPath(this.settings.gradle)}:distributions:teamcity"

--- a/gradle/settings/distributions.gradle
+++ b/gradle/settings/distributions.gradle
@@ -44,4 +44,8 @@ import org.labkey.gradle.util.BuildUtils
 
 apply from: 'all.gradle'
 
-BuildUtils.includeModules(this.settings, rootDir, ["distributions"], [])
+List<String> excludedModules = []
+if (hasProperty('excludedModulePaths'))
+    excludedModules.addAll("${excludedModulePaths}".split(","))
+
+BuildUtils.includeModules(this.settings, rootDir, ["distributions"], excludedModules)

--- a/gradle/settings/distributions.gradle
+++ b/gradle/settings/distributions.gradle
@@ -45,7 +45,7 @@ import org.labkey.gradle.util.BuildUtils
 apply from: 'all.gradle'
 
 List<String> excludedModules = []
-if (hasProperty('excludedModulePaths'))
-    excludedModules.addAll("${excludedModulePaths}".split(","))
+if (hasProperty('excludedModules'))
+    excludedModules.addAll("${excludedModules}".split(","))
 
 BuildUtils.includeModules(this.settings, rootDir, ["distributions"], excludedModules)

--- a/gradle/settings/ehr.gradle
+++ b/gradle/settings/ehr.gradle
@@ -57,8 +57,13 @@ List<String> ehrModulesDirs = [
         "server/modules/LabDevKitModules"
 ]
 
-BuildUtils.includeModules(this.settings, rootDir, [BuildUtils.PLATFORM_MODULES_DIR, BuildUtils.COMMON_ASSAYS_MODULES_DIR], [])
-BuildUtils.includeModules(this.settings, rootDir, ehrModulesDirs, [])
+List<String> excludedModules = []
+if (hasProperty('excludedModulePaths'))
+    excludedModules.addAll("${excludedModulePaths}".split(","))
+
+
+BuildUtils.includeModules(this.settings, rootDir, [BuildUtils.PLATFORM_MODULES_DIR, BuildUtils.COMMON_ASSAYS_MODULES_DIR], excludedModules)
+BuildUtils.includeModules(this.settings, rootDir, ehrModulesDirs, excludedModules)
 
 include ":server:modules:snd"
 include ":server:modules:tnprc_ehr"

--- a/gradle/settings/ehr.gradle
+++ b/gradle/settings/ehr.gradle
@@ -58,8 +58,8 @@ List<String> ehrModulesDirs = [
 ]
 
 List<String> excludedModules = []
-if (hasProperty('excludedModulePaths'))
-    excludedModules.addAll("${excludedModulePaths}".split(","))
+if (hasProperty('excludedModules'))
+    excludedModules.addAll("${excludedModules}".split(","))
 
 
 BuildUtils.includeModules(this.settings, rootDir, [BuildUtils.PLATFORM_MODULES_DIR, BuildUtils.COMMON_ASSAYS_MODULES_DIR], excludedModules)

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -40,7 +40,7 @@ project.tasks.register("tomcatLibsZip", Zip) {
         zip.description = "produce jar file with jars to be deployed in \$CATALINA_HOME/lib"
         zip.from project.configurations.tomcatJars.getAsFileTree()
         zip.archiveBaseName.set("tomcat-libs")
-        zip.destinationDirectory = project.file(project.labkey.explodedModuleLibDir)
+        zip.destinationDirectory.set(project.file(project.labkey.explodedModuleLibDir))
 }
 
 configurations
@@ -210,8 +210,8 @@ tasks.register('createModule', CreateModule) {
 // Each project that requires node will have its own downloaded version of node and npm, but for the symlinkNode
 // task we need a single location, and one that works even when not building from source (Issue 35207)
 project.node {
-    workDir = project.file("${project.rootProject.buildDir}/.node")
-    npmWorkDir = project.file("${project.rootProject.buildDir}/.node")
-    yarnWorkDir = project.file("${project.rootProject.buildDir}/.node")
+    workDir = BuildUtils.getRootBuildDirFile(project, ".node")
+    npmWorkDir = BuildUtils.getRootBuildDirFile(project, ".node")
+    yarnWorkDir = BuildUtils.getRootBuildDirFile(project, ".node")
 }
 project.tasks.named('deployApp').configure { dependsOn(project.tasks.npmSetup) }

--- a/settings.gradle
+++ b/settings.gradle
@@ -103,11 +103,20 @@ if (hasProperty("useEmbeddedTomcat"))
 
 include BuildUtils.getMinificationProjectPath(gradle)
 
+// A list of directory names or fully qualified module paths that correspond to modules to be excluded from configuration.
+// Items may be individual module names (e.g. 'luminex'), module container names (e.g. 'customModules'), or paths (e.g., ':server:modules:commonAssays:flow')
+// You must make sure to pass this list to the appropriate calls to `BuildUtils.includeModules`
+List<String> excludedModules = []
+if (hasProperty('excludedModulePaths'))
+{
+    excludedModules.addAll("${excludedModulePaths}".split(","))
+}
+
 if (new File(getRootDir(), BuildUtils.convertPathToRelativeDir(BuildUtils.getPlatformProjectPath(gradle))).exists()
         && !hasProperty('excludeBaseModules'))
 {
     // The line below includes the set of modules for a minimally functional LabKey server
-    BuildUtils.includeBaseModules(this.settings)
+    BuildUtils.includeBaseModules(this.settings, excludedModules)
 
     // Some test modules require base modules to build JSPs.
     // TODO: Un-nest this 'if' once test modules can build without platform present.
@@ -115,7 +124,7 @@ if (new File(getRootDir(), BuildUtils.convertPathToRelativeDir(BuildUtils.getPla
             && !hasProperty('excludeTestModules'))
     {
         // The line below will include the server/testAutomation project as well as the server/testAutomation/modules projects
-        BuildUtils.includeTestModules(this.settings, rootDir)
+        BuildUtils.includeTestModules(this.settings, rootDir, excludedModules)
     }
 }
 else if (new File(getRootDir(), BuildUtils.convertPathToRelativeDir(BuildUtils.getTestProjectPath(gradle))).exists())
@@ -149,10 +158,6 @@ else if (hasProperty('moduleSet'))
 }
 else
 {
-    // A list of directory names that correspond to modules to be excluded from configuration.
-    // Items may be individual module names (e.g. 'luminex') or module container names (e.g. 'customModules')
-    // You must make sure to pass this list to the appropriate calls to `BuildUtils.includeModules`
-    List<String> excludedModules = []
 
     // The line below recursively includes all modules in server/modules 
     BuildUtils.includeModules(this.settings, rootDir, [BuildUtils.SERVER_MODULES_DIR], excludedModules, true)
@@ -188,7 +193,7 @@ if (hasProperty('extraIncludes'))
 
 if (hasProperty('extraModuleDirs'))
 {
-    BuildUtils.includeModules(this.settings, rootDir, Arrays.asList("${extraModuleDirs}".split(",")), [])
+    BuildUtils.includeModules(this.settings, rootDir, Arrays.asList("${extraModuleDirs}".split(",")), excludedModules)
 }
 
 if (hasProperty('inheritedDistPath'))

--- a/settings.gradle
+++ b/settings.gradle
@@ -107,9 +107,9 @@ include BuildUtils.getMinificationProjectPath(gradle)
 // Items may be individual module names (e.g. 'luminex'), module container names (e.g. 'customModules'), or paths (e.g., ':server:modules:commonAssays:flow')
 // You must make sure to pass this list to the appropriate calls to `BuildUtils.includeModules`
 List<String> excludedModules = []
-if (hasProperty('excludedModulePaths'))
+if (hasProperty('excludedModules'))
 {
-    excludedModules.addAll("${excludedModulePaths}".split(","))
+    excludedModules.addAll("${excludedModules}".split(","))
 }
 
 if (new File(getRootDir(), BuildUtils.convertPathToRelativeDir(BuildUtils.getPlatformProjectPath(gradle))).exists()


### PR DESCRIPTION
#### Rationale
In Gradle 8.3, the use of `project.buildDir` was [deprecated](https://docs.gradle.org/current/userguide/upgrading_version_8.html#project_builddir) in favor of `project.layout.buildDirectory`.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/185

#### Changes
* Replace deprecated buildDir with layout.buildDirectory
* Add support for new property `excludeModules` that allows specifying a full path to a module (or set of modules) to exclude
