### PR TITLE
CVE-2023-34055: Update spring version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -103,7 +103,7 @@ apacheDirectoryVersion=2.1.3
 apacheMinaVersion=2.2.1
 
 # Keep in sync with springBootTomcatVersion below
-apacheTomcatVersion=9.0.82
+apacheTomcatVersion=9.0.83
 
 # (mothership) -> json-path -> json-smart -> accessor-smart
 # (core) -> graalvm

--- a/gradle.properties
+++ b/gradle.properties
@@ -283,7 +283,7 @@ slf4jLog4jApiVersion=2.0.7
 # This is a dependency for HTSJDK. Force version for CVE-2023-43642
 snappyJavaVersion=1.1.10.5
 
-springBootVersion=2.7.17
+springBootVersion=2.7.18
 # This MUST match the Tomcat version dictated by springBootVersion
 # Also, keep this in sync with apacheTomcatVersion above
 springBootTomcatVersion=9.0.82

--- a/gradle.properties
+++ b/gradle.properties
@@ -286,7 +286,7 @@ snappyJavaVersion=1.1.10.5
 springBootVersion=2.7.18
 # This MUST match the Tomcat version dictated by springBootVersion
 # Also, keep this in sync with apacheTomcatVersion above
-springBootTomcatVersion=9.0.82
+springBootTomcatVersion=9.0.83
 
 springVersion=5.3.30
 


### PR DESCRIPTION
#### Rationale
CVE-2023-34055 - a medium-level risk but we may as well update to the latest patch version

#### Changes
* spring version update