### PR TITLE
Set pipeline config directory for embedded Tomcat

### DIFF
--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -61,7 +61,7 @@ context.encryptionKey=@@encryptionKey@@
 
 #context.oldEncryptionKey=
 #context.requiredModules=
-#context.pipelineConfig=/path/to/pipeline/config/dir
+context.pipelineConfig=./config
 #context.serverGUID=
 #context.bypass2FA=false
 #context.workDirLocation=/path/to/desired/workDir

--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -61,7 +61,7 @@ context.encryptionKey=@@encryptionKey@@
 
 #context.oldEncryptionKey=
 #context.requiredModules=
-context.pipelineConfig=./config
+context.pipelineConfig=@@pathToServer@@/build/deploy/embedded/config
 #context.serverGUID=
 #context.bypass2FA=false
 #context.workDirLocation=/path/to/desired/workDir


### PR DESCRIPTION
#### Rationale
Some tests expect to put the pipeline config file in `build/deploy/embedded/config`. The server needs to be configured to look there.

#### Related Pull Requests
* https://github.com/LabKey/DiscvrLabKeyModules/pull/270

#### Changes
* Set `context.pipelineConfig` in `application.properties`
