### PR TITLE
Force version consistency for annotations and reflections

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -204,6 +204,7 @@ allprojects {
                     force "commons-codec:commons-codec:${commonsCodecVersion}"
                     // force version consistency in TCRdb, SequenceAnalysis, API
                     force "org.apache.commons:commons-math3:${commonsMath3Version}"
+                    force "org.reflections:reflections:${reflectionsVersion}"
                     // force version for cloud, docker, fileTransfer, googledrive, tcrb, wnprc_ehr
                     force "org.apache.httpcomponents:httpcore:${httpcoreVersion}"
                     force "org.apache.httpcomponents.core5:httpcore5:${httpcore5Version}"
@@ -279,6 +280,7 @@ allprojects {
                     force "org.apache.xmlgraphics:xmlgraphics-commons:${fopVersion}"
                     // force consistency in TCRdb, WNPRC
                     force "org.javassist:javassist:${javassistVersion}"
+                    force "org.jetbrains:annotations:${annotationsVersion}"
                     // force consistency between API and Java remote API
                     force "org.json:json:${orgJsonVersion}"
                     force "org.ow2.asm:asm:${asmVersion}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -267,6 +267,8 @@ postgresqlDriverVersion=42.7.1
 
 quartzVersion=2.3.2
 
+reflectionsVersion=0.10.2
+
 rforgeVersion=0.6-8.1
 
 # sync with Tika version


### PR DESCRIPTION
#### Rationale
A recent dependency update in `tcrdb` caused some version discrepancies.
```
> Task :showDiscrepancies
org.reflections:reflections has 2 versions as follows:
        0.10.2  [:server:modules:BimberLabKeyModules:tcrdb]
        0.9.10  [:server:modules:wnprc-modules:WNPRC_EHR]
org.jetbrains:annotations has 2 versions as follows:
        15.0    [:server:modules:platform:api]
        13.0    [:server:modules:BimberLabKeyModules:tcrdb]
```

#### Related Pull Requests
* https://github.com/LabKey/BimberLabKeyModules/commit/6c5e0f3effbdeb500ce793559c70b086584c4589 via https://github.com/LabKey/BimberLabKeyModules/pull/191

#### Changes
* Force version consistency for annotations and reflections
