### PR TITLE
Compress text content by default in HTTP responses

### DIFF
--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -67,7 +67,11 @@ public class LabKeyServer
         application.addListeners(new ApplicationPidFileWriter("./labkey.pid"));
         application.setDefaultProperties(Map.of(
                 "server.tomcat.basedir", ".",
-                "server.tomcat.accesslog.directory", logHome));
+                "server.tomcat.accesslog.directory", logHome,
+
+                // Enable HTTP compression for response content
+                "server.compression.enabled", "true"
+                ));
         application.setBannerMode(Banner.Mode.OFF);
         application.run(args);
     }


### PR DESCRIPTION
#### Rationale
We used to have docs encouraging admins to enable compression in HTTP responses. With Spring Boot, we can set the default ourselves.

We don't need to adjust the size threshold is 2KB (same as our recommendations before) or MIME types from Spring Boot's defaults:

https://docs.spring.io/spring-boot/docs/current/reference/html/application-properties.html#application-properties.server.server.compression.enabled

https://www.labkey.org/Documentation/Archive/23.11/wiki-page.view?name=configTomcat#10

#### Changes
* Compress by default