### PR TITLE
Update Tika 2.9.1 -> 2.9.2. Update dependencies.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -108,7 +108,7 @@ apacheTomcatVersion=10.1.19
 # (mothership) -> json-path -> json-smart -> accessor-smart
 # (core) -> graalvm
 # tika
-asmVersion=9.6
+asmVersion=9.7
 
 # Apache Batik -- Batik version needs to be compatible with Apache FOP, but we need to pull in batik-codec separately
 batikVersion=1.17
@@ -127,7 +127,7 @@ commonsBeanutilsVersion=1.9.4
 commonsCollectionsVersion=3.2.2
 commonsCollections4Version=4.4
 commonsCodecVersion=1.16.1
-commonsCompressVersion=1.26.0
+commonsCompressVersion=1.26.1
 commonsDbcpVersion=1.4
 commonsDiscoveryVersion=0.2
 commonsDigesterVersion=1.8.1
@@ -254,10 +254,10 @@ openTracingVersion=0.33.0
 oracleJdbcVersion=23.3.0.23.09
 
 # sync with version Tika ships
-pdfboxVersion=2.0.29
+pdfboxVersion=2.0.31
 
 # sync with version Tika ships
-poiVersion=5.2.3
+poiVersion=5.2.5
 
 pollingWatchVersion=0.2.0
 
@@ -276,9 +276,9 @@ romeVersion=2.1.0
 servletApiVersion=6.0.0
 
 # this version is forced for compatibility with pipeline and tika
-slf4jLog4j12Version=2.0.9
+slf4jLog4j12Version=2.0.12
 # this version is forced for compatibility with api, LDK, and workflow
-slf4jLog4jApiVersion=2.0.9
+slf4jLog4jApiVersion=2.0.12
 
 # This is a dependency for HTSJDK. Force version for CVE-2023-43642
 snappyJavaVersion=1.1.10.5


### PR DESCRIPTION
#### Rationale
It's the latest

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5416