### PR TITLE
Remove 'LABKEY_HOME' from example service

### DIFF
--- a/server/configs/webapps/embedded/README.txt
+++ b/server/configs/webapps/embedded/README.txt
@@ -1,7 +1,7 @@
 Thank you for downloading LabKey Server. For more information about...
 
-- Installing LabKey Server. See https://www.labkey.org/Documentation/wiki-page.view?name=embeddedConfig
+- Installing LabKey Server. See https://www.labkey.org/Documentation/wiki-page.view?name=config
 
-- Upgrading LabKey Server. See https://www.labkey.org/Documentation/wiki-page.view?name=embeddedUpgrade
+- Upgrading LabKey Server. See https://www.labkey.org/Documentation/wiki-page.view?name=upgrade
 
 - Using LabKey Server. See https://www.labkey.org/Documentation/project-begin.view

--- a/server/configs/webapps/embedded/labkey_server.service
+++ b/server/configs/webapps/embedded/labkey_server.service
@@ -6,18 +6,17 @@ After=syslog.target network.target
 
 [Service]
 Type=simple
-Environment="LABKEY_HOME=/labkey/labkey"
 Environment="JAVA_HOME=/usr/lib/jvm/jdk-17.0.10+7"
 Environment="JAVA_PRE_JAR_OPS=-Duser.timezone=America/Los_Angeles -Djava.library.path=/usr/lib/x86_64-linux-gnu -Djava.awt.headless=true -Xms1932M -Xmx1932M -Djava.security.egd=file:/dev/./urandom"
-Environment="JAVA_MID_JAR_OPS=-XX:+HeapDumpOnOutOfMemoryError -XX:+UseContainerSupport -XX:HeapDumpPath=$LABKEY_HOME/labkey-tmp -Djava.net.preferIPv4Stack=true"
-Environment="LABKEY_JAR_OPS=-Dlabkey.home=$LABKEY_HOME -Dlabkey.log.home=$LABKEY_HOME/logs -Djava.io.tmpdir=$LABKEY_HOME/labkey-tmp"
-Environment="JAVA_LOG_JAR_OPS=-XX:ErrorFile=$LABKEY_HOME/logs/error_%p.log -Dlog4j.configurationFile=log4j2.xml"
+Environment="JAVA_MID_JAR_OPS=-XX:+HeapDumpOnOutOfMemoryError -XX:+UseContainerSupport -XX:HeapDumpPath=/labkey/labkey/labkey-tmp -Djava.net.preferIPv4Stack=true"
+Environment="LABKEY_JAR_OPS=-Dlabkey.home=/labkey/labkey -Dlabkey.log.home=/labkey/labkey/logs -Djava.io.tmpdir=/labkey/labkey/labkey-tmp"
+Environment="JAVA_LOG_JAR_OPS=-XX:ErrorFile=/labkey/labkey/logs/error_%p.log -Dlog4j.configurationFile=log4j2.xml"
 Environment="JAVA_FLAGS_JAR_OPS=-Dorg.apache.catalina.startup.EXIT_ON_INIT_FAILURE=true -DsynchronousStartup=true -DterminateOnStartupFailure=true"
 Environment="JAVA_REFLECTION_JAR_OPS=--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED"
-WorkingDirectory=$LABKEY_HOME
+WorkingDirectory=/labkey/labkey
 OOMScoreAdjust=-500
 
-ExecStart=$JAVA_HOME/bin/java $JAVA_PRE_JAR_OPS $JAVA_MID_JAR_OPS $LABKEY_JAR_OPS $JAVA_LOG_JAR_OPS $JAVA_FLAGS_JAR_OPS $JAVA_REFLECTION_JAR_OPS -jar $LABKEY_HOME/labkeyServer.jar
+ExecStart=$JAVA_HOME/bin/java $JAVA_PRE_JAR_OPS $JAVA_MID_JAR_OPS $LABKEY_JAR_OPS $JAVA_LOG_JAR_OPS $JAVA_FLAGS_JAR_OPS $JAVA_REFLECTION_JAR_OPS -jar /labkey/labkey/labkeyServer.jar
 SuccessExitStatus=0 143
 Restart=on-failure
 RestartSec=15


### PR DESCRIPTION
#### Rationale
systemd doesn't do variable expansion in environment variable definitions.

#### Related Pull Requests
* #765 

#### Changes
* Remove 'LABKEY_HOME' from example service
