### PR TITLE
Gradle plugins update: Don't use providers for ant directories.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -62,7 +62,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.31.9
 gradleNodePluginVersion=3.5.1
-gradlePluginsVersion=1.43.0
+gradlePluginsVersion=1.43.1-antDirectories-SNAPSHOT
 owaspDependencyCheckPluginVersion=8.4.2
 versioningPluginVersion=1.1.2
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -62,7 +62,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.31.9
 gradleNodePluginVersion=3.5.1
-gradlePluginsVersion=1.43.1-antDirectories-SNAPSHOT
+gradlePluginsVersion=1.43.1
 owaspDependencyCheckPluginVersion=8.4.2
 versioningPluginVersion=1.1.2
 


### PR DESCRIPTION
#### Rationale
See related PR

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/186

#### Changes
* gradlePluginsVersion update
