### PR TITLE
embedded default cipher update

### DIFF
--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -6,14 +6,14 @@ server.port=@@serverPort@@
 ## To use ssl, update the properties below for your local installation
 
 #server.ssl.enabled=true
-#server.ssl.enabled-protocols=TLSv1.3,TLSv1.2,TLSv1.1
+#server.ssl.enabled-protocols=TLSv1.3,TLSv1.2
 #server.ssl.protocol=TLS
 #server.ssl.key-alias=tomcat
 #server.ssl.key-store=@@keyStore@@
 #server.ssl.key-store-password=@@keyStorePassword@@
 ## Typically either PKCS12 or JKS
 #server.ssl.key-store-type=PKCS12
-#server.ssl.ciphers=HIGH:!ADH:!EXP:!SSLv2:!SSLv3:!MEDIUM:!LOW:!NULL:!aNULL
+#server.ssl.ciphers=HIGH:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!kRSA:!EDH:!DHE:!DH:!CAMELLIA:!ARIA:!AESCCM:!SHA:!CHACHA20
 
 ## HTTP-only port for servers that need to handle both HTTPS (configure via server.port and server.ssl above) and HTTP
 #context.httpPort=8080

--- a/server/configs/webapps/embedded/config/application.properties
+++ b/server/configs/webapps/embedded/config/application.properties
@@ -2,14 +2,14 @@ server.port=8080
 
 ## To use ssl, update the properties below for your local installation
 #server.ssl.enabled=true
-#server.ssl.enabled-protocols=TLSv1.3,TLSv1.2,TLSv1.1
+#server.ssl.enabled-protocols=TLSv1.3,TLSv1.2
 #server.ssl.protocol=TLS
 #server.ssl.key-alias=tomcat
 #server.ssl.key-store=@@keyStore@@
 #server.ssl.key-store-password=@@keyStorePassword@@
 ## Typically either PKCS12 or JKS
 #server.ssl.key-store-type=PKCS12
-#server.ssl.ciphers=HIGH:!ADH:!EXP:!SSLv2:!SSLv3:!MEDIUM:!LOW:!NULL:!aNULL
+#server.ssl.ciphers=HIGH:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!kRSA:!EDH:!DHE:!DH:!CAMELLIA:!ARIA:!AESCCM:!SHA:!CHACHA20
 
 ## HTTP-only port for servers that need to handle both HTTPS (configure via server.port and server.ssl above) and HTTP
 #context.httpPort=8080


### PR DESCRIPTION
#### Rationale
The default cipher suite is outdated. This updates available cipher suites to match AWS's `ELBSecurityPolicy-TLS13-1-2-2021-06`, but is still compatible with at least `ELBSecurityPolicy-TLS-1-2-2017-01`, and maybe more. This makes it more secure than tomcat's [default set](https://github.com/apache/tomcat/blob/main/java/org/apache/tomcat/util/net/SSLHostConfig.java#L59).


#### Related Pull Requests
* https://github.com/LabKey/Dockerfile/pull/90

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
