### PR TITLE
Add ${CSP.REPORT.PARAMS} to sample CSP report-uri directives

### DIFF
--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -91,7 +91,7 @@ spring.main.banner-mode=off
 #    base-uri 'self' ;\
 #    upgrade-insecure-requests ;\
 #    frame-ancestors 'self' ;\
-#    report-uri https://www.labkey.org/admin-contentsecuritypolicyreport.api ;
+#    report-uri https://www.labkey.org/admin-contentsecuritypolicyreport.api?${CSP.REPORT.PARAMS} ;
 
 # example usage 2 - less strict but enforces directives, (NOTE: unsafe-inline is still required for many modules)
 
@@ -106,7 +106,7 @@ spring.main.banner-mode=off
 #    base-uri 'self' ;\
 #    upgrade-insecure-requests ;\
 #    frame-ancestors 'self' ;\
-#    report-uri  https://www.labkey.org/admin-contentsecuritypolicyreport.api ;
+#    report-uri  https://www.labkey.org/admin-contentsecuritypolicyreport.api?${CSP.REPORT.PARAMS} ;
 
 # Default CSP for TeamCity and dev deployments
 #setupTask#csp.report=\
@@ -119,7 +119,7 @@ spring.main.banner-mode=off
 #setupTask#    script-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ;\
 #setupTask#    base-uri 'self' ;\
 #setupTask#    frame-ancestors 'self' ;\
-#setupTask#    report-uri /admin-contentsecuritypolicyreport.api ;
+#setupTask#    report-uri /admin-contentsecuritypolicyreport.api?${CSP.REPORT.PARAMS} ;
 
 # Use a non-temp directory for tomcat
 #setupTask#server.tomcat.basedir=@@pathToServer@@/build/deploy/embedded


### PR DESCRIPTION
#### Rationale
`${CSP.REPORT.PARAMS}` is getting automatically appended to `report-uri` but this is temporary. Need to actually add it to `application.properties`.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/5164

#### Changes
* Add `?${CSP.REPORT.PARAMS}` to testing and example report-uri directives
