### PR TITLE
Avoid importing old versions of servlet classes

### DIFF
--- a/.idea/codeInsightSettings.xml
+++ b/.idea/codeInsightSettings.xml
@@ -10,6 +10,7 @@
       <name>java.lang.System.Logger</name>
       <name>java.util.logging.Logger</name>
       <name>javax.annotation.Nullable</name>
+      <name>javax.servlet</name>
       <name>javax.validation.constraints.NotNull</name>
       <name>org.apache.camel.processor.Logger</name>
       <name>org.apache.commons.codec.binary.StringUtils</name>


### PR DESCRIPTION
#### Rationale
We need to have the old `javax.servlet` classes around for a dependency that expects them. We don't want developers importing them for new code though.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/5173

#### Changes
* Block `javax.servlet` import suggestions from IntelliJ
