### PR TITLE
CVE-2023-46589: Update tomcat (and spring) versions

### DIFF
--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -9,6 +9,13 @@
        <packageUrl regex="true">^pkg:maven/ch\.qos\.logback/logback\-classic@.*$</packageUrl>
        <vulnerabilityName>CVE-2023-6378</vulnerabilityName>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+        file name: logback-core-1.2.12.jar
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/ch\.qos\.logback/logback\-core@.*$</packageUrl>
+        <vulnerabilityName>CVE-2023-6378</vulnerabilityName>
+    </suppress>
 
     <!-- Prevent match against unrelated "rengine" at https://github.com/yogeshojha/rengine -->
     <suppress>

--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+
+    <!-- We do not include logback with our embedded tomcat distributions -->
+    <suppress>
+       <notes><![CDATA[
+       file name: logback-classic-1.2.12.jar
+       ]]></notes>
+       <packageUrl regex="true">^pkg:maven/ch\.qos\.logback/logback\-classic@.*$</packageUrl>
+       <vulnerabilityName>CVE-2023-6378</vulnerabilityName>
+    </suppress>
+
     <!-- Prevent match against unrelated "rengine" at https://github.com/yogeshojha/rengine -->
     <suppress>
         <notes><![CDATA[

--- a/gradle.properties
+++ b/gradle.properties
@@ -100,7 +100,7 @@ apacheDirectoryVersion=2.1.3
 apacheMinaVersion=2.2.1
 
 # Keep in sync with springBootTomcatVersion below
-apacheTomcatVersion=9.0.82
+apacheTomcatVersion=9.0.83
 
 # (mothership) -> json-path -> json-smart -> accessor-smart
 # (core) -> graalvm
@@ -276,10 +276,10 @@ slf4jLog4jApiVersion=2.0.7
 # This is a dependency for HTSJDK. Force to avoid a deserialization problem. Remove once HTSJDK bumps its preferred version
 snappyJavaVersion=1.1.10.4
 
-springBootVersion=2.7.17
+springBootVersion=2.7.18
 # This MUST match the Tomcat version dictated by springBootVersion
 # Also, keep this in sync with apacheTomcatVersion above
-springBootTomcatVersion=9.0.82
+springBootTomcatVersion=9.0.83
 
 springVersion=5.3.28
 


### PR DESCRIPTION
#### Rationale
- CVE-2023-46589
- CVE-2023-34055

#### Related Pull Requests
* https://github.com/LabKey/tutorialModules/pull/167

#### Changes
* Upgrade tomcat and spring versions
