### PR TITLE
Update to the latest OWASP plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,12 @@ allprojects {
             formats = ['HTML', 'JUNIT']
             skipConfigurations = ['dedupe', 'gwtCompileClasspath', 'gwtRuntimeClasspath', 'developmentOnly']
             skipProjects = [':server:testAutomation']
+            if (project.hasProperty('nvdApiKey'))
+            {
+                nvd {
+                    apiKey = "${project.property('nvdApiKey')}"
+                }
+            }
         }
     }
     if (BuildUtils.shouldPublish(project) || BuildUtils.shouldPublishDistribution(project))

--- a/gradle.properties
+++ b/gradle.properties
@@ -63,7 +63,7 @@ windowsProteomicsBinariesVersion=1.0
 artifactoryPluginVersion=4.31.9
 gradleNodePluginVersion=3.5.1
 gradlePluginsVersion=2.3.0
-owaspDependencyCheckPluginVersion=8.4.3
+owaspDependencyCheckPluginVersion=9.0.9
 versioningPluginVersion=1.1.2
 
 # Versions of node and npm to use during the build. If set, these versions


### PR DESCRIPTION
#### Rationale
Docs for the latest (9.0.x) version strongly recommend obtaining and using an NVD API key, otherwise very long download times may be experienced, https://github.com/jeremylong/DependencyCheck. In my local testing, the initial download took about 35 minutes and subsequent runs took about a minute, which is inline with the previous version. We'll see how TeamCity tolerates this.


