### PR TITLE
Suppress CSP reporting for dev "hot reload"

### DIFF
--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -176,11 +176,11 @@ spring.main.banner-mode=off
 # Default CSP for TeamCity and dev deployments
 #setupTask#csp.report=\
 #setupTask#    default-src 'self' https: http: ;\
-#setupTask#    connect-src 'self' ${LABKEY.ALLOWED.CONNECTIONS} ;\
+#setupTask#    connect-src 'self' localhost:* ws: ${LABKEY.ALLOWED.CONNECTIONS} ;\
 #setupTask#    object-src 'none' ;\
 #setupTask#    style-src 'self' https: 'unsafe-inline' ;\
 #setupTask#    img-src 'self' https: data: ;\
-#setupTask#    font-src 'self' https: data: ;\
+#setupTask#    font-src 'self' http: https: data: ;\
 #setupTask#    script-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ;\
 #setupTask#    base-uri 'self' ;\
 #setupTask#    frame-ancestors 'self' ;\


### PR DESCRIPTION
#### Rationale
Configures CSP reporting for dev deployments to not report against our "hot reload" requests.

#### Changes
- Update `connect-src` and `font-src` to allow for dynamic reload of app content.
