### PR TITLE
Skip trigger file creation if not using local build

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -62,7 +62,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.31.9
 gradleNodePluginVersion=3.5.1
-gradlePluginsVersion=2.6.0-skipTriggerFile-SNAPSHOT
+gradlePluginsVersion=2.5.1
 owaspDependencyCheckPluginVersion=9.0.9
 versioningPluginVersion=1.1.2
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -62,7 +62,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.31.9
 gradleNodePluginVersion=3.5.1
-gradlePluginsVersion=2.5.0
+gradlePluginsVersion=2.6.0-skipTriggerFile-SNAPSHOT
 owaspDependencyCheckPluginVersion=9.0.9
 versioningPluginVersion=1.1.2
 


### PR DESCRIPTION
#### Rationale
TeamCity apparently does not have a `build/deploy/modules` directory and is angry about our trying to write a file there.  We'll skip the writing of this file if not using a local build.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/203

#### Changes
* gradle plugins version update