### PR TITLE
Tweak spring boot properties to allow access to shutdown endpoint

### DIFF
--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -46,6 +46,9 @@ mail.smtpUser=@@smtpUser@@
 
 #useLocalBuild#spring.devtools.restart.additional-paths=@@pathToServer@@/build/deploy/modules,@@pathToServer@@/build/deploy/embedded/config
 
+# Make management endpoints accessible with LabKey at ROOT context path
+server.servlet.context-path=/actuator
+management.endpoints.web.base-path=/
 #Enable shutdown endpoint
 management.endpoint.shutdown.enabled=true
 # turn off other endpoints

--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -11,6 +11,7 @@ import org.labkey.bootstrap.ConfigException;
 import org.labkey.filters.ContentSecurityPolicyFilter;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.ApplicationPidFileWriter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
 import org.springframework.boot.web.embedded.tomcat.TomcatWebServer;
@@ -56,7 +57,9 @@ public class LabKeyServer
             System.setProperty(TERMINATE_ON_STARTUP_FAILURE, "true");
         }
 
-        SpringApplication.run(LabKeyServer.class, args);
+        SpringApplication application = new SpringApplication(LabKeyServer.class);
+        application.addListeners(new ApplicationPidFileWriter("./labkey.pid"));
+        application.run(args);
     }
 
     @Bean


### PR DESCRIPTION
#### Rationale
The Spring shutdown endpoint (`localhost:$port/actuator/shutdown`) is currently inaccessible because the request is sent to LabKey. If we set the servlet context-path to `/actuator` instead of `/` and set the management endpoint base path to `/` instead of `/actuator`, shutdown requests are handled correctly.
This might not be the correct longterm solution but being unable to shut down embedded LabKey is a big problem for wider use on TeamCity.

#### Related Pull Requests
* N/A

#### Changes
* Tweak spring boot properties to allow access to shutdown endpoint
* Create `pid` file when starting embedded `LabKeyServer`
