### PR TITLE
Update CSP report configuration to allow BarTender connections

### DIFF
--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -84,7 +84,7 @@ spring.main.banner-mode=off
 #csp.enforce=default-src 'self' https: ;\nconnect-src 'self' https: ;\nobject-src 'none' ;\nstyle-src 'self' https: 'unsafe-inline' ;\nimg-src 'self' data: ;\nscript-src 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}';\nbase-uri 'self' ;\nupgrade-insecure-requests ;\nframe-ancestors 'self' ;\nreport-to  https://www.labkey.org/admin-contentsecuritypolicyreport.api ;\nreport-uri  https://www.labkey.org/admin-contentsecuritypolicyreport.api ;
 
 # Default CSP for TeamCity and dev deployments
-#setupTask#csp.report=default-src 'self' https: http: ;\nconnect-src 'self' localhost ${LABKEY.ALLOWED.CONNECTIONS} ;\nobject-src 'none' ;\nstyle-src 'self' https: 'unsafe-inline' ;\nimg-src 'self' https: data: ;\nscript-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ;\nbase-uri 'self' ;\nframe-ancestors 'self' ;\nreport-to /admin-contentsecuritypolicyreport.api ;\nreport-uri /admin-contentsecuritypolicyreport.api ;
+#setupTask#csp.report=default-src 'self' https: http: ;\nconnect-src 'self' ${LABKEY.ALLOWED.CONNECTIONS} ;\nobject-src 'none' ;\nstyle-src 'self' https: 'unsafe-inline' ;\nimg-src 'self' https: data: ;\nscript-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ;\nbase-uri 'self' ;\nframe-ancestors 'self' ;\nreport-to /admin-contentsecuritypolicyreport.api ;\nreport-uri /admin-contentsecuritypolicyreport.api ;
 
 # Use a non-temp directory for tomcat
 #setupTask#server.tomcat.basedir=@@pathToServer@@/build/deploy/embedded

--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -84,7 +84,7 @@ spring.main.banner-mode=off
 #csp.enforce=default-src 'self' https: ;\nconnect-src 'self' https: ;\nobject-src 'none' ;\nstyle-src 'self' https: 'unsafe-inline' ;\nimg-src 'self' data: ;\nscript-src 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}';\nbase-uri 'self' ;\nupgrade-insecure-requests ;\nframe-ancestors 'self' ;\nreport-to  https://www.labkey.org/admin-contentsecuritypolicyreport.api ;\nreport-uri  https://www.labkey.org/admin-contentsecuritypolicyreport.api ;
 
 # Default CSP for TeamCity and dev deployments
-#setupTask#csp.report=default-src 'self' https: http: ;\nconnect-src 'self' ;\nobject-src 'none' ;\nstyle-src 'self' https: 'unsafe-inline' ;\nimg-src 'self' https: data: ;\nscript-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ;\nbase-uri 'self' ;\nframe-ancestors 'self' ;\nreport-to /admin-contentsecuritypolicyreport.api ;\nreport-uri /admin-contentsecuritypolicyreport.api ;
+#setupTask#csp.report=default-src 'self' https: http: ;\nconnect-src 'self' localhost ${LABKEY.ALLOWED.CONNECTIONS} ;\nobject-src 'none' ;\nstyle-src 'self' https: 'unsafe-inline' ;\nimg-src 'self' https: data: ;\nscript-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ;\nbase-uri 'self' ;\nframe-ancestors 'self' ;\nreport-to /admin-contentsecuritypolicyreport.api ;\nreport-uri /admin-contentsecuritypolicyreport.api ;
 
 # Use a non-temp directory for tomcat
 #setupTask#server.tomcat.basedir=@@pathToServer@@/build/deploy/embedded


### PR DESCRIPTION
#### Rationale
This is the CSP policy used for testing embedded Tomcat on TeamCity. Standalone Tomcat has been updated already.

#### Related Pull Requests
* N/A

#### Changes
* Add `${LABKEY.ALLOWED.CONNECTIONS}` to `connect-src` directive