### PR TITLE
Fix non-HTTPS embedded Tomcat scenarios

### DIFF
--- a/server/embedded/src/org/labkey/embedded/LabKeyTomcatServletWebServerFactory.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyTomcatServletWebServerFactory.java
@@ -166,7 +166,7 @@ class LabKeyTomcatServletWebServerFactory extends TomcatServletWebServerFactory
                 }
 
                 LabKeyServer.ServerSslProperties sslProps = _server.serverSslSource();
-                if (null != sslProps)
+                if (null != sslProps && sslProps.getKeyStore() != null)
                 {
                     context.addParameter(SERVER_SSL_KEYSTORE, sslProps.getKeyStore());
                 }


### PR DESCRIPTION
#### Rationale
Tomcat isn't happy if you try to set a context parameter without a value

#### Changes
* Check for null