### PR TITLE
Remove more unnecessary suppressions

### DIFF
--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -112,19 +112,6 @@
         <vulnerabilityName>CVE-2018-17201</vulnerabilityName>
     </suppress>
 
-    <!--
-    This is a transitive dependency from spring-boot-starter that we're forcing to get CVE hotfixes. We're not
-    vulnerable since we're not accepting untrusted Spring Boot config files. See more details at
-    https://bitbucket.org/snakeyaml/snakeyaml/wiki/CVE-2022-1471
-    -->
-    <suppress>
-        <notes><![CDATA[
-   file name: snakeyaml-1.33.jar
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
-        <cve>CVE-2022-1471</cve>
-    </suppress>
-
     <suppress>
         <notes><![CDATA[
    file name: jackson-databind-2.15.2.jar

--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -1,36 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
 
-    <!-- We do not include logback with our embedded tomcat distributions -->
-    <suppress>
-       <notes><![CDATA[
-       file name: logback-classic-1.2.12.jar
-       ]]></notes>
-       <packageUrl regex="true">^pkg:maven/ch\.qos\.logback/logback\-classic@.*$</packageUrl>
-       <vulnerabilityName>CVE-2023-6378</vulnerabilityName>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-        file name: logback-core-1.2.12.jar
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/ch\.qos\.logback/logback\-core@.*$</packageUrl>
-        <vulnerabilityName>CVE-2023-6378</vulnerabilityName>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-       file name: logback-classic-1.2.12.jar
-       ]]></notes>
-        <packageUrl regex="true">^pkg:maven/ch\.qos\.logback/logback\-classic@.*$</packageUrl>
-        <vulnerabilityName>CVE-2023-6481</vulnerabilityName>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-        file name: logback-core-1.2.12.jar
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/ch\.qos\.logback/logback\-core@.*$</packageUrl>
-        <vulnerabilityName>CVE-2023-6481</vulnerabilityName>
-    </suppress>
-
     <!-- Prevent match against unrelated "rengine" at https://github.com/yogeshojha/rengine -->
     <suppress>
         <notes><![CDATA[
@@ -70,19 +40,6 @@
    ]]></notes>
         <packageUrl regex="true">^pkg:maven/xerces/xercesImpl@.*$</packageUrl>
         <vulnerabilityName>CVE-2017-10355</vulnerabilityName>
-    </suppress>
-
-    <!--
-     We don't use any classes from org.springframework.remoting.httpinvoker like HttpInvokerServiceExporter
-     https://github.com/spring-projects/spring-framework/issues/24434
-     The unsafe classes are slated for complete removal in Spring 6.x
-     -->
-    <suppress>
-        <notes><![CDATA[
-   file name: spring-web-5.3.26.jar
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-web@.*$</packageUrl>
-        <vulnerabilityName>CVE-2016-1000027</vulnerabilityName>
     </suppress>
 
     <!--
@@ -142,22 +99,6 @@
         <cve>CVE-2006-5391</cve>
     </suppress>
 
-    <!-- Checker is confusing this library and the WNPRC GoogleDrive module with the OSX Desktop Google Drive application -->
-    <suppress>
-        <notes><![CDATA[
-   file name: google-api-services-drive-v3-rev197-1.25.0.jar
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/com\.google\.apis/google\-api\-services\-drive@.*$</packageUrl>
-        <cve>CVE-2022-3421</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-   file name: GoogleDrive_api-23.5-SNAPSHOT.jar
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.labkey/GoogleDrive@.*$</packageUrl>
-        <cve>CVE-2022-3421</cve>
-    </suppress>
-
     <!--
     This is a dependency of Java-FPDF, used by the WNPRC billing module for PDF generation, which hasn't been updated
     to reference the now-renamed Commons Imaging library instead of the old Sanselan incubator. The CVE is related
@@ -184,15 +125,6 @@
         <cve>CVE-2022-1471</cve>
     </suppress>
 
-    <!-- Jackson stack overflow when serializing a cyclic object tree. We don't deploy untrusted modules, so not a
-    concern as there is no deserialization risk. They may mitigate in 2.16.0 which is months away. -->
-    <suppress>
-        <notes><![CDATA[
-   file name: jackson-databind-2.13.5.jar
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
-        <vulnerabilityName>CVE-2023-35116</vulnerabilityName>
-    </suppress>
     <suppress>
         <notes><![CDATA[
    file name: jackson-databind-2.15.2.jar

--- a/server/embedded/build.gradle
+++ b/server/embedded/build.gradle
@@ -59,15 +59,6 @@ dependencies {
         }
     }
 
-    // This is a transitive dependency from spring-boot-starter that we're forcing to pick up CVE hotfixes. We're not
-    // vulnerable since we're not accepting untrusted Spring Boot config files, but this cleans up the reporting.
-    // At some point Spring Boot should update its preferred version and we can yank this
-    implementation('org.yaml:snakeyaml') {
-        version {
-            strictly '1.33'
-        }
-    }
-
     runtimeOnly "org.apache.tomcat.embed:tomcat-embed-jasper:${springBootTomcatVersion}"
     runtimeOnly group: "com.sun.mail", name: "jakarta.mail", version: "${javaMailVersion}"
     runtimeOnly group: "org.apache.tomcat", name: "tomcat-dbcp", version: "${springBootTomcatVersion}"


### PR DESCRIPTION
#### Rationale
With the Tomcat 10 merge and other dependency upgrades, some CVE suppressions are no longer needed. In these cases, we're pulling in a more recent library version that addresses the flagged CVE(s).
