### PR TITLE
upgrade Spring Framework, Bouncy Castle, and Joda Time

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -313,6 +313,9 @@ allprojects {
                     // Force snappy-java version for CVE-2023-43642. Remove once HTSJDK bumps its preferred version.
                     force "org.xerial.snappy:snappy-java:${snappyJavaVersion}"
 
+                    // Force consistency for dependencies from cloud
+                    force "joda-time:joda-time:${jodaTimeVersion}"
+
                     dependencySubstitution {
                         // Because the client api artifact name is not the same as the directory structure, we use
                         // Gradle's dependency substitution so the dependency will appear correctly in the pom files that

--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -314,5 +314,16 @@
         <vulnerabilityName>CVE-2023-45960</vulnerabilityName>
     </suppress>
 
+    <!--
+    suppress CVE-2024-23080 after jodaTime upgrade to 2.12.7, as still detected as 2.12.5
+    -->
+    <suppress>
+        <notes><![CDATA[
+   file name: joda-time-2.12.7.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/joda\-time/joda\-time@.*$</packageUrl>
+        <vulnerabilityName>CVE-2024-23080</vulnerabilityName>
+    </suppress>
+
 </suppressions>
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -115,7 +115,7 @@ batikVersion=1.17
 
 # sync with Tika version (or later)
 bouncycastlePgpVersion=1.76
-bouncycastleVersion=1.76
+bouncycastleVersion=1.78
 
 cglibNodepVersion=2.2.3
 
@@ -216,7 +216,7 @@ jfreechartVersion=1.0.19
 
 jmockVersion=2.6.0
 
-jodaTimeVersion=2.8.1
+jodaTimeVersion=2.12.7
 
 # brought in transitively from guava and other google packages. Need to resolve consistently
 jsr305Version=3.0.2
@@ -287,7 +287,7 @@ springBootVersion=2.7.18
 # Also, keep this in sync with apacheTomcatVersion above
 springBootTomcatVersion=9.0.86
 
-springVersion=5.3.32
+springVersion=5.3.34
 
 # Do not upgrade until BaseDaoImpl stops calling getGeneratedKeys()
 sqliteJdbcVersion=3.42.0.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -114,7 +114,7 @@ asmVersion=9.5
 batikVersion=1.17
 
 # sync with Tika version (or later)
-bouncycastlePgpVersion=1.76
+bouncycastlePgpVersion=1.78
 bouncycastleVersion=1.78
 
 cglibNodepVersion=2.2.3


### PR DESCRIPTION
#### Rationale
bump versions for OWASP warnings

#### Related Pull Requests
* https://github.com/LabKey/server/pull/801

#### Changes
* Spring Framework to 5.3.4
* Bouncy Castle to 1.78
* Joda Time to 2.12.7
  * force version for `cloud`
  * suppress CVE-2024-23080, as 2.12.5 still being detected