### PR TITLE
Gradle 8.5, OWASP plugin update, update some default code styling settings for IntelliJ

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -7,10 +7,18 @@
     <option name="WHILE_ON_NEW_LINE" value="true" />
     <option name="CATCH_ON_NEW_LINE" value="true" />
     <option name="FINALLY_ON_NEW_LINE" value="true" />
+    <JSCodeStyleSettings version="0">
+      <option name="USE_DOUBLE_QUOTES" value="false" />
+      <option name="IMPORTS_WRAP" value="0" />
+      <option name="SPACES_WITHIN_OBJECT_LITERAL_BRACES" value="true" />
+      <option name="SPACES_WITHIN_IMPORTS" value="true" />
+      <option name="IMPORT_SORT_MODULE_NAME" value="true" />
+      <option name="IMPORT_USE_NODE_RESOLUTION" value="FALSE" />
+    </JSCodeStyleSettings>
     <JavaCodeStyleSettings>
       <option name="FIELD_NAME_PREFIX" value="_" />
-      <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="20" />
-      <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="20" />
+      <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="2000" />
+      <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="2000" />
     </JavaCodeStyleSettings>
     <TypeScriptCodeStyleSettings version="0">
       <option name="FORCE_SEMICOLON_STYLE" value="true" />
@@ -20,6 +28,7 @@
       <option name="PREFER_EXPLICIT_TYPES_FUNCTION_RETURNS" value="true" />
       <option name="PREFER_EXPLICIT_TYPES_FUNCTION_EXPRESSION_RETURNS" value="true" />
       <option name="SPACES_WITHIN_IMPORTS" value="true" />
+      <option name="IMPORT_USE_NODE_RESOLUTION" value="GLOBAL" />
     </TypeScriptCodeStyleSettings>
     <ADDITIONAL_INDENT_OPTIONS fileType="txt">
       <option name="INDENT_SIZE" value="2" />
@@ -29,6 +38,12 @@
       <option name="ELSE_ON_NEW_LINE" value="true" />
       <option name="WHILE_ON_NEW_LINE" value="true" />
       <option name="CATCH_ON_NEW_LINE" value="true" />
+    </codeStyleSettings>
+    <codeStyleSettings language="CSS">
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
     </codeStyleSettings>
     <codeStyleSettings language="ECMA Script Level 4">
       <option name="BRACE_STYLE" value="2" />
@@ -62,7 +77,6 @@
       <option name="FINALLY_ON_NEW_LINE" value="true" />
     </codeStyleSettings>
     <codeStyleSettings language="JavaScript">
-      <option name="ELSE_ON_NEW_LINE" value="true" />
       <option name="WHILE_ON_NEW_LINE" value="true" />
       <option name="CATCH_ON_NEW_LINE" value="true" />
       <option name="FINALLY_ON_NEW_LINE" value="true" />
@@ -73,6 +87,16 @@
     <codeStyleSettings language="Python">
       <indentOptions>
         <option name="USE_TAB_CHARACTER" value="true" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="SASS">
+      <indentOptions>
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="SCSS">
+      <indentOptions>
+        <option name="TAB_SIZE" value="2" />
       </indentOptions>
     </codeStyleSettings>
     <codeStyleSettings language="TypeScript">

--- a/build.gradle
+++ b/build.gradle
@@ -35,12 +35,6 @@ allprojects {
             formats = ['HTML', 'JUNIT']
             skipConfigurations = ['dedupe', 'gwtCompileClasspath', 'gwtRuntimeClasspath', 'developmentOnly']
             skipProjects = [':server:testAutomation']
-            if (project.hasProperty('nvdApiKey'))
-            {
-                nvd {
-                    apiKey = "${project.property('nvdApiKey')}"
-                }
-            }
         }
     }
     if (BuildUtils.shouldPublish(project) || BuildUtils.shouldPublishDistribution(project))

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,12 @@ allprojects {
             formats = ['HTML', 'JUNIT']
             skipConfigurations = ['dedupe', 'gwtCompileClasspath', 'gwtRuntimeClasspath', 'developmentOnly']
             skipProjects = [':server:testAutomation']
+            if (project.hasProperty('nvdApiKey'))
+            {
+                nvd {
+                    apiKey = "${project.property('nvdApiKey')}"
+                }
+            }
         }
     }
     if (BuildUtils.shouldPublish(project) || BuildUtils.shouldPublishDistribution(project))

--- a/gradle.properties
+++ b/gradle.properties
@@ -63,7 +63,7 @@ windowsProteomicsBinariesVersion=1.0
 artifactoryPluginVersion=4.31.9
 gradleNodePluginVersion=3.5.1
 gradlePluginsVersion=1.43.1
-owaspDependencyCheckPluginVersion=8.4.2
+owaspDependencyCheckPluginVersion=9.0.1
 versioningPluginVersion=1.1.2
 
 # Versions of node and npm to use during the build. If set, these versions

--- a/gradle.properties
+++ b/gradle.properties
@@ -63,7 +63,7 @@ windowsProteomicsBinariesVersion=1.0
 artifactoryPluginVersion=4.31.9
 gradleNodePluginVersion=3.5.1
 gradlePluginsVersion=1.43.1
-owaspDependencyCheckPluginVersion=9.0.1
+owaspDependencyCheckPluginVersion=8.4.3
 versioningPluginVersion=1.1.2
 
 # Versions of node and npm to use during the build. If set, these versions

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew
+++ b/gradlew
@@ -145,7 +145,7 @@ if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
     case $MAX_FD in #(
       max*)
         # In POSIX sh, ulimit -H is undefined. That's why the result is checked to see if it worked.
-        # shellcheck disable=SC3045
+        # shellcheck disable=SC2039,SC3045
         MAX_FD=$( ulimit -H -n ) ||
             warn "Could not query maximum file descriptor limit"
     esac
@@ -153,7 +153,7 @@ if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
       '' | soft) :;; #(
       *)
         # In POSIX sh, ulimit -n is undefined. That's why the result is checked to see if it worked.
-        # shellcheck disable=SC3045
+        # shellcheck disable=SC2039,SC3045
         ulimit -n "$MAX_FD" ||
             warn "Could not set maximum file descriptor limit to $MAX_FD"
     esac
@@ -202,11 +202,11 @@ fi
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
 DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 
-# Collect all arguments for the java command;
-#   * $DEFAULT_JVM_OPTS, $JAVA_OPTS, and $GRADLE_OPTS can contain fragments of
-#     shell script including quotes and variable substitutions, so put them in
-#     double quotes to make sure that they get re-expanded; and
-#   * put everything else in single quotes, so that it's not re-expanded.
+# Collect all arguments for the java command:
+#   * DEFAULT_JVM_OPTS, JAVA_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,
+#     and any embedded shellness will be escaped.
+#   * For example: A user cannot expect ${Hostname} to be expanded, as it is an environment variable and will be
+#     treated as '${Hostname}' itself on the command line.
 
 set -- \
         "-Dorg.gradle.appname=$APP_BASE_NAME" \


### PR DESCRIPTION
#### Rationale

- Gradle 8.5 is the latest
- OWASP 8.4.3 is the latest 8.x version. Updating to 9.x may also be possible, but locally I ran into problems, so I'll stick with the latest 8.x version for now.
- In preparation for our conversion to Tomcat 10, it is anticipated there will be fewer merge conflicts if IntelliJ doesn't collapse imports into *-imports, so this updates the style to increase the limit on when *-imports are used.  
- Some other styling changes that seem to be our standard but are not capture are also included here.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Update gradle version
* Update OWASP dependency check plugin version
* Update IntelliJ project code style settings.
