### PR TITLE
Fix startup errors with embedded Tomcat deployments

### DIFF
--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -70,7 +70,7 @@ mail.smtpPort=@@smtpPort@@
 mail.smtpUser=@@smtpUser@@
 #mail.smtpFrom=@@smtpFrom@@
 #mail.smtpPassword=@@smtpPassword@@
-#mail.startTlsEnable=@@smtpStartTlsEnable@@
+#mail.smtpStartTlsEnable=@@smtpStartTlsEnable@@
 #mail.smtpSocketFactoryClass=@@smtpSocketFactoryClass@@
 #mail.smtpAuth=@@smtpAuth@@
 

--- a/server/configs/webapps/embedded/config/application.properties
+++ b/server/configs/webapps/embedded/config/application.properties
@@ -66,7 +66,7 @@ mail.smtpPort=25
 mail.smtpUser=Anonymous
 #mail.smtpFrom=@@smtpFrom@@
 #mail.smtpPassword=@@smtpPassword@@
-#mail.startTlsEnable=@@smtpStartTlsEnable@@
+#mail.smtpStartTlsEnable=@@smtpStartTlsEnable@@
 #mail.smtpSocketFactoryClass=@@smtpSocketFactoryClass@@
 #mail.smtpAuth=@@smtpAuth@@
 

--- a/server/embedded/src/org/labkey/embedded/EmbeddedExtractor.java
+++ b/server/embedded/src/org/labkey/embedded/EmbeddedExtractor.java
@@ -31,7 +31,7 @@ public class EmbeddedExtractor
     {
         File[] files = currentDir.listFiles(file -> {
             String name = file.getName().toLowerCase();
-            return name.endsWith(".jar") && name.contains("labkeyserver");
+            return name.endsWith(".jar") && !name.contains("embedded");
         });
 
         if (files == null || files.length == 0)

--- a/server/embedded/src/org/labkey/embedded/EmbeddedExtractor.java
+++ b/server/embedded/src/org/labkey/embedded/EmbeddedExtractor.java
@@ -31,7 +31,7 @@ public class EmbeddedExtractor
     {
         File[] files = currentDir.listFiles(file -> {
             String name = file.getName().toLowerCase();
-            return name.endsWith(".jar") && !name.contains("embedded");
+            return name.endsWith(".jar") && !name.contains("embedded") && !name.contains("labkeybootstrap");
         });
 
         if (files == null || files.length == 0)

--- a/server/embedded/src/org/labkey/embedded/EmbeddedExtractor.java
+++ b/server/embedded/src/org/labkey/embedded/EmbeddedExtractor.java
@@ -295,7 +295,10 @@ public class EmbeddedExtractor
             if (toBackup.stream().anyMatch(File::exists))
             {
                 File backupDir = new File(verifyJar().getParentFile(), "backup");
-                FileUtils.forceDelete(backupDir); // Delete existing backup
+                if (backupDir.exists())
+                {
+                    FileUtils.forceDelete(backupDir); // Delete existing backup
+                }
 
                 for (File f : toBackup)
                 {


### PR DESCRIPTION
#### Rationale
Some of our deployment scripts rename the `labkeyServer.jar`. We can be less restrictive about the name when looking for the jar during initial deployment/upgrade. We just need to make sure we don't look in other jars that might be present (`embedded-LABKEY_VERSION.jar` or `labkeyBootstrap.jar`).
Also fixing various problems uncovered by manual testing.

#### Related Pull Requests
* #752 
* #728 

#### Changes
* Be less strict about labkeyServer jar file name
* Fix typo in property name: smtpStartTlsEnable
* Don't attempt to delete a non-existent backup
