### PR TITLE
Issue 49824: Improve embedded Tomcat auto-redeploy using a trigger file

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -62,7 +62,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.31.9
 gradleNodePluginVersion=3.5.1
-gradlePluginsVersion=2.3.0
+gradlePluginsVersion=2.4.0-restartTrigger-SNAPSHOT
 owaspDependencyCheckPluginVersion=9.0.9
 versioningPluginVersion=1.1.2
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -62,7 +62,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.31.9
 gradleNodePluginVersion=3.5.1
-gradlePluginsVersion=2.5.0-restartTrigger-SNAPSHOT
+gradlePluginsVersion=2.5.0
 owaspDependencyCheckPluginVersion=9.0.9
 versioningPluginVersion=1.1.2
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -62,7 +62,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.31.9
 gradleNodePluginVersion=3.5.1
-gradlePluginsVersion=2.4.0-restartTrigger-SNAPSHOT
+gradlePluginsVersion=2.5.0-restartTrigger-SNAPSHOT
 owaspDependencyCheckPluginVersion=9.0.9
 versioningPluginVersion=1.1.2
 

--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -91,7 +91,9 @@ mail.smtpUser=@@smtpUser@@
 #context.resources.ldap.ConfigFactory.useSsl=false
 #context.resources.ldap.ConfigFactory.sslProtocol=SSLv3
 
-#useLocalBuild#spring.devtools.restart.additional-paths=@@pathToServer@@/build/deploy/modules,@@pathToServer@@/build/deploy/embedded/config
+#useLocalBuild#spring.devtools.restart.additional-paths=@@pathToServer@@/build/deploy/modules
+# Use a trigger file for smoother restart behavior
+#useLocalBuild#spring.devtools.restart.trigger-file=.restartTrigger
 
 # HTTP session timeout for users - defaults to 30 minutes
 #server.servlet.session.timeout=30m


### PR DESCRIPTION
#### Rationale
[Issue 49824](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49824) Currently, we have configured the restart of embedded tomcat by having SpringBoot watch the `build/deploy/modules` and `build/deploy/embedded` directories. Since we write a lot of things to these directories during a deployment when using a local build, usually the restart from SpringBoot happens before all the copying is complete, resulting in a failed start and the need to start manually.  This PR updates the Gradle plugins to add a final step in various tasks that are meant to trigger a restart , which will modify a file that we will configure SpringBoot to look for as a signal to restart (see [SpringBoot docs](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#using.devtools.restart.triggerfile)).

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/201

#### Changes
* Update `application.properties` file with trigger file configuration for local builds
