### PR TITLE
Make `stopTomcat` and `killFirefox` tasks more reliable on TeamCity

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -62,7 +62,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.31.9
 gradleNodePluginVersion=3.5.1
-gradlePluginsVersion=2.1.0
+gradlePluginsVersion=2.1.1-stopEmbeddedTomcat-SNAPSHOT
 owaspDependencyCheckPluginVersion=8.4.3
 versioningPluginVersion=1.1.2
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -62,7 +62,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.31.9
 gradleNodePluginVersion=3.5.1
-gradlePluginsVersion=2.1.1
+gradlePluginsVersion=2.2.1
 owaspDependencyCheckPluginVersion=8.4.3
 versioningPluginVersion=1.1.2
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -62,7 +62,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.31.9
 gradleNodePluginVersion=3.5.1
-gradlePluginsVersion=2.1.1-stopEmbeddedTomcat-SNAPSHOT
+gradlePluginsVersion=2.1.1
 owaspDependencyCheckPluginVersion=8.4.3
 versioningPluginVersion=1.1.2
 


### PR DESCRIPTION
#### Rationale
The debug port is getting left open on TeamCity when running with embedded tomcat.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/194

#### Changes
* Update `gradlePluginsVersion=2.2.1`
