### PR TITLE
Improve usability of application.properties

### DIFF
--- a/server/bootstrap/src/org/labkey/bootstrap/ConfigException.java
+++ b/server/bootstrap/src/org/labkey/bootstrap/ConfigException.java
@@ -15,11 +15,10 @@
  */
 package org.labkey.bootstrap;
 
-/*
-* User: jeckels
-* Date: Jun 26, 2008
-*/
-public class ConfigException extends Exception
+/**
+ * Thrown to signal a fatal configuration problem with a deployment.
+ */
+public class ConfigException extends RuntimeException
 {
     public ConfigException(String message)
     {

--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -14,41 +14,39 @@ server.port=@@serverPort@@
 # HTTP-only port for servers that need to handle both HTTPS (configure via server.port and server.ssl above) and HTTP
 #context.httpPort=8080
 
-context.dataSourceName[0]=jdbc/labkeyDataSource
-context.driverClassName[0]=@@jdbcDriverClassName@@
-context.url[0]=@@jdbcURL@@
-context.username[0]=@@jdbcUser@@
-context.password[0]=@@jdbcPassword@@
-context.maxTotal[0]=50
-context.maxIdle[0]=10
-context.maxWaitMillis[0]=120000
-context.accessToUnderlyingConnectionAllowed[0]=true
-context.validationQuery[0]=SELECT 1
+context.resources.jdbc.labkeyDataSource.type=javax.sql.DataSource
+context.resources.jdbc.labkeyDataSource.driverClassName=@@jdbcDriverClassName@@
+context.resources.jdbc.labkeyDataSource.url=@@jdbcURL@@
+context.resources.jdbc.labkeyDataSource.username=@@jdbcUser@@
+context.resources.jdbc.labkeyDataSource.password=@@jdbcPassword@@
+context.resources.jdbc.labkeyDataSource.maxTotal=50
+context.resources.jdbc.labkeyDataSource.maxIdle=10
+context.resources.jdbc.labkeyDataSource.maxWaitMillis=120000
+context.resources.jdbc.labkeyDataSource.accessToUnderlyingConnectionAllowed=true
+context.resources.jdbc.labkeyDataSource.validationQuery=SELECT 1
+#context.resources.jdbc.labkeyDataSource.logQueries=true
+#context.resources.jdbc.labkeyDataSource.displayName=Alternate Display Name
 
-#context.logQueries[0]=true
-#context.displayName[0]=Alternate Display Name
-
-#context.dataSourceName[1]=jdbc/@@extraJdbcDataSource@@
-#context.driverClassName[1]=@@extraJdbcDriverClassName@@
-#context.url[1]=@@extraJdbcUrl@@
-#context.username[1]=@@extraJdbcUsername@@
-#context.password[1]=@@extraJdbcPassword@@
+#context.resources.jdbc.otherDataSource.driverClassName=@@extraJdbcDriverClassName@@
+#context.resources.jdbc.otherDataSource.url=@@extraJdbcUrl@@
+#context.resources.jdbc.otherDataSource.username=@@extraJdbcUsername@@
+#context.resources.jdbc.otherDataSource.password=@@extraJdbcPassword@@
 
 #useLocalBuild#context.webAppLocation=@@pathToServer@@/build/deploy/labkeyWebapp
 context.encryptionKey=@@encryptionKey@@
 
-# By default, we'll deploy to the root context path. However, some servers have historically used /labkey or even /cpas
+# By default, we deploy to the root context path. However, some servers have historically used /labkey or even /cpas
 #context.contextPath=/labkey
 
 # Using a legacy context path provides backwards compatibility with old deployments. A typical use case would be to
-# deploy to the root context (the default) and configure /labkey as the legacy path. GETs will be redirected, and
-# non-GETs will be handled server-side via a servlet forward.
+# deploy to the root context (the default) and configure /labkey as the legacy path. GETs will be redirected.
+# All other methods (POSTs, PUTs, etc) will be handled server-side via a servlet forward.
 #context.legacyContextPath=/labkey
 
-# Other webapps to be deployed, most commonly to deliver a set of static files. Additional
-# webapps can be specified via additional indices. docBase should point at the root of the webapp's content
-#webapps.contextPath[0]=/anotherWebapp
-#webapps.docBase[0]=/my/webapp/path
+# Other webapps to be deployed, most commonly to deliver a set of static files. The context path to deploy into is the
+# property name after the "context.additionalWebapps." prefix, and the value is the location of the webapp on disk
+#context.additionalWebapps.firstContextPath=/my/webapp/path
+#context.additionalWebapps.secondContextPath=/my/other/webapp/path
 
 #context.oldEncryptionKey=
 #context.requiredModules=
@@ -65,6 +63,29 @@ mail.smtpUser=@@smtpUser@@
 # mail.startTlsEnable=@@smtpStartTlsEnable@@
 # mail.smtpSocketFactoryClass=@@smtpSocketFactoryClass@@
 # mail.smtpAuth=@@smtpAuth@@
+
+# Optional - JMS configuration for remote ActiveMQ message management for distributed pipeline jobs
+# https://www.labkey.org/Documentation/wiki-page.view?name=jmsQueue
+#context.resources.jms.ConnectionFactory.type=org.apache.activemq.ActiveMQConnectionFactory
+#context.resources.jms.ConnectionFactory.factory=org.apache.activemq.jndi.JNDIReferenceFactory
+#context.resources.jms.ConnectionFactory.description=JMS Connection Factory
+# Use an in-process ActiveMQ queue
+#context.resources.jms.ConnectionFactory.brokerURL=vm://localhost?broker.persistent=false&broker.useJmx=false
+# Use an out-of-process ActiveMQ queue
+#context.resources.jms.ConnectionFactory.brokerURL=tcp://localhost:61616
+#context.resources.jms.ConnectionFactory.brokerName=LocalActiveMQBroker
+
+# Optional - LDAP configuration for LDAP group/user synchronization
+# https://www.labkey.org/Documentation/wiki-page.view?name=LDAP_sync
+#context.resources.ldap.ConfigFactory.type=org.labkey.premium.ldap.LdapConnectionConfigFactory
+#context.resources.ldap.ConfigFactory.factory=org.labkey.premium.ldap.LdapConnectionConfigFactory
+#context.resources.ldap.ConfigFactory.host=ldap.forumsys.com
+#context.resources.ldap.ConfigFactory.port=389
+#context.resources.ldap.ConfigFactory.principal=cn=read-only-admin,dc=example,dc=com
+#context.resources.ldap.ConfigFactory.credentials=password
+#context.resources.ldap.ConfigFactory.useTls=false
+#context.resources.ldap.ConfigFactory.useSsl=false
+#context.resources.ldap.ConfigFactory.sslProtocol=SSLv3
 
 #useLocalBuild#spring.devtools.restart.additional-paths=@@pathToServer@@/build/deploy/modules,@@pathToServer@@/build/deploy/embedded/config
 

--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -30,10 +30,10 @@ context.resources.jdbc.labkeyDataSource.validationQuery=SELECT 1
 #context.resources.jdbc.labkeyDataSource.logQueries=true
 #context.resources.jdbc.labkeyDataSource.displayName=Alternate Display Name
 
-#context.resources.jdbc.otherDataSource.driverClassName=@@extraJdbcDriverClassName@@
-#context.resources.jdbc.otherDataSource.url=@@extraJdbcUrl@@
-#context.resources.jdbc.otherDataSource.username=@@extraJdbcUsername@@
-#context.resources.jdbc.otherDataSource.password=@@extraJdbcPassword@@
+#context.resources.jdbc.@@extraJdbcDataSource@@.driverClassName=@@extraJdbcDriverClassName@@
+#context.resources.jdbc.@@extraJdbcDataSource@@.url=@@extraJdbcUrl@@
+#context.resources.jdbc.@@extraJdbcDataSource@@.username=@@extraJdbcUsername@@
+#context.resources.jdbc.@@extraJdbcDataSource@@.password=@@extraJdbcPassword@@
 
 # Retain legacy syntax until automated tests are updated to configure via the 'context.resources.jdbc.' prefix
 #context.dataSourceName[1]=jdbc/@@extraJdbcDataSource@@

--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -14,6 +14,9 @@ server.port=@@serverPort@@
 # HTTP-only port for servers that need to handle both HTTPS (configure via server.port and server.ssl above) and HTTP
 #context.httpPort=8080
 
+# Database connections. All deployments need a labkeyDataSource as their primary database. Add additional external
+# data sources by specifying the required properties (at least driverClassName, url, username, and password)
+# with a prefix of context.resources.jdbc.<dataSourceName>.
 context.resources.jdbc.labkeyDataSource.type=javax.sql.DataSource
 context.resources.jdbc.labkeyDataSource.driverClassName=@@jdbcDriverClassName@@
 context.resources.jdbc.labkeyDataSource.url=@@jdbcURL@@
@@ -31,6 +34,14 @@ context.resources.jdbc.labkeyDataSource.validationQuery=SELECT 1
 #context.resources.jdbc.otherDataSource.url=@@extraJdbcUrl@@
 #context.resources.jdbc.otherDataSource.username=@@extraJdbcUsername@@
 #context.resources.jdbc.otherDataSource.password=@@extraJdbcPassword@@
+
+# Retain legacy syntax until automated tests are updated to configure via the 'context.resources.jdbc.' prefix
+#context.dataSourceName[1]=jdbc/@@extraJdbcDataSource@@
+#context.driverClassName[1]=@@extraJdbcDriverClassName@@
+#context.url[1]=@@extraJdbcUrl@@
+#context.username[1]=@@extraJdbcUsername@@
+#context.password[1]=@@extraJdbcPassword@@
+
 
 #useLocalBuild#context.webAppLocation=@@pathToServer@@/build/deploy/labkeyWebapp
 context.encryptionKey=@@encryptionKey@@

--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -90,10 +90,10 @@ mail.smtpUser=@@smtpUser@@
 # https://www.labkey.org/Documentation/wiki-page.view?name=LDAP_sync
 #context.resources.ldap.ConfigFactory.type=org.labkey.premium.ldap.LdapConnectionConfigFactory
 #context.resources.ldap.ConfigFactory.factory=org.labkey.premium.ldap.LdapConnectionConfigFactory
-#context.resources.ldap.ConfigFactory.host=ldap.forumsys.com
+#context.resources.ldap.ConfigFactory.host=myldap.mydomain.com
 #context.resources.ldap.ConfigFactory.port=389
-#context.resources.ldap.ConfigFactory.principal=cn=read-only-admin,dc=example,dc=com
-#context.resources.ldap.ConfigFactory.credentials=password
+#context.resources.ldap.ConfigFactory.principal=cn=read_user
+#context.resources.ldap.ConfigFactory.credentials=read_user_password
 #context.resources.ldap.ConfigFactory.useTls=false
 #context.resources.ldap.ConfigFactory.useSsl=false
 #context.resources.ldap.ConfigFactory.sslProtocol=SSLv3

--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -328,8 +328,6 @@ public class LabKeyServer
                 {
                     for (Map.Entry<String, Map<String, String>> entry : parentEntry.getValue().entrySet())
                     {
-                        Map<String, String> resourceMap = new CaseInsensitiveKeyMap<>();
-                        resourceMap.putAll(entry.getValue());
                         String resourceTypeString = parentEntry.getKey();
 
                         ResourceType type;

--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -330,19 +330,19 @@ public class LabKeyServer
                     {
                         String resourceTypeString = parentEntry.getKey();
 
-                        ResourceType type;
+                        ResourceType resourceType;
                         try
                         {
-                            type = ResourceType.valueOf(resourceTypeString);
+                            resourceType = ResourceType.valueOf(resourceTypeString);
                         }
                         catch (IllegalArgumentException e)
                         {
-                            type = ResourceType.generic;
+                            resourceType = ResourceType.generic;
                         }
 
                         String name = parentEntry.getKey() + "/" + entry.getKey();
 
-                        type.addResource(name, entry.getValue(), context);
+                        resourceType.addResource(name, entry.getValue(), context);
                     }
                 }
             }

--- a/server/embedded/src/org/labkey/embedded/ResourceType.java
+++ b/server/embedded/src/org/labkey/embedded/ResourceType.java
@@ -1,0 +1,113 @@
+package org.labkey.embedded;
+
+import org.apache.catalina.core.StandardContext;
+import org.apache.tomcat.util.collections.CaseInsensitiveKeyMap;
+import org.apache.tomcat.util.descriptor.web.ContextResource;
+import org.labkey.bootstrap.ConfigException;
+
+import javax.sql.DataSource;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.labkey.embedded.LabKeyServer.ACCESS_TO_CONNECTION_ALLOWED_DEFAULT;
+import static org.labkey.embedded.LabKeyServer.MAX_IDLE_DEFAULT;
+import static org.labkey.embedded.LabKeyServer.MAX_TOTAL_CONNECTIONS_DEFAULT;
+import static org.labkey.embedded.LabKeyServer.MAX_WAIT_MILLIS_DEFAULT;
+import static org.labkey.embedded.LabKeyServer.VALIDATION_QUERY_DEFAULT;
+
+public enum ResourceType
+{
+    jdbc
+            {
+                @Override
+                protected Map<String, String> mergeWithDefaults(Map<String, String> props)
+                {
+                    Map<String, String> result = super.mergeWithDefaults(props);
+                    result.putIfAbsent("type", DataSource.class.getName());
+                    result.putIfAbsent("maxTotal", MAX_TOTAL_CONNECTIONS_DEFAULT);
+                    result.putIfAbsent("maxIdle", MAX_IDLE_DEFAULT);
+                    result.putIfAbsent("maxWaitMillis", MAX_WAIT_MILLIS_DEFAULT);
+                    result.putIfAbsent("accessToUnderlyingConnectionAllowed", ACCESS_TO_CONNECTION_ALLOWED_DEFAULT);
+                    result.putIfAbsent("validationQuery", VALIDATION_QUERY_DEFAULT);
+                    return result;
+                }
+
+                @Override
+                public void addResource(String name, Map<String, String> props, StandardContext context) throws ConfigException
+                {
+                    String displayName = props.remove("displayName");
+                    if (displayName != null)
+                    {
+                        context.addParameter(name + ":DisplayName", displayName);
+                    }
+                    String logQueries = props.remove("logQueries");
+                    if (logQueries != null)
+                    {
+                        context.addParameter(name + ":LogQueries", displayName);
+                    }
+
+                    super.addResource(name, props, context);
+                }
+            },
+    jms
+            {
+                @Override
+                protected Map<String, String> mergeWithDefaults(Map<String, String> props)
+                {
+                    Map<String, String> result = super.mergeWithDefaults(props);
+                    result.putIfAbsent("type", "org.apache.activemq.ActiveMQConnectionFactory");
+                    result.putIfAbsent("factory", "org.apache.activemq.jndi.JNDIReferenceFactory");
+                    result.putIfAbsent("description", "JMS Connection Factory");
+                    result.putIfAbsent("brokerName", "LocalActiveMQBroker");
+                    return result;
+                }
+            },
+    ldap
+            {
+                @Override
+                protected Map<String, String> mergeWithDefaults(Map<String, String> props)
+                {
+                    Map<String, String> result = super.mergeWithDefaults(props);
+                    result.putIfAbsent("type", "org.labkey.premium.ldap.LdapConnectionConfigFactory");
+                    result.putIfAbsent("factory", "org.labkey.premium.ldap.LdapConnectionConfigFactory");
+                    return result;
+                }
+            },
+    generic;
+
+    protected Map<String, String> mergeWithDefaults(Map<String, String> props)
+    {
+        Map<String, String> result = new CaseInsensitiveKeyMap<>();
+        result.putAll(props);
+        return result;
+    }
+
+    public void addResource(String name, Map<String, String> props, StandardContext context) throws ConfigException
+    {
+        props = mergeWithDefaults(props);
+        ContextResource contextResource = new ContextResource();
+        // Handle resource properties with explicit setters
+        contextResource.setName(name);
+
+        if (!props.containsKey("type"))
+        {
+            throw new ConfigException("Resource configuration error: 'type' is not defined for resource '%s'".formatted(name));
+        }
+
+        contextResource.setType(props.remove("type"));
+        contextResource.setDescription(props.remove("description"));
+        contextResource.setLookupName(props.remove("lookupName"));
+        if (props.containsKey("scope"))
+        {
+            contextResource.setScope(props.remove("scope"));
+        }
+        contextResource.setAuth(Objects.requireNonNullElse(props.remove("auth"), "Container"));
+
+        // Set remaining properties
+        for (Map.Entry<String, String> prop : props.entrySet())
+        {
+            contextResource.setProperty(prop.getKey(), prop.getValue());
+        }
+        context.getNamingResources().addResource(contextResource);
+    }
+}

--- a/server/embedded/src/org/labkey/embedded/ResourceType.java
+++ b/server/embedded/src/org/labkey/embedded/ResourceType.java
@@ -102,7 +102,7 @@ public enum ResourceType
         {
             contextResource.setScope(props.remove("scope"));
         }
-        contextResource.setAuth(Objects.requireNonNullElse(props.remove("auth"), "Container"));
+        contextResource.setAuth(props.remove("auth"));
 
         // Set remaining properties
         for (Map.Entry<String, String> prop : props.entrySet())

--- a/server/embedded/src/org/labkey/embedded/ResourceType.java
+++ b/server/embedded/src/org/labkey/embedded/ResourceType.java
@@ -79,6 +79,7 @@ public enum ResourceType
     {
         Map<String, String> result = new CaseInsensitiveKeyMap<>();
         result.putAll(props);
+        result.putIfAbsent("auth", "Container");
         return result;
     }
 

--- a/server/embedded/src/org/labkey/embedded/ResourceType.java
+++ b/server/embedded/src/org/labkey/embedded/ResourceType.java
@@ -7,7 +7,6 @@ import org.labkey.bootstrap.ConfigException;
 
 import javax.sql.DataSource;
 import java.util.Map;
-import java.util.Objects;
 
 import static org.labkey.embedded.LabKeyServer.ACCESS_TO_CONNECTION_ALLOWED_DEFAULT;
 import static org.labkey.embedded.LabKeyServer.MAX_IDLE_DEFAULT;
@@ -59,17 +58,6 @@ public enum ResourceType
                     result.putIfAbsent("factory", "org.apache.activemq.jndi.JNDIReferenceFactory");
                     result.putIfAbsent("description", "JMS Connection Factory");
                     result.putIfAbsent("brokerName", "LocalActiveMQBroker");
-                    return result;
-                }
-            },
-    ldap
-            {
-                @Override
-                protected Map<String, String> mergeWithDefaults(Map<String, String> props)
-                {
-                    Map<String, String> result = super.mergeWithDefaults(props);
-                    result.putIfAbsent("type", "org.labkey.premium.ldap.LdapConnectionConfigFactory");
-                    result.putIfAbsent("factory", "org.labkey.premium.ldap.LdapConnectionConfigFactory");
                     return result;
                 }
             },


### PR DESCRIPTION
#### Rationale
`application.properties` should be easy to configure and internally consistent.

#### Changes
* Enhance `context.resources` config
* Support JDBC, LDAP, and JMS with default values and arbitrary pass-throughs
* Use property names as resource names
* Avoid using numeric indices
* Turn on JMX in embedded Tomcat scenarios