### PR TITLE
Update several dependencies

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -143,7 +143,7 @@ commonsPoolVersion=1.6
 commonsTextVersion=1.11.0
 commonsValidatorVersion=1.8.0
 
-datadogVersion=0.108.1
+datadogVersion=1.27.0
 
 dom4jVersion=2.1.4
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -108,7 +108,7 @@ apacheTomcatVersion=9.0.83
 # (mothership) -> json-path -> json-smart -> accessor-smart
 # (core) -> graalvm
 # tika
-asmVersion=9.5
+asmVersion=9.6
 
 # Apache Batik -- Batik version needs to be compatible with Apache FOP, but we need to pull in batik-codec separately
 batikVersion=1.17
@@ -237,7 +237,7 @@ log4j2Version=2.22.1
 
 lombokVersion=1.18.24
 
-luceneVersion=9.8.0
+luceneVersion=9.9.1
 
 mysqlDriverVersion=8.2.0
 
@@ -257,7 +257,7 @@ openTracingVersion=0.33.0
 oracleJdbcVersion=23.3.0.23.09
 
 # sync with version Tika ships
-pdfboxVersion=2.0.28
+pdfboxVersion=2.0.29
 
 # sync with version Tika ships
 poiVersion=5.2.3
@@ -271,15 +271,15 @@ quartzVersion=2.3.2
 rforgeVersion=0.6-8.1
 
 # sync with Tika version
-romeVersion=1.19.0
+romeVersion=2.1.0
 
 # Tomcat 9 implements 4.x
 servletApiVersion=4.0.1
 
 # this version is forced for compatibility with pipeline and tika
-slf4jLog4j12Version=2.0.7
+slf4jLog4j12Version=2.0.9
 # this version is forced for compatibility with api, LDK, and workflow
-slf4jLog4jApiVersion=2.0.7
+slf4jLog4jApiVersion=2.0.9
 
 # This is a dependency for HTSJDK. Force version for CVE-2023-43642
 snappyJavaVersion=1.1.10.5
@@ -300,7 +300,7 @@ stax2ApiVersion=4.2.1
 thumbnailatorVersion=0.4.8
 
 # used for tika-core in API and tika-parsers in search
-tikaVersion=2.8.0
+tikaVersion=2.9.1
 
 # sync with Tika
 tukaaniXZVersion=1.9
@@ -321,4 +321,4 @@ xercesImplVersion=2.12.2
 xmlApisVersion=1.0.b2
 
 # sync with Tika/POI
-xmlbeansVersion=5.1.1
+xmlbeansVersion=5.2.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -128,7 +128,7 @@ commonsCollectionsVersion=3.2.2
 commonsCollections4Version=4.4
 commonsCodecVersion=1.16.0
 # sync with version Tika ships
-commonsCompressVersion=1.24.0
+commonsCompressVersion=1.25.0
 commonsDbcpVersion=1.4
 commonsDiscoveryVersion=0.2
 commonsDigesterVersion=1.8.1
@@ -136,12 +136,12 @@ commonsFileuploadVersion=1.5
 commonsIoVersion=2.15.1
 commonsLangVersion=2.6
 commonsLang3Version=3.14.0
-commonsLoggingVersion=1.2
+commonsLoggingVersion=1.3.0
 commonsMath3Version=3.6.1
 commonsNetVersion=3.10.0
 commonsPoolVersion=1.6
 commonsTextVersion=1.11.0
-commonsValidatorVersion=1.7
+commonsValidatorVersion=1.8.0
 
 datadogVersion=0.108.1
 


### PR DESCRIPTION
#### Rationale
Update Tika and all its dependencies to the latest version. Update Lucene. Update other libraries.