### PR TITLE
Make CSP examples consistent

### DIFF
--- a/server/bootstrap/src/org/labkey/filters/ContentSecurityPolicyFilter.java
+++ b/server/bootstrap/src/org/labkey/filters/ContentSecurityPolicyFilter.java
@@ -32,10 +32,11 @@ import java.util.stream.Collectors;
           <param-name>policy</param-name>
           <param-value>
             default-src 'self';
-            connect-src 'self' ;
+            connect-src 'self' ${LABKEY.ALLOWED.CONNECTIONS} ;
             object-src 'none' ;
             style-src 'self' 'unsafe-inline' ;
             img-src 'self' data: ;
+            font-src 'self' data: ;
             script-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}';
             base-uri 'self' ;
             upgrade-insecure-requests ;
@@ -64,10 +65,11 @@ import java.util.stream.Collectors;
           <param-name>policy</param-name>
           <param-value>
             default-src 'self' https: ;
-            connect-src 'self' https: ;
+            connect-src 'self' https: ${LABKEY.ALLOWED.CONNECTIONS} ;
             object-src 'none' ;
             style-src 'self' https: 'unsafe-inline' ;
             img-src 'self' data: ;
+            font-src 'self' data: ;
             script-src 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}';
             base-uri 'self' ;
             upgrade-insecure-requests ;

--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -80,14 +80,46 @@ spring.main.banner-mode=off
 
 # example usage 1 - very strict, disallows 'external' websites, disallows unsafe-inline, but only reports violations (does not enforce)
 
-#csp.report=default-src 'self' https: ;\nconnect-src 'self' https: ${LABKEY.ALLOWED.CONNECTIONS};\nobject-src 'none' ;\nstyle-src 'self' https: 'unsafe-inline' ;\nimg-src 'self' data: ;\nscript-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}';\nbase-uri 'self' ;\nupgrade-insecure-requests ;\nframe-ancestors 'self' ;\nreport-uri  https://www.labkey.org/admin-contentsecuritypolicyreport.api ;
+#csp.report=\
+#    default-src 'self';\
+#    connect-src 'self' ${LABKEY.ALLOWED.CONNECTIONS} ;\
+#    object-src 'none' ;\
+#    style-src 'self' 'unsafe-inline' ;\
+#    img-src 'self' data: ;\
+#    font-src 'self' data: ;\
+#    script-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}';\
+#    base-uri 'self' ;\
+#    upgrade-insecure-requests ;\
+#    frame-ancestors 'self' ;\
+#    report-uri https://www.labkey.org/admin-contentsecuritypolicyreport.api ;
 
 # example usage 2 - less strict but enforces directives, (NOTE: unsafe-inline is still required for many modules)
 
-#csp.enforce=default-src 'self' https: ;\nconnect-src 'self' https: ${LABKEY.ALLOWED.CONNECTIONS};\nobject-src 'none' ;\nstyle-src 'self' https: 'unsafe-inline' ;\nimg-src 'self' data: ;\nscript-src 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}';\nbase-uri 'self' ;\nupgrade-insecure-requests ;\nframe-ancestors 'self' ;\nreport-uri  https://www.labkey.org/admin-contentsecuritypolicyreport.api ;
+#csp.enforce=\
+#    default-src 'self' https: ;\
+#    connect-src 'self' https: ${LABKEY.ALLOWED.CONNECTIONS};\
+#    object-src 'none' ;\
+#    style-src 'self' https: 'unsafe-inline' ;\
+#    img-src 'self' data: ;\
+#    font-src 'self' data: ;\
+#    script-src 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}';\
+#    base-uri 'self' ;\
+#    upgrade-insecure-requests ;\
+#    frame-ancestors 'self' ;\
+#    report-uri  https://www.labkey.org/admin-contentsecuritypolicyreport.api ;
 
 # Default CSP for TeamCity and dev deployments
-#setupTask#csp.report=default-src 'self' https: http: ;\nconnect-src 'self' ${LABKEY.ALLOWED.CONNECTIONS} ;\nobject-src 'none' ;\nstyle-src 'self' https: 'unsafe-inline' ;\nimg-src 'self' https: data: ;\nfont-src 'self' https: data: ;\nscript-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ;\nbase-uri 'self' ;\nframe-ancestors 'self' ;\nreport-uri /admin-contentsecuritypolicyreport.api ;
+#setupTask#csp.report=\
+#setupTask#    default-src 'self' https: http: ;\
+#setupTask#    connect-src 'self' ${LABKEY.ALLOWED.CONNECTIONS} ;\
+#setupTask#    object-src 'none' ;\
+#setupTask#    style-src 'self' https: 'unsafe-inline' ;\
+#setupTask#    img-src 'self' https: data: ;\
+#setupTask#    font-src 'self' https: data: ;\
+#setupTask#    script-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ;\
+#setupTask#    base-uri 'self' ;\
+#setupTask#    frame-ancestors 'self' ;\
+#setupTask#    report-uri /admin-contentsecuritypolicyreport.api ;
 
 # Use a non-temp directory for tomcat
 #setupTask#server.tomcat.basedir=@@pathToServer@@/build/deploy/embedded

--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -80,11 +80,11 @@ spring.main.banner-mode=off
 
 # example usage 1 - very strict, disallows 'external' websites, disallows unsafe-inline, but only reports violations (does not enforce)
 
-#csp.report=default-src 'self' https: ;\nconnect-src 'self' https: ;\nobject-src 'none' ;\nstyle-src 'self' https: 'unsafe-inline' ;\nimg-src 'self' data: ;\nscript-src 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}';\nbase-uri 'self' ;\nupgrade-insecure-requests ;\nframe-ancestors 'self' ;\nreport-uri  https://www.labkey.org/admin-contentsecuritypolicyreport.api ;
+#csp.report=default-src 'self' https: ;\nconnect-src 'self' https: ${LABKEY.ALLOWED.CONNECTIONS};\nobject-src 'none' ;\nstyle-src 'self' https: 'unsafe-inline' ;\nimg-src 'self' data: ;\nscript-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}';\nbase-uri 'self' ;\nupgrade-insecure-requests ;\nframe-ancestors 'self' ;\nreport-uri  https://www.labkey.org/admin-contentsecuritypolicyreport.api ;
 
 # example usage 2 - less strict but enforces directives, (NOTE: unsafe-inline is still required for many modules)
 
-#csp.enforce=default-src 'self' https: ;\nconnect-src 'self' https: ;\nobject-src 'none' ;\nstyle-src 'self' https: 'unsafe-inline' ;\nimg-src 'self' data: ;\nscript-src 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}';\nbase-uri 'self' ;\nupgrade-insecure-requests ;\nframe-ancestors 'self' ;\nreport-uri  https://www.labkey.org/admin-contentsecuritypolicyreport.api ;
+#csp.enforce=default-src 'self' https: ;\nconnect-src 'self' https: ${LABKEY.ALLOWED.CONNECTIONS};\nobject-src 'none' ;\nstyle-src 'self' https: 'unsafe-inline' ;\nimg-src 'self' data: ;\nscript-src 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}';\nbase-uri 'self' ;\nupgrade-insecure-requests ;\nframe-ancestors 'self' ;\nreport-uri  https://www.labkey.org/admin-contentsecuritypolicyreport.api ;
 
 # Default CSP for TeamCity and dev deployments
 #setupTask#csp.report=default-src 'self' https: http: ;\nconnect-src 'self' ${LABKEY.ALLOWED.CONNECTIONS} ;\nobject-src 'none' ;\nstyle-src 'self' https: 'unsafe-inline' ;\nimg-src 'self' https: data: ;\nfont-src 'self' https: data: ;\nscript-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ;\nbase-uri 'self' ;\nframe-ancestors 'self' ;\nreport-uri /admin-contentsecuritypolicyreport.api ;

--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -80,14 +80,14 @@ spring.main.banner-mode=off
 
 # example usage 1 - very strict, disallows 'external' websites, disallows unsafe-inline, but only reports violations (does not enforce)
 
-#csp.report=default-src 'self' https: ;\nconnect-src 'self' https: ;\nobject-src 'none' ;\nstyle-src 'self' https: 'unsafe-inline' ;\nimg-src 'self' data: ;\nscript-src 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}';\nbase-uri 'self' ;\nupgrade-insecure-requests ;\nframe-ancestors 'self' ;\nreport-to  https://www.labkey.org/admin-contentsecuritypolicyreport.api ;\nreport-uri  https://www.labkey.org/admin-contentsecuritypolicyreport.api ;
+#csp.report=default-src 'self' https: ;\nconnect-src 'self' https: ;\nobject-src 'none' ;\nstyle-src 'self' https: 'unsafe-inline' ;\nimg-src 'self' data: ;\nscript-src 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}';\nbase-uri 'self' ;\nupgrade-insecure-requests ;\nframe-ancestors 'self' ;\nreport-uri  https://www.labkey.org/admin-contentsecuritypolicyreport.api ;
 
 # example usage 2 - less strict but enforces directives, (NOTE: unsafe-inline is still required for many modules)
 
-#csp.enforce=default-src 'self' https: ;\nconnect-src 'self' https: ;\nobject-src 'none' ;\nstyle-src 'self' https: 'unsafe-inline' ;\nimg-src 'self' data: ;\nscript-src 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}';\nbase-uri 'self' ;\nupgrade-insecure-requests ;\nframe-ancestors 'self' ;\nreport-to  https://www.labkey.org/admin-contentsecuritypolicyreport.api ;\nreport-uri  https://www.labkey.org/admin-contentsecuritypolicyreport.api ;
+#csp.enforce=default-src 'self' https: ;\nconnect-src 'self' https: ;\nobject-src 'none' ;\nstyle-src 'self' https: 'unsafe-inline' ;\nimg-src 'self' data: ;\nscript-src 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}';\nbase-uri 'self' ;\nupgrade-insecure-requests ;\nframe-ancestors 'self' ;\nreport-uri  https://www.labkey.org/admin-contentsecuritypolicyreport.api ;
 
 # Default CSP for TeamCity and dev deployments
-#setupTask#csp.report=default-src 'self' https: http: ;\nconnect-src 'self' ${LABKEY.ALLOWED.CONNECTIONS} ;\nobject-src 'none' ;\nstyle-src 'self' https: 'unsafe-inline' ;\nimg-src 'self' https: data: ;\nscript-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ;\nbase-uri 'self' ;\nframe-ancestors 'self' ;\nreport-to /admin-contentsecuritypolicyreport.api ;\nreport-uri /admin-contentsecuritypolicyreport.api ;
+#setupTask#csp.report=default-src 'self' https: http: ;\nconnect-src 'self' ${LABKEY.ALLOWED.CONNECTIONS} ;\nobject-src 'none' ;\nstyle-src 'self' https: 'unsafe-inline' ;\nimg-src 'self' https: data: ;\nfont-src 'self' https: data: ;\nscript-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ;\nbase-uri 'self' ;\nframe-ancestors 'self' ;\nreport-uri /admin-contentsecuritypolicyreport.api ;
 
 # Use a non-temp directory for tomcat
 #setupTask#server.tomcat.basedir=@@pathToServer@@/build/deploy/embedded


### PR DESCRIPTION
#### Rationale
`${LABKEY.ALLOWED.CONNECTIONS}` is missing from the `web.xml` CSP example. `font-src` is also missing from all examples, which is causing warnings locally and on labkey.org.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Add `${LABKEY.ALLOWED.CONNECTIONS}` to `connect-src` directives
* Add `font-src` to CSP examples
* Remove `report-to` from `application.properties`
* Make examples more readable in `application.properties`
