### PR TITLE
Pull in gradlePlugin fix for missing restart trigger file

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -62,7 +62,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.31.9
 gradleNodePluginVersion=3.5.1
-gradlePluginsVersion=2.6.0
+gradlePluginsVersion=2.6.1
 owaspDependencyCheckPluginVersion=8.4.3
 versioningPluginVersion=1.1.2
 


### PR DESCRIPTION
#### Rationale
24.3 needs the fix from gradlePluginsVersion 2.6.1

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/205

#### Changes
* Update gradle plugins to 2.6.1
