### PR TITLE
Upgrade many dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -213,6 +213,8 @@ allprojects {
                     force "org.checkerframework:checker-qual:${checkerQualVersion}"
                     // force version for SequenceAnalysis, api, cloud
                     force "com.google.guava:guava:${guavaVersion}"
+                    // force version for SequenceAnalysis, TargetedMS
+                    force "com.google.protobuf:protobuf-java:${googleProtocolBufVersion}"
                     // force version for accounts, api, query
                     force "javax.validation:validation-api:${validationApiVersion}"
                     // force version for accounts, docker, api, workflow

--- a/build.gradle
+++ b/build.gradle
@@ -197,6 +197,8 @@ allprojects {
                     force "commons-io:commons-io:${commonsIoVersion}"
                     force "commons-logging:commons-logging:${commonsLoggingVersion}"
                     force "commons-pool:commons-pool:${commonsPoolVersion}"
+                    // force version for consistency with premium, OpenLdapSync
+                    force "org.apache.commons:commons-text:${commonsTextVersion}"
                     // force version for consistency with query, saml, LDK, api
                     force "commons-collections:commons-collections:${commonsCollectionsVersion}"
                     // force version for ms2, saml, fileTransfer, harvest, api, accounts, docker

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-#moduleSet=all
-#ideaIncludeAllModules=true
+moduleSet=all
+ideaIncludeAllModules=true
 # This controls Gradle's file system watching, which improves efficiency of incremental builds
 # https://docs.gradle.org/current/userguide/file_system_watching.html
 org.gradle.vfs.watch=true
@@ -48,7 +48,7 @@ buildFromSource=true
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
 labkeyVersion=24.2-SNAPSHOT
-labkeyClientApiVersion=5.3.0
+labkeyClientApiVersion=6.0.0
 
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.
@@ -114,8 +114,8 @@ asmVersion=9.5
 batikVersion=1.17
 
 # sync with Tika version (or later)
-bouncycastlePgpVersion=1.76
-bouncycastleVersion=1.76
+bouncycastlePgpVersion=1.77
+bouncycastleVersion=1.77
 
 cglibNodepVersion=2.2.3
 
@@ -133,13 +133,14 @@ commonsDbcpVersion=1.4
 commonsDiscoveryVersion=0.2
 commonsDigesterVersion=1.8.1
 commonsFileuploadVersion=1.5
-commonsIoVersion=2.15.0
+commonsIoVersion=2.15.1
 commonsLangVersion=2.6
-commonsLang3Version=3.13.0
+commonsLang3Version=3.14.0
 commonsLoggingVersion=1.2
 commonsMath3Version=3.6.1
 commonsNetVersion=3.10.0
 commonsPoolVersion=1.6
+commonsTextVersion=1.11.0
 commonsValidatorVersion=1.7
 
 datadogVersion=0.108.1
@@ -157,11 +158,11 @@ flyingsaucerVersion=R8
 fopVersion=2.9
 
 # Force latest for consistency
-googleAutoValueAnnotationsVersion=1.10.2
-googleErrorProneAnnotationsVersion=2.23.0
+googleAutoValueAnnotationsVersion=1.10.4
+googleErrorProneAnnotationsVersion=2.24.1
 googleHttpClientVersion=1.43.3
 googleOauthClientVersion=1.34.1
-googleProtocolBufVersion=3.23.2
+googleProtocolBufVersion=3.25.1
 
 graalVersion=23.0.2
 
@@ -171,7 +172,7 @@ graalVersion=23.0.2
 # "java.lang.NoSuchMethodError: 'void com.google.gson.internal.ConstructorConstructor.<init>(java.util.Map)'" errors
 gsonVersion=2.8.9
 
-grpcVersion=1.60.0
+grpcVersion=1.60.1
 
 guavaVersion=33.0.0-jre
 gwtVersion=2.10.0
@@ -184,18 +185,18 @@ hamcrestVersion=1.3
 # Note: if changing this, we might need to match with the picard version in the SequenceAnalysis module build.gradle
 htsjdkVersion=4.0.0
 
-httpclient5Version=5.2.1
-httpcore5Version=5.2.3
+httpclient5Version=5.3
+httpcore5Version=5.2.4
 
 # Not used directly, but these are widely used transitive dependencies
 httpclientVersion=4.5.14
 httpcoreVersion=4.4.16
 
 # Jackson dependencies are usually released in tandem, but occasionally one gets a patch release out-of-sync with the others
-jacksonVersion=2.15.3
-jacksonAnnotationsVersion=2.15.3
-jacksonDatabindVersion=2.15.3
-jacksonJaxrsBaseVersion=2.15.3
+jacksonVersion=2.16.1
+jacksonAnnotationsVersion=2.16.1
+jacksonDatabindVersion=2.16.1
+jacksonJaxrsBaseVersion=2.16.1
 
 jamaVersion=1.0.3
 
@@ -224,7 +225,7 @@ jsr305Version=3.0.2
 
 orgJsonVersion=20231013
 
-jsoupVersion=1.16.2
+jsoupVersion=1.17.2
 
 junitVersion=4.13.2
 
@@ -232,7 +233,7 @@ jxlVersion=2.6.3
 
 kaptchaVersion=2.3
 
-log4j2Version=2.21.1
+log4j2Version=2.22.1
 
 lombokVersion=1.18.24
 
@@ -240,11 +241,11 @@ luceneVersion=9.8.0
 
 mysqlDriverVersion=8.2.0
 
-mssqlJdbcVersion=12.4.1.jre11
+mssqlJdbcVersion=12.4.2.jre11
 
 # forced compatibility between docker and UserReg-
 # update version in modules/UserReg-WS/gradle.properties as well
-nettyVersion=4.1.100.Final
+nettyVersion=4.1.104.Final
 
 objenesisVersion=1.0
 
@@ -263,7 +264,7 @@ poiVersion=5.2.3
 
 pollingWatchVersion=0.2.0
 
-postgresqlDriverVersion=42.6.0
+postgresqlDriverVersion=42.7.1
 
 quartzVersion=2.3.2
 
@@ -288,7 +289,7 @@ springBootVersion=2.7.18
 # Also, keep this in sync with apacheTomcatVersion above
 springBootTomcatVersion=9.0.83
 
-springVersion=5.3.30
+springVersion=5.3.31
 
 # Do not upgrade until BaseDaoImpl stops calling getGeneratedKeys()
 sqliteJdbcVersion=3.42.0.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-moduleSet=all
-ideaIncludeAllModules=true
+#moduleSet=all
+#ideaIncludeAllModules=true
 # This controls Gradle's file system watching, which improves efficiency of incremental builds
 # https://docs.gradle.org/current/userguide/file_system_watching.html
 org.gradle.vfs.watch=true


### PR DESCRIPTION
#### Rationale
Keeping up-to-date

Also, introduce `commonsTextVersion` to sync version used by tests, wnprc, and snprc