### PR TITLE
Add task to report LabKey version to TeamCity

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,6 @@ import org.labkey.gradle.task.PurgeNpmAlphaVersions
 import org.labkey.gradle.task.ShowDiscrepancies
 import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.GroupNames
-import org.labkey.gradle.plugin.NpmRun
-import org.labkey.gradle.task.PurgeNpmAlphaVersions
 
 plugins {
     id "com.jfrog.artifactory" version "${artifactoryPluginVersion}" apply false
@@ -379,8 +377,6 @@ if (BuildUtils.shouldPublish(project) || BuildUtils.shouldPublishDistribution(pr
 
     artifactoryPublish.skip = true
 }
-
-project.logger.info("##teamcity[setParameter name='labkey.version' value='${labkeyVersion}']")
 
 subprojects {
     project.tasks.register("showRepos", DefaultTask) {

--- a/build.gradle
+++ b/build.gradle
@@ -380,6 +380,8 @@ if (BuildUtils.shouldPublish(project) || BuildUtils.shouldPublishDistribution(pr
     artifactoryPublish.skip = true
 }
 
+project.log.info("##teamcity[setParameter name='labkey.version' value='${labkeyVersion}']")
+
 subprojects {
     project.tasks.register("showRepos", DefaultTask) {
         task ->

--- a/build.gradle
+++ b/build.gradle
@@ -380,7 +380,7 @@ if (BuildUtils.shouldPublish(project) || BuildUtils.shouldPublishDistribution(pr
     artifactoryPublish.skip = true
 }
 
-project.log.info("##teamcity[setParameter name='labkey.version' value='${labkeyVersion}']")
+project.logger.info("##teamcity[setParameter name='labkey.version' value='${labkeyVersion}']")
 
 subprojects {
     project.tasks.register("showRepos", DefaultTask) {

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -4,6 +4,7 @@ import org.labkey.gradle.plugin.XsdDoc
 import org.labkey.gradle.task.CreateModule
 import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.GroupNames
+import org.labkey.gradle.util.PomFileHelper
 
 plugins {
     id 'maven-publish'

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -208,13 +208,17 @@ tasks.register('createModule', CreateModule) {
 
 project.tasks.register("reportVersionToTeamCity", DefaultTask) {
     DefaultTask task ->
-        task.group = GroupNames.DOCUMENTATION
-        task.description = "Report version number '${labkeyVersion}' to TeamCity"
+        task.group = GroupNames.PUBLISHING
+        task.description = "Report version number (${labkeyVersion}) to TeamCity"
         task.doLast({
             println "##teamcity[setParameter name='labkey.version' value='${labkeyVersion}']"
         })
 }
-project.tasks.named('stageApp').configure { dependsOn(project.tasks.named('reportVersionToTeamCity')) }
+if (project.hasProperty("teamcity"))
+{
+    project.tasks.named('stageApp').configure { dependsOn(project.tasks.named('reportVersionToTeamCity')) }
+}
+
 
 // We add this configuration here so we have a single location to link to for the npm and node executables.
 // Each project that requires node will have its own downloaded version of node and npm, but for the symlinkNode

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -4,7 +4,6 @@ import org.labkey.gradle.plugin.XsdDoc
 import org.labkey.gradle.task.CreateModule
 import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.GroupNames
-import org.labkey.gradle.util.PomFileHelper
 
 plugins {
     id 'maven-publish'
@@ -205,6 +204,16 @@ tasks.register('createModule', CreateModule) {
             "in a comma delimited list to create those subdirectories in the new module. If none are required, still " +
             "include -PcreateFiles with no value to avoid being prompted."
 }
+
+project.tasks.register("reportVersionToTeamCity", DefaultTask) {
+    DefaultTask task ->
+        task.group = GroupNames.DOCUMENTATION
+        task.description = "Report version number '${labkeyVersion}' to TeamCity"
+        task.doLast({
+            project.logger.info("##teamcity[setParameter name='labkey.version' value='${labkeyVersion}']")
+        })
+}
+project.tasks.named('stageApp').configure { dependsOn(project.tasks.named('reportVersionToTeamCity')) }
 
 // We add this configuration here so we have a single location to link to for the npm and node executables.
 // Each project that requires node will have its own downloaded version of node and npm, but for the symlinkNode

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -211,7 +211,7 @@ project.tasks.register("reportVersionToTeamCity", DefaultTask) {
         task.group = GroupNames.DOCUMENTATION
         task.description = "Report version number '${labkeyVersion}' to TeamCity"
         task.doLast({
-            project.logger.info("##teamcity[setParameter name='labkey.version' value='${labkeyVersion}']")
+            println "##teamcity[setParameter name='labkey.version' value='${labkeyVersion}']"
         })
 }
 project.tasks.named('stageApp').configure { dependsOn(project.tasks.named('reportVersionToTeamCity')) }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -211,6 +211,7 @@ project.tasks.register("reportVersionToTeamCity", DefaultTask) {
         task.group = GroupNames.PUBLISHING
         task.description = "Report version number (${labkeyVersion}) to TeamCity"
         task.doLast({
+            // https://www.jetbrains.com/help/teamcity/2018.1/build-script-interaction-with-teamcity.html#adding-or-changing-a-build-parameter
             println "##teamcity[setParameter name='labkey.version' value='${labkeyVersion}']"
         })
 }


### PR DESCRIPTION
#### Rationale
Our Docker container builds currently require manual intervention to have the correct version number. We can pass the version number between builds with some [special logging](https://www.jetbrains.com/help/teamcity/2018.1/build-script-interaction-with-teamcity.html#adding-or-changing-a-build-parameter), which will allow us to remove the manual step.

#### Related Pull Requests
* N/A

#### Changes
* Add task to report 'labkeyVersion' to TeamCity
