### PR TITLE
Upgrade version of commons-compress (#726)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -127,8 +127,7 @@ commonsBeanutilsVersion=1.9.4
 commonsCollectionsVersion=3.2.2
 commonsCollections4Version=4.4
 commonsCodecVersion=1.16.0
-# sync with version Tika ships
-commonsCompressVersion=1.24.0
+commonsCompressVersion=1.26.0
 commonsDbcpVersion=1.4
 commonsDiscoveryVersion=0.2
 commonsDigesterVersion=1.8.1


### PR DESCRIPTION
* Upgrade version of commons-compress

#### Rationale
Pulling forward commons-compress upgrade

#### Related Pull Requests
* https://github.com/LabKey/server/pull/726
* https://github.com/LabKey/platform/pull/5253

#### Changes
* Version bump to commons-compress
