### PR TITLE
Fix configuration of second data source for embedded Tomcat

### DIFF
--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -23,8 +23,8 @@ context.validationQuery[0]=SELECT 1
 
 #context.dataSourceName[1]=jdbc/@@extraJdbcDataSource@@
 #context.driverClassName[1]=@@extraJdbcDriverClassName@@
-#context.url[1]=@@extraJdbcURL@@
-#context.username[1]=@@extraJdbcUser@@
+#context.url[1]=@@extraJdbcUrl@@
+#context.username[1]=@@extraJdbcUsername@@
 #context.password[1]=@@extraJdbcPassword@@
 
 #useLocalBuild#context.webAppLocation=@@pathToServer@@/build/deploy/labkeyWebapp


### PR DESCRIPTION
#### Rationale
The replacement strings in `application.properties` should match what's in `labkey.xml` so that we can switch to embedded more easily.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/30

#### Changes
* Fix some replacement strings in `application.properties`
