### PR TITLE
Revert to older SQLite JDBC driver

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -291,7 +291,8 @@ springBootTomcatVersion=9.0.83
 
 springVersion=5.3.31
 
-sqliteJdbcVersion=3.45.0.0
+# Do not upgrade until BaseDaoImpl stops calling getGeneratedKeys(), Issue 49462
+sqliteJdbcVersion=3.42.0.1
 
 # NLP and SAML bring stax2-api in as a transitive dependency but with very different versions. We force the later version.
 stax2ApiVersion=4.2.1


### PR DESCRIPTION
#### Rationale
Newer versions of SQLite JDBC stopped implementing `Statement.getGeneratedKeys()` for multi-row inserts; TargetedMS `BaseDaoImpl.insertAndReturnIds()` relies on this behavior, hence tests failed (appropriately).

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49462

#### Related Pull Requests
* https://github.com/LabKey/server/pull/689