### PR TITLE
Put access logs in 'labkey.log.home' by default

### DIFF
--- a/server/bootstrap/src/org/labkey/bootstrap/PipelineBootstrapConfig.java
+++ b/server/bootstrap/src/org/labkey/bootstrap/PipelineBootstrapConfig.java
@@ -16,10 +16,14 @@
 package org.labkey.bootstrap;
 
 import java.io.File;
-import java.util.*;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.net.MalformedURLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.StringTokenizer;
 
 /*
 * User: jeckels
@@ -245,9 +249,10 @@ public class PipelineBootstrapConfig
         return _moduleFiles;
     }
 
-    public static void ensureLogHomeSet(String location)
+    public static String ensureLogHomeSet(String location)
     {
         if (System.getProperty(LOG_HOME_PROPERTY_NAME) == null)
             System.setProperty(LOG_HOME_PROPERTY_NAME, location);
+        return System.getProperty(LOG_HOME_PROPERTY_NAME);
     }
 }

--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -171,10 +171,6 @@ csp.report=\
 ## Use a custom logging configuration
 #logging.config=path/to/alternative/log4j2.xml
 
-## Use a non-temp directory for tomcat
-server.tomcat.basedir=.
-
 ## Enable tomcat access log
 server.tomcat.accesslog.enabled=true
-server.tomcat.accesslog.directory=logs
 server.tomcat.accesslog.pattern=%h %l %u %t "%r" %s %b %D %S %I "%{Referrer}i" "%{User-Agent}i" %{LABKEY.username}s

--- a/server/configs/webapps/embedded/config/application.properties
+++ b/server/configs/webapps/embedded/config/application.properties
@@ -107,7 +107,5 @@ mail.smtpUser=Anonymous
 #logging.config=labkeywebapp/WEB-INF/classes/log4j2.xml
 
 ## Enable tomcat access log
-#server.tomcat.basedir=.
 #server.tomcat.accesslog.enabled=true
-#server.tomcat.accesslog.directory=logs
 #server.tomcat.accesslog.pattern=%h %l %u %t "%r" %s %b %D %S %I "%{Referrer}i" "%{User-Agent}i" %{LABKEY.username}s

--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -50,11 +50,7 @@ public class LabKeyServer
             System.setProperty(TERMINATE_ON_STARTUP_FAILURE, "true");
         }
 
-        // On most installs, catalina.home and catalina.base point to the same directory. However, it's possible
-        // to have multiple instances share the Tomcat binaries but have their own ./logs, ./conf, etc. directories
-        // Thus, we want to use catalina.base for our place to find log files. http://www.jguru.com/faq/view.jsp?EID=1121565
-        String catalinaBase = System.getProperty("catalina.base");
-        PipelineBootstrapConfig.ensureLogHomeSet((null != catalinaBase ? catalinaBase + "/" : "") + "logs");
+        String logHome = PipelineBootstrapConfig.ensureLogHomeSet("logs");
 
         // Restrict Tomcat's jar scanning to the absolute minimum to speed up server startup. Downside is we need to
         // update the jarsToScan list any time we add a new @WebListener annotation... but this happens very rarely.
@@ -69,6 +65,9 @@ public class LabKeyServer
 
         SpringApplication application = new SpringApplication(LabKeyServer.class);
         application.addListeners(new ApplicationPidFileWriter("./labkey.pid"));
+        application.setDefaultProperties(Map.of(
+                "server.tomcat.basedir", ".",
+                "server.tomcat.accesslog.directory", logHome));
         application.setBannerMode(Banner.Mode.OFF);
         application.run(args);
     }


### PR DESCRIPTION
#### Rationale
Our example spring boot access log configuration puts them in `$LABKEY_HOME/logs`, which matches the default `labkey.log` location. If `labkey.log.home` has been set, however, the access logs will not use it.
Also, we probably shouldn't be using `catalina.base` for embedded tomcat.

#### Related Pull Requests
N/A

#### Changes
* Put access logs in 'labkey.log.home' by default