### PR TITLE
Support additional context paths

### DIFF
--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -32,6 +32,20 @@ context.validationQuery[0]=SELECT 1
 
 #useLocalBuild#context.webAppLocation=@@pathToServer@@/build/deploy/labkeyWebapp
 context.encryptionKey=@@encryptionKey@@
+
+# By default, we'll deploy to the root context path. However, some servers have historically used /labkey or even /cpas
+#context.contextPath=/labkey
+
+# Using a legacy context path provides backwards compatibility with old deployments. A typical use case would be to
+# deploy to the root context (the default) and configure /labkey as the legacy path. GETs will be redirected, and
+# non-GETs will be handled server-side via a servlet forward.
+#context.legacyContextPath=/labkey
+
+# Other webapps to be deployed, most commonly to deliver a set of static files. Additional
+# webapps can be specified via additional indices. docBase should point at the root of the webapp's content
+#webapps.contextPath[0]=/anotherWebapp
+#webapps.docBase[0]=/my/webapp/path
+
 #context.oldEncryptionKey=
 #context.requiredModules=
 #context.pipelineConfig=/path/to/pipeline/config/dir

--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -193,7 +193,7 @@ public class LabKeyServer
                     {
                         if (contextProperties.getContextPath() != null && !contextProperties.getContextPath().isEmpty() && !contextProperties.getContextPath().equals("/"))
                         {
-                            throw new IllegalArgumentException("contextPath.legacyContextPath is only intended for use when deploying the LabKey application to the root context path. Please update application.properties");
+                            throw new IllegalArgumentException("contextPath.legacyContextPath is only intended for use when deploying the LabKey application to the root context path. Please update application.properties.");
                         }
                         context.addParameter("legacyContextPath", contextProperties.getLegacyContextPath());
                     }

--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -191,6 +191,10 @@ public class LabKeyServer
 
                     if (contextProperties.getLegacyContextPath() != null)
                     {
+                        if (contextProperties.getContextPath() != null && !contextProperties.getContextPath().isEmpty() && !contextProperties.getContextPath().equals("/"))
+                        {
+                            throw new IllegalArgumentException("contextPath.legacyContextPath is only intended for use when deploying the LabKey application to the root context path. Please update application.properties");
+                        }
                         context.addParameter("legacyContextPath", contextProperties.getLegacyContextPath());
                     }
                     if (contextProperties.getRequiredModules() != null)


### PR DESCRIPTION
#### Rationale
Some server configurations have historically used non-root context paths, and/or deployed additional web apps for delivering static content.

#### Changes
* Property to control LabKey's context path: `context.contextPath`
* Property to automatically redirect/forward requests from a legacy context path to the root: `context.legacyContextPath`
* Properties to deploy extra web apps: `webapps.contextPath` and `webapps.docBase`