### PR TITLE
Apply JavaScript syntax highlighting to `labkey:script` JSP tags

### DIFF
--- a/.idea/IntelliLang.xml
+++ b/.idea/IntelliLang.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="LanguageInjectionConfiguration">
+    <injection language="JavaScript" injector-id="xml">
+      <display-name>labkey:script</display-name>
+      <single-file value="true" />
+      <place><![CDATA[xmlTag().withLocalName(string().equalTo("script")).withNamespace(string().equalTo("http://www.labkey.org/taglib"))]]></place>
+    </injection>
+  </component>
+</project>


### PR DESCRIPTION
#### Rationale
`<labkey:script>` tag bodies in JSPs are treated like plain text by default. IntelliJ can treat them like JavaScript if [configured](https://www.jetbrains.com/help/idea/using-language-injections.html#configure-injection-rules) to do so. It will do syntax highlighting and some code completion but the formatting/indentation is less than perfect.

#### Related Pull Requests
* N/A

#### Changes
* Apply JavaScript syntax highlighting to `labkey:script` JSP tags
