### PR TITLE
Netty CVE 2024-29025

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -243,7 +243,7 @@ mssqlJdbcVersion=12.4.1.jre11
 
 # forced compatibility between docker and UserReg-
 # update version in modules/UserReg-WS/gradle.properties as well
-nettyVersion=4.1.100.Final
+nettyVersion=4.1.108.Final
 
 objenesisVersion=1.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -285,7 +285,7 @@ snappyJavaVersion=1.1.10.5
 springBootVersion=2.7.18
 # This MUST match the Tomcat version dictated by springBootVersion
 # Also, keep this in sync with apacheTomcatVersion above
-springBootTomcatVersion=9.0.83
+springBootTomcatVersion=9.0.86
 
 springVersion=5.3.32
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -103,7 +103,7 @@ apacheDirectoryVersion=2.1.3
 apacheMinaVersion=2.2.1
 
 # Keep in sync with springBootTomcatVersion below
-apacheTomcatVersion=9.0.83
+apacheTomcatVersion=9.0.86
 
 # (mothership) -> json-path -> json-smart -> accessor-smart
 # (core) -> graalvm


### PR DESCRIPTION
#### Rationale
Update Netty version per CVE recommendation. Update tomcat version.

#### Related Pull Requests
* https://github.com/FDA-MyStudies/UserReg-WS/pull/145

#### Changes
* netty version
* tomcat version
