### PR TITLE
Allow TeamCity to disable embedded tomcat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,10 @@ enlistment.properties
 server/config.properties
 #IntelliJ build output directory
 server/bootstrap/out/
+dist/
+external/
 
 # Ignore other common repository locations
-dist/
 distributions/
 labkey-api-*/
 labkey-ui-components/

--- a/gradle.properties
+++ b/gradle.properties
@@ -62,7 +62,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.31.9
 gradleNodePluginVersion=3.5.1
-gradlePluginsVersion=2.2.1
+gradlePluginsVersion=2.2.2-useEmbeddedTomcatFalse-SNAPSHOT
 owaspDependencyCheckPluginVersion=8.4.3
 versioningPluginVersion=1.1.2
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -62,7 +62,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.31.9
 gradleNodePluginVersion=3.5.1
-gradlePluginsVersion=2.2.2-useEmbeddedTomcatFalse-SNAPSHOT
+gradlePluginsVersion=2.2.2
 owaspDependencyCheckPluginVersion=8.4.3
 versioningPluginVersion=1.1.2
 

--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -91,7 +91,7 @@ spring.main.banner-mode=off
 #    base-uri 'self' ;\
 #    upgrade-insecure-requests ;\
 #    frame-ancestors 'self' ;\
-#    report-uri https://www.labkey.org/admin-contentsecuritypolicyreport.api ;
+#    report-uri https://www.labkey.org/admin-contentsecuritypolicyreport.api?${CSP.REPORT.PARAMS} ;
 
 # example usage 2 - less strict but enforces directives, (NOTE: unsafe-inline is still required for many modules)
 
@@ -106,7 +106,7 @@ spring.main.banner-mode=off
 #    base-uri 'self' ;\
 #    upgrade-insecure-requests ;\
 #    frame-ancestors 'self' ;\
-#    report-uri  https://www.labkey.org/admin-contentsecuritypolicyreport.api ;
+#    report-uri  https://www.labkey.org/admin-contentsecuritypolicyreport.api?${CSP.REPORT.PARAMS} ;
 
 # Default CSP for TeamCity and dev deployments
 #setupTask#csp.report=\
@@ -119,7 +119,7 @@ spring.main.banner-mode=off
 #setupTask#    script-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ;\
 #setupTask#    base-uri 'self' ;\
 #setupTask#    frame-ancestors 'self' ;\
-#setupTask#    report-uri /admin-contentsecuritypolicyreport.api ;
+#setupTask#    report-uri /admin-contentsecuritypolicyreport.api?${CSP.REPORT.PARAMS} ;
 
 # Use a non-temp directory for tomcat
 #setupTask#server.tomcat.basedir=@@pathToServer@@/build/deploy/embedded

--- a/settings.gradle
+++ b/settings.gradle
@@ -96,7 +96,7 @@ import org.labkey.gradle.util.BuildUtils
   node in the tree with these leaves (e.g., 'server:modules:core' will create projects for ":server"
   ":server:modules" and ":server:modules:core").
  */
-if (hasProperty("useEmbeddedTomcat") && useEmbeddedTomcat != "false")
+if (BuildUtils.useEmbeddedTomcat(this.settings))
 {
     include ":server:embedded"
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -96,7 +96,7 @@ import org.labkey.gradle.util.BuildUtils
   node in the tree with these leaves (e.g., 'server:modules:core' will create projects for ":server"
   ":server:modules" and ":server:modules:core").
  */
-if (hasProperty("useEmbeddedTomcat"))
+if (hasProperty("useEmbeddedTomcat") && useEmbeddedTomcat != "false")
 {
     include ":server:embedded"
 }


### PR DESCRIPTION
#### Rationale
In order to make embedded tomcat the default, we need a way to turn it off for testing on TeamCity.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/195

#### Changes
* Update gradle plugin to get new handling of `useEmbeddedTomcat` flag
