### PR TITLE
Suppress CVE-2023-6481

### DIFF
--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -16,6 +16,20 @@
         <packageUrl regex="true">^pkg:maven/ch\.qos\.logback/logback\-core@.*$</packageUrl>
         <vulnerabilityName>CVE-2023-6378</vulnerabilityName>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+       file name: logback-classic-1.2.12.jar
+       ]]></notes>
+        <packageUrl regex="true">^pkg:maven/ch\.qos\.logback/logback\-classic@.*$</packageUrl>
+        <vulnerabilityName>CVE-2023-6481</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        file name: logback-core-1.2.12.jar
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/ch\.qos\.logback/logback\-core@.*$</packageUrl>
+        <vulnerabilityName>CVE-2023-6481</vulnerabilityName>
+    </suppress>
 
     <!-- Prevent match against unrelated "rengine" at https://github.com/yogeshojha/rengine -->
     <suppress>


### PR DESCRIPTION
#### Rationale
Logback not used in our embedded tomcat. 

From the logback release notes:
Note that a successful exploitation of CVE-2023-6378/CVE-2023-6481 requires that logback-receiver component is enabled and also reachable by the attacker.

#### Changes
* Suppress CVE-2023-6481 for logback jar.
