### PR TITLE
Add configuration and tasks for capturing tomcat libs for RecompilingJspClassLoader

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -16,6 +16,14 @@ plugins {
     id 'org.labkey.build.database'
 }
 
+configurations {
+    recompilingJsp {
+        canBeConsumed = true
+        canBeResolved = true
+    }
+}
+configurations.recompilingJsp.setDescription("Dependencies used by RecompileJspClassLoader")
+BuildUtils.addTomcatBuildDependencies(project, 'recompilingJsp')
 
 BuildUtils.addLabKeyDependency(project: project, config: 'tomcatJars', depProjectPath: BuildUtils.getBootstrapProjectPath(gradle)/*, depProjectConfig: 'runTimeElements'*/)
 
@@ -219,7 +227,35 @@ if (project.hasProperty("teamcity"))
 {
     project.tasks.named('stageApp').configure { dependsOn(project.tasks.named('reportVersionToTeamCity')) }
 }
+else
+{
+    var cleanJspRecompileSetup = project.tasks.register("cleanJspRecompileSetup", Delete) {
+        DeleteSpec task ->
+            task.group = GroupNames.BUILD
+            task.delete project.rootProject.layout.buildDirectory.dir("jspRecompiling").get()
+            task.description = "Remove build/jspRecompiling directory"
+    }
 
+    var jspRecompileSetup = project.tasks.register("jspRecompileSetup", Copy) {
+        CopySpec task ->
+            task.group = GroupNames.BUILD
+            task.description = "Copy dependencies required for JSP dynamic compiling"
+            task.into project.rootProject.layout.buildDirectory.dir("jspRecompiling")
+            task.from project.configurations.recompilingJsp
+            task.mustRunAfter(cleanJspRecompileSetup)
+            if (project.hasProperty('apacheTomcatVersion'))
+                task.inputs.property 'apacheTomcatVersion', project.property('apacheTomcatVersion')
+            else
+                task.outputs.cacheIf { false } // Just don't cache if we can't be sure of the Jasper version
+            task.doFirst {
+                project.delete project.rootProject.layout.buildDirectory.dir("jspRecompiling")
+            }
+    }
+
+    project.tasks.named('deployApp').configure {
+        dependsOn(jspRecompileSetup)
+    }
+}
 
 // We add this configuration here so we have a single location to link to for the npm and node executables.
 // Each project that requires node will have its own downloaded version of node and npm, but for the symlinkNode


### PR DESCRIPTION
#### Rationale
The `RecompilingJspClassLoader` currently depends on getting the tomcat libraries it needs from the local installation of tomcat. As we march toward using embedded Tomcat, we need a different way to make these jar files available for the classpath. This PR adds a task (and its cleaning partner) to copy the same dependencies used by Gradle to a `build/jspRecompiling` directory. The task depends on the `apacheTomcatVersion` property so should get refreshed as new versions are requested.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/5174

#### Changes
* add `jspRecompileSetup` and `cleanJspRecompileSetup` tasks to the `:server` project along with the requisite configuration
