### PR TITLE
Apply no-op CSP filter to extra webapps

### DIFF
--- a/server/bootstrap/src/org/labkey/filters/ContentSecurityPolicyFilter.java
+++ b/server/bootstrap/src/org/labkey/filters/ContentSecurityPolicyFilter.java
@@ -1,0 +1,24 @@
+package org.labkey.filters;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+
+/**
+ * A no-op CSP filter that gets applied (for now) to extra webapps
+ */
+public class ContentSecurityPolicyFilter implements Filter
+{
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException
+    {
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
+    {
+    }
+}


### PR DESCRIPTION
#### Rationale
Extra webapps are failing to load on standalone Tomcat when a CSP is configured in web.xml because `ContentSecurityPolicyFilter` is not accessible at filter registration time (the class was moved to the webapp). https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=49733

Simplest solution (for now, to quickly unblock the labkey.org issue) is to throw a no-op filter with the same name into bootstrap. In my local testing, this gets applied to extra webapps whereas the "real" filter gets applied to the LabKey webapp.