### PR TITLE
Make 'pickPg'/'pickMssql' enable shutdown endpoint

### DIFF
--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -92,8 +92,8 @@ mail.smtpUser=@@smtpUser@@
 #server.servlet.session.timeout=30m
 
 ## Make management endpoints accessible with LabKey at ROOT context path
-#setupTask#server.servlet.context-path=/actuator
-#setupTask#management.endpoints.web.base-path=/
+server.servlet.context-path=/actuator
+management.endpoints.web.base-path=/
 #Enable shutdown endpoint
 management.endpoint.shutdown.enabled=true
 # turn off other endpoints

--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -92,8 +92,8 @@ mail.smtpUser=@@smtpUser@@
 #server.servlet.session.timeout=30m
 
 ## Make management endpoints accessible with LabKey at ROOT context path
-#server.servlet.context-path=/actuator
-#management.endpoints.web.base-path=/
+#setupTask#server.servlet.context-path=/actuator
+#setupTask#management.endpoints.web.base-path=/
 #Enable shutdown endpoint
 management.endpoint.shutdown.enabled=true
 # turn off other endpoints


### PR DESCRIPTION
#### Rationale
Unless something has changed, these properties need to be set on TeamCity so that gradle can shut down Labkey.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/697

#### Changes
* Make 'pickPg'/'pickMssql' enable shutdown endpoint
