### PR TITLE
Backport fix to avoid errors from `hitachivantara` repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -297,6 +297,11 @@ allprojects {
 
                         // This library was renamed
                         substitute module('org.codehaus.woodstox:woodstox-core-asl') using module("com.fasterxml.woodstox:woodstox-core:${woodstoxCoreVersion}")
+
+                        // Avoid conflicts with declared dependencies on the newer versions from 'net.hydromatic'
+                        substitute module('eigenbase:eigenbase-properties') using module("net.hydromatic:eigenbase-properties:${eigenbasePropertiesVersion}")
+                        substitute module('eigenbase:eigenbase-resgen') using module("net.hydromatic:eigenbase-resgen:${eigenbaseResgenVersion}")
+                        substitute module('eigenbase:eigenbase-xom') using module("net.hydromatic:eigenbase-xom:${eigenbaseXomVersion}")
                     }
                 }
             }

--- a/build.gradle
+++ b/build.gradle
@@ -157,7 +157,14 @@ allprojects {
                     maven {
                         // Mondrian dependencies are available via this repository. It's a direct dependency of the Query
                         // module but is declared here as many modules depend on Query and therefore need it as well.
-                    	url "https://repo.orl.eng.hitachivantara.com/artifactory/pnt-mvn"
+                        url "https://repo.orl.eng.hitachivantara.com/artifactory/pnt-mvn"
+                        content {
+                            includeGroup "pentaho"
+                            includeGroup "org.pentaho"
+                            includeGroup "org.olap4j"
+                            includeGroup "javacup"
+                            includeGroup "eigenbase"
+                        }
                     }
                 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -140,6 +140,9 @@ datadogVersion=0.108.1
 dom4jVersion=1.6.1
 
 ehcacheCoreVersion=2.6.8
+eigenbasePropertiesVersion=1.1.6
+eigenbaseResgenVersion=1.3.7
+eigenbaseXomVersion=1.3.7
 
 flyingsaucerVersion=R8
 


### PR DESCRIPTION
#### Rationale
Seeing these errors in 23.3:
```
07:53:49              > Could not resolve org.nodejs:node:16.19.0.
07:53:49                 > Could not get resource 'https://repo.orl.eng.hitachivantara.com/artifactory/pnt-mvn/org/nodejs/node/16.19.0/node-16.19.0.pom'.
07:53:49                    > Could not GET 'https://repo.orl.eng.hitachivantara.com/artifactory/pnt-mvn/org/nodejs/node/16.19.0/node-16.19.0.pom'. Received status code 503 from server: Service Unavailable
```
Need to backport to fix builds.

#### Related Pull Requests
* #589 

#### Changes
* Backport #589 
