### PR TITLE
Update to Java API v6.1.0 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -48,7 +48,7 @@ buildFromSource=true
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
 labkeyVersion=24.3-SNAPSHOT
-labkeyClientApiVersion=6.0.0
+labkeyClientApiVersion=6.1.0
 
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.


### PR DESCRIPTION
#### Rationale
Update to Java API version 6.1.0.

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-java/pull/70

