### PR TITLE
fix application properties for embedded csp

### DIFF
--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -78,10 +78,8 @@ spring.main.banner-mode=off
 # example usage 1 - very strict, disallows 'external' websites, disallows unsafe-inline, but only reports violations (does not enforce)
 # good for test automation!
 
-#csp.disposition=report
-#csp.policy="default-src 'self' https: ;\nconnect-src 'self' https: ;\nobject-src 'none' ;\nstyle-src 'self' https: 'unsafe-inline' ;\nimg-src 'self' data: ;\nscript-src 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}';\nbase-uri 'self' ;\nupgrade-insecure-requests ;\nframe-ancestors 'self' ;\nreport-to /labkey/admin-contentsecuritypolicyreport.api ;\nreport-uri /labkey/admin-contentsecuritypolicyreport.api ;"
+csp.report="default-src 'self' https: ;\nconnect-src 'self' https: ;\nobject-src 'none' ;\nstyle-src 'self' https: 'unsafe-inline' ;\nimg-src 'self' data: ;\nscript-src 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}';\nbase-uri 'self' ;\nupgrade-insecure-requests ;\nframe-ancestors 'self' ;\nreport-to /labkey/admin-contentsecuritypolicyreport.api ;\nreport-uri /labkey/admin-contentsecuritypolicyreport.api ;"
 
 # example usage 2 - less strict but enforces directives, (NOTE: unsafe-inline is still required for many modules)
 
-#csp.disposition=enforce
-#csp.policy="default-src 'self' https: ;\nconnect-src 'self' https: ;\nobject-src 'none' ;\nstyle-src 'self' https: 'unsafe-inline' ;\nimg-src 'self' data: ;\nscript-src 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}';\nbase-uri 'self' ;\nupgrade-insecure-requests ;\nframe-ancestors 'self' ;\nreport-to /labkey/admin-contentsecuritypolicyreport.api ;\nreport-uri /labkey/admin-contentsecuritypolicyreport.api ;"
+csp.enforce="default-src 'self' https: ;\nconnect-src 'self' https: ;\nobject-src 'none' ;\nstyle-src 'self' https: 'unsafe-inline' ;\nimg-src 'self' data: ;\nscript-src 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}';\nbase-uri 'self' ;\nupgrade-insecure-requests ;\nframe-ancestors 'self' ;\nreport-to /labkey/admin-contentsecuritypolicyreport.api ;\nreport-uri /labkey/admin-contentsecuritypolicyreport.api ;"


### PR DESCRIPTION
#### Rationale
This PR provides a way to define two different headers enforce and report for content security policy delivered through embedded tomcat.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/626

#### Changes
* new application.properties - csp.enforce and csp.report
