### PR TITLE
Fix LogQueries property

### DIFF
--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -30,8 +30,6 @@ context.resources.jdbc.labkeyDataSource.maxIdle=10
 context.resources.jdbc.labkeyDataSource.maxWaitMillis=120000
 context.resources.jdbc.labkeyDataSource.accessToUnderlyingConnectionAllowed=true
 context.resources.jdbc.labkeyDataSource.validationQuery=SELECT 1
-#context.resources.jdbc.labkeyDataSource.logQueries=true
-#context.resources.jdbc.labkeyDataSource.displayName=Alternate Display Name
 
 ## Add additional external data sources with a prefix of context.resources.jdbc.<dataSourceName>.
 ## At a minimum, they must include the required properties: driverClassName, url, username, and password
@@ -39,6 +37,8 @@ context.resources.jdbc.labkeyDataSource.validationQuery=SELECT 1
 #context.resources.jdbc.@@extraJdbcDataSource@@.url=@@extraJdbcUrl@@
 #context.resources.jdbc.@@extraJdbcDataSource@@.username=@@extraJdbcUsername@@
 #context.resources.jdbc.@@extraJdbcDataSource@@.password=@@extraJdbcPassword@@
+#context.resources.jdbc.@@extraJdbcDataSource@@.logQueries=true
+#context.resources.jdbc.@@extraJdbcDataSource@@.displayName=Alternative Display Name
 
 #useLocalBuild#context.webAppLocation=@@pathToServer@@/build/deploy/labkeyWebapp
 context.encryptionKey=@@encryptionKey@@

--- a/server/embedded/src/org/labkey/embedded/ResourceType.java
+++ b/server/embedded/src/org/labkey/embedded/ResourceType.java
@@ -1,11 +1,9 @@
 package org.labkey.embedded;
 
 import org.apache.catalina.core.StandardContext;
-import org.apache.logging.log4j.LogManager;
 import org.apache.tomcat.util.collections.CaseInsensitiveKeyMap;
 import org.apache.tomcat.util.descriptor.web.ContextResource;
 import org.labkey.bootstrap.ConfigException;
-import org.labkey.bootstrap.LabKeyBootstrapClassLoader;
 
 import javax.sql.DataSource;
 import java.util.Map;
@@ -44,7 +42,7 @@ public enum ResourceType
                     String logQueries = props.remove("logQueries");
                     if (logQueries != null)
                     {
-                        context.addParameter(name + ":LogQueries", displayName);
+                        context.addParameter(name + ":LogQueries", logQueries);
                     }
 
                     super.addResource(name, props, context);


### PR DESCRIPTION
#### Rationale
Fix bug in `ResourceType`. Discourage use of special properties on labkey datasource; logQueries won't work and use of displayName is dubious.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/5426