### PR TITLE
Support both HTTPS and HTTP concurrently, respect session timeout

### DIFF
--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -7,8 +7,12 @@ server.port=@@serverPort@@
 #server.ssl.key-alias=my_selfsigned
 #server.ssl.key-store=/path/to/key-store-file
 #server.ssl.key-store-password=pwd
-#server.ssl.key-store-type=key-store-type
+# Typically either PKCS12 or JKS
+#server.ssl.key-store-type=PKCS12
 #server.ssl.ciphers=ciphers
+
+# HTTP-only port for servers that need to handle both HTTPS (configure via server.port and server.ssl above) and HTTP
+#context.httpPort=8080
 
 context.dataSourceName[0]=jdbc/labkeyDataSource
 context.driverClassName[0]=@@jdbcDriverClassName@@
@@ -84,9 +88,12 @@ mail.smtpUser=@@smtpUser@@
 
 #useLocalBuild#spring.devtools.restart.additional-paths=@@pathToServer@@/build/deploy/modules,@@pathToServer@@/build/deploy/embedded/config
 
-# Make management endpoints accessible with LabKey at ROOT context path
-server.servlet.context-path=/actuator
-management.endpoints.web.base-path=/
+# HTTP session timeout for users - defaults to 30 minutes
+#server.servlet.session.timeout=30m
+
+## Make management endpoints accessible with LabKey at ROOT context path
+#server.servlet.context-path=/actuator
+#management.endpoints.web.base-path=/
 #Enable shutdown endpoint
 management.endpoint.shutdown.enabled=true
 # turn off other endpoints


### PR DESCRIPTION
#### Rationale
We need embedded Tomcat deployments to support both HTTPS and HTTP at the same time. We also want to let admins configure things like session timeouts via the normal Spring Boot properties.

#### Changes
* New config property `context.httpPort` to configure a minimalist HTTP connector
* Propagate the config from the embedded Tomcat context into the StandardContext for our web app