### PR TITLE
Embedded Tomcat support for custom webapp resources

### DIFF
--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -64,6 +64,14 @@ management.endpoints.web.exposure.include=*
 # Don't show the Spring banner on startup
 spring.main.banner-mode=off
 
+# Optional - JMS configuration for remote ActiveMQ message management for distributed pipeline jobs
+# https://www.labkey.org/Documentation/wiki-page.view?name=jmsQueue
+#context.resources.jms.name=jms/ConnectionFactory
+#context.resources.jms.type=org.apache.activemq.ActiveMQConnectionFactory
+#context.resources.jms.factory=org.apache.activemq.jndi.JNDIReferenceFactory
+#context.resources.jms.description=JMS Connection Factory
+#context.resources.jms.brokerURL=vm://localhost?broker.persistent=false&broker.useJmx=false
+#context.resources.jms.brokerName=LocalActiveMQBroker
 
 # Turn on JSON-formatted HTTP access logging to stdout. See issue 48565
 # https://tomcat.apache.org/tomcat-9.0-doc/config/valve.html#JSON_Access_Log_Valve

--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -66,26 +66,6 @@ mail.smtpUser=@@smtpUser@@
 # mail.smtpSocketFactoryClass=@@smtpSocketFactoryClass@@
 # mail.smtpAuth=@@smtpAuth@@
 
-# Optional - JMS configuration for remote ActiveMQ message management for distributed pipeline jobs
-# https://www.labkey.org/Documentation/wiki-page.view?name=jmsQueue
-#jms.type=org.apache.activemq.ActiveMQConnectionFactory
-#jms.factory=org.apache.activemq.jndi.JNDIReferenceFactory
-#jms.description=JMS Connection Factory
-#jms.brokerURL=vm://localhost?broker.persistent=false&broker.useJmx=false
-#jms.brokerName=LocalActiveMQBroker
-
-# Optional - LDAP configuration for LDAP group/user synchronization
-# https://www.labkey.org/Documentation/wiki-page.view?name=LDAP_sync
-#ldap.type=org.labkey.premium.ldap.LdapConnectionConfigFactory
-#ldap.factory=org.labkey.premium.ldap.LdapConnectionConfigFactory
-#ldap.host=ldap.forumsys.com
-#ldap.port=389
-#ldap.principal=cn=read-only-admin,dc=example,dc=com
-#ldap.credentials=password
-#ldap.useTls=false
-#ldap.useSsl=false
-#ldap.sslProtocol=SSLv3
-
 #useLocalBuild#spring.devtools.restart.additional-paths=@@pathToServer@@/build/deploy/modules,@@pathToServer@@/build/deploy/embedded/config
 
 # HTTP session timeout for users - defaults to 30 minutes

--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -263,16 +263,15 @@ public class LabKeyServer
                     resourceMap.putAll(entry.getValue());
                     if (!resourceMap.containsKey("name"))
                     {
-                        logger.error("Resource configuration error: Ignoring unnamed resource 'context.resources.%s'".formatted(entry.getKey()));
-                        continue;
+                        throw new ConfigException("Resource configuration error: Unnamed resource found 'context.resources.%s'".formatted(entry.getKey()));
                     }
                     if (!resourceMap.containsKey("type"))
                     {
-                        logger.error("Resource configuration error: type is not defined for resource '%s'".formatted(resourceMap.get("name")));
-                        continue;
+                        throw new ConfigException("Resource configuration error: 'type' is not defined for resource '%s'".formatted(resourceMap.get("name")));
                     }
 
                     ContextResource contextResource = new ContextResource();
+                    // Handle resource properties with explicit setters
                     contextResource.setName(resourceMap.remove("name"));
                     contextResource.setType(resourceMap.remove("type"));
                     contextResource.setDescription(resourceMap.remove("description"));
@@ -282,6 +281,8 @@ public class LabKeyServer
                         contextResource.setScope(resourceMap.remove("scope"));
                     }
                     contextResource.setAuth(Objects.requireNonNullElse(resourceMap.remove("auth"), "Container"));
+
+                    // Set remaining properties
                     for (Map.Entry<String, String> prop : resourceMap.entrySet())
                     {
                         contextResource.setProperty(prop.getKey(), prop.getValue());

--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -79,18 +79,6 @@ public class LabKeyServer
     }
 
     @Bean
-    public LdapProperties ldapSource()
-    {
-        return new LdapProperties();
-    }
-
-    @Bean
-    public JmsProperties jmsSource()
-    {
-        return new JmsProperties();
-    }
-
-    @Bean
     public WebappProperties additionalWebappSource()
     {
         return new WebappProperties();
@@ -182,18 +170,6 @@ public class LabKeyServer
 
                     // Add the SMTP config
                     context.getNamingResources().addResource(getMailResource());
-
-                    ContextResource jmsResource = getJmsResource();
-                    if (jmsResource != null)
-                    {
-                        context.getNamingResources().addResource(jmsResource);
-                    }
-
-                    ContextResource ldapResource = getLdapResource();
-                    if (ldapResource != null)
-                    {
-                        context.getNamingResources().addResource(ldapResource);
-                    }
 
                     // And the master encryption key
                     context.addParameter("EncryptionKey", contextProperties.getEncryptionKey());
@@ -388,57 +364,6 @@ public class LabKeyServer
 
                 String val = propValues.getOrDefault(resourceKey, defaultValue);
                 return val != null && !val.isBlank() ? val.trim() : defaultValue;
-            }
-
-            private ContextResource getJmsResource()
-            {
-                JmsProperties jmsProps = jmsSource();
-                if (jmsProps.getBrokerURL() == null)
-                {
-                    return null;
-                }
-
-                ContextResource jmsResource = new ContextResource();
-                jmsResource.setName("jms/ConnectionFactory");
-                jmsResource.setAuth("Container");
-                jmsResource.setType(jmsProps.getType());
-                jmsResource.setProperty("factory", jmsProps.getFactory());
-                jmsResource.setProperty("description", jmsProps.getDescription());
-                jmsResource.setProperty("brokerURL", jmsProps.getBrokerURL());
-                jmsResource.setProperty("brokerName", jmsProps.getBrokerName());
-                return jmsResource;
-            }
-
-            private ContextResource getLdapResource()
-            {
-                LdapProperties ldapProps = ldapSource();
-                if (ldapProps.getHost() == null)
-                {
-                    return null;
-                }
-
-                ContextResource ldapResource = new ContextResource();
-                ldapResource.setName("ldap/ConfigFactory");
-                ldapResource.setAuth("Container");
-                ldapResource.setType(ldapProps.getType());
-                ldapResource.setProperty("factory", ldapProps.getFactory());
-                ldapResource.setProperty("host", ldapProps.getHost());
-                ldapResource.setProperty("port", Integer.toString(ldapProps.getPort()));
-                if (ldapProps.getPrincipal() != null)
-                {
-                    ldapResource.setProperty("principal", ldapProps.getPrincipal());
-                }
-                if (ldapProps.getCredentials() != null)
-                {
-                    ldapResource.setProperty("credentials", ldapProps.getCredentials());
-                }
-                ldapResource.setProperty("useSsl", Boolean.toString(ldapProps.isUseSsl()));
-                ldapResource.setProperty("useTls", Boolean.toString(ldapProps.isUseTls()));
-                if (ldapProps.getSslProtocol() != null)
-                {
-                    ldapResource.setProperty("sslProtocol", ldapProps.getSslProtocol());
-                }
-                return ldapResource;
             }
 
             private ContextResource getMailResource()
@@ -935,16 +860,6 @@ public class LabKeyServer
             this.validationQuery = validationQuery;
         }
 
-        public Map<String, Map<String, String>> getResources()
-        {
-            return resources;
-        }
-
-        public void setResources(Map<String, Map<String, String>> resources)
-        {
-            this.resources = resources;
-        }
-
         public Map<Integer, String> getDisplayName()
         {
             return displayName;
@@ -964,171 +879,15 @@ public class LabKeyServer
         {
             this.logQueries = logQueries;
         }
-    }
 
-    @Configuration
-    @ConfigurationProperties("ldap")
-    public static class LdapProperties
-    {
-        private String type = "org.labkey.premium.ldap.LdapConnectionConfigFactory";
-        private String factory = "org.labkey.premium.ldap.LdapConnectionConfigFactory";
-        private String host = null;
-        private int port = 389;
-        private String principal = null;
-        private String credentials = null;
-        private boolean useTls = false;
-        private boolean useSsl = false;
-        private String sslProtocol;
-
-        public String getType()
+        public Map<String, Map<String, String>> getResources()
         {
-            return type;
+            return resources;
         }
 
-        public void setType(String type)
+        public void setResources(Map<String, Map<String, String>> resources)
         {
-            this.type = type;
-        }
-
-        public String getFactory()
-        {
-            return factory;
-        }
-
-        public void setFactory(String factory)
-        {
-            this.factory = factory;
-        }
-
-        public String getHost()
-        {
-            return host;
-        }
-
-        public void setHost(String host)
-        {
-            this.host = host;
-        }
-
-        public int getPort()
-        {
-            return port;
-        }
-
-        public void setPort(int port)
-        {
-            this.port = port;
-        }
-
-        public String getPrincipal()
-        {
-            return principal;
-        }
-
-        public void setPrincipal(String principal)
-        {
-            this.principal = principal;
-        }
-
-        public String getCredentials()
-        {
-            return credentials;
-        }
-
-        public void setCredentials(String credentials)
-        {
-            this.credentials = credentials;
-        }
-
-        public boolean isUseTls()
-        {
-            return useTls;
-        }
-
-        public void setUseTls(boolean useTls)
-        {
-            this.useTls = useTls;
-        }
-
-        public boolean isUseSsl()
-        {
-            return useSsl;
-        }
-
-        public void setUseSsl(boolean useSsl)
-        {
-            this.useSsl = useSsl;
-        }
-
-        public String getSslProtocol()
-        {
-            return sslProtocol;
-        }
-
-        public void setSslProtocol(String sslProtocol)
-        {
-            this.sslProtocol = sslProtocol;
-        }
-    }
-
-    @Configuration
-    @ConfigurationProperties("jms")
-    public static class JmsProperties
-    {
-        private String type = "org.apache.activemq.ActiveMQConnectionFactory";
-        private String factory = "org.apache.activemq.jndi.JNDIReferenceFactory";
-        private String description = "JMS Connection Factory";
-        private String brokerURL = null;
-        private String brokerName = "LocalActiveMQBroker";
-
-        public String getType()
-        {
-            return type;
-        }
-
-        public void setType(String type)
-        {
-            this.type = type;
-        }
-
-        public String getFactory()
-        {
-            return factory;
-        }
-
-        public void setFactory(String factory)
-        {
-            this.factory = factory;
-        }
-
-        public String getDescription()
-        {
-            return description;
-        }
-
-        public void setDescription(String description)
-        {
-            this.description = description;
-        }
-
-        public String getBrokerURL()
-        {
-            return brokerURL;
-        }
-
-        public void setBrokerURL(String brokerURL)
-        {
-            this.brokerURL = brokerURL;
-        }
-
-        public String getBrokerName()
-        {
-            return brokerName;
-        }
-
-        public void setBrokerName(String brokerName)
-        {
-            this.brokerName = brokerName;
+            this.resources = resources;
         }
     }
 


### PR DESCRIPTION
#### Rationale
A more generic solution for adding Resources to the webapp.
`labkey.xml` could have arbitrary `<Resource>` elements. This adds similar capability to `application.properties`.

This JMS resource from `labkey.xml`:
```
<Resource name="jms/ConnectionFactory" auth="Container"
        type="org.apache.activemq.ActiveMQConnectionFactory"
        factory="org.apache.activemq.jndi.JNDIReferenceFactory"
        description="JMS Connection Factory"
        brokerURL="vm://localhost?broker.persistent=false&amp;broker.useJmx=false"
        brokerName="LocalActiveMQBroker"/>
```
Can be represented like this in `application.properties`:
```
context.resources.jms.name=jms/ConnectionFactory
context.resources.jms.type=org.apache.activemq.ActiveMQConnectionFactory
context.resources.jms.factory=org.apache.activemq.jndi.JNDIReferenceFactory
context.resources.jms.description=JMS Connection Factory
context.resources.jms.brokerURL=vm://localhost?broker.persistent=false&broker.useJmx=false
context.resources.jms.brokerName=LocalActiveMQBroker
```

The `jms` in the property names is required to link related resource properties together but its exact text is unimportant.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/680

#### Changes
* Add support for custom webapp resources
