### PR TITLE
Update to Java API v6.1.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -22,10 +22,10 @@ org.gradle.jvmargs=-Xmx2048m -XX:+UseParallelGC
 versionConflictAction=delete
 
 # uncomment the following line for running the application with embedded tomcat
-useEmbeddedTomcat
+#useEmbeddedTomcat
 
 # uncomment the following line when using a local build of a server with embedded tomcat
-useLocalBuild
+#useLocalBuild
 
 # uncomment the following line when using SSL for your embedded tomcat server
 #useSsl
@@ -323,5 +323,3 @@ xmlApisVersion=1.0.b2
 
 # sync with Tika/POI
 xmlbeansVersion=5.2.0
-
-npmInstallCommand=install

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,10 +22,10 @@ org.gradle.jvmargs=-Xmx2048m -XX:+UseParallelGC
 versionConflictAction=delete
 
 # uncomment the following line for running the application with embedded tomcat
-#useEmbeddedTomcat
+useEmbeddedTomcat
 
 # uncomment the following line when using a local build of a server with embedded tomcat
-#useLocalBuild
+useLocalBuild
 
 # uncomment the following line when using SSL for your embedded tomcat server
 #useSsl
@@ -48,7 +48,7 @@ buildFromSource=true
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
 labkeyVersion=24.3-SNAPSHOT
-labkeyClientApiVersion=6.0.0
+labkeyClientApiVersion=6.1.0
 
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.
@@ -323,3 +323,5 @@ xmlApisVersion=1.0.b2
 
 # sync with Tika/POI
 xmlbeansVersion=5.2.0
+
+npmInstallCommand=install


### PR DESCRIPTION
#### Rationale
Update to Java API version 6.1.0.

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-java/pull/70
