### PR TITLE
CVE-2023-44487: grpc DoS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -239,7 +239,7 @@ allprojects {
                     // Force patched version of GPRC, dependency of a number of Google service APIs in WNPRC and fileTransfer
                     force "io.grpc:grpc-context:${grpcVersion}"
 
-                    // TODO Remove these when the Picard version brought in by the SequenceAnalysis module is upgraded to use a version >=1.57.2
+                    // TODO Remove these when the Picard version brought in by the SequenceAnalysis module is upgraded to use a version of grpc > 1.60.0
                     force "io.grpc:grpc-alts:${grpcVersion}"
                     force "io.grpc:grpc-auth:${grpcVersion}"
                     force "io.grpc:grpc-core:${grpcVersion}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -165,7 +165,7 @@ graalVersion=23.0.1
 # "java.lang.NoSuchMethodError: 'void com.google.gson.internal.ConstructorConstructor.<init>(java.util.Map)'" errors
 gsonVersion=2.8.9
 
-grpcVersion=1.57.2
+grpcVersion=1.60.0
 
 guavaVersion=32.0.1-jre
 gwtVersion=2.10.0


### PR DESCRIPTION
#### Rationale
[CVE-2023-44487](https://nvd.nist.gov/vuln/detail/CVE-2023-44487)

Does not look likely to affect core LabKey but possibly external developer libraries could be vulnerable.

#### Changes
* Update version of grpc
