### PR TITLE
upgrade Spring Framework, Bouncy Castle, and Joda Time

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -322,6 +322,9 @@ allprojects {
                     // Force snappy-java version for CVE-2023-43642. Remove once HTSJDK bumps its preferred version.
                     force "org.xerial.snappy:snappy-java:${snappyJavaVersion}"
 
+                    // Force consistency for dependencies from cloud
+                    force "joda-time:joda-time:${jodaTimeVersion}"
+
                     dependencySubstitution {
                         // Because the client api artifact name is not the same as the directory structure, we use
                         // Gradle's dependency substitution so the dependency will appear correctly in the pom files that

--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -168,5 +168,16 @@
         <cpe>cpe:/a:apache:tomcat</cpe>
     </suppress>
 
+    <!--
+    suppress CVE-2024-23080 after jodaTime upgrade to 2.12.7, as still detected as 2.12.5
+    -->
+    <suppress>
+        <notes><![CDATA[
+   file name: joda-time-2.12.7.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/joda\-time/joda\-time@.*$</packageUrl>
+        <vulnerabilityName>CVE-2024-23080</vulnerabilityName>
+    </suppress>
+
 </suppressions>
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -114,8 +114,8 @@ asmVersion=9.6
 batikVersion=1.17
 
 # sync with Tika version (or later)
-bouncycastlePgpVersion=1.77
-bouncycastleVersion=1.77
+bouncycastlePgpVersion=1.78
+bouncycastleVersion=1.78
 
 cglibNodepVersion=2.2.3
 
@@ -214,7 +214,7 @@ jfreechartVersion=1.0.19
 
 jmockVersion=2.6.0
 
-jodaTimeVersion=2.8.1
+jodaTimeVersion=2.12.7
 
 # brought in transitively from guava and other google packages. Need to resolve consistently
 jsr305Version=3.0.2
@@ -287,7 +287,7 @@ springBootVersion=3.2.3
 # Also, keep this in sync with apacheTomcatVersion above
 springBootTomcatVersion=10.1.19
 
-springVersion=6.1.4
+springVersion=6.1.6
 
 sqliteJdbcVersion=3.45.1.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -282,7 +282,7 @@ slf4jLog4jApiVersion=2.0.9
 # This is a dependency for HTSJDK. Force version for CVE-2023-43642
 snappyJavaVersion=1.1.10.5
 
-springBootVersion=3.2.4
+springBootVersion=3.2.3
 # This usually matches the Tomcat version dictated by springBootVersion
 # Also, keep this in sync with apacheTomcatVersion above
 springBootTomcatVersion=10.1.19

--- a/gradle.properties
+++ b/gradle.properties
@@ -282,7 +282,7 @@ slf4jLog4jApiVersion=2.0.9
 # This is a dependency for HTSJDK. Force version for CVE-2023-43642
 snappyJavaVersion=1.1.10.5
 
-springBootVersion=3.2.3
+springBootVersion=3.2.4
 # This usually matches the Tomcat version dictated by springBootVersion
 # Also, keep this in sync with apacheTomcatVersion above
 springBootTomcatVersion=10.1.19

--- a/server/embedded/build.gradle
+++ b/server/embedded/build.gradle
@@ -38,7 +38,12 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-actuator:${springBootVersion}"
     implementation "org.springframework.boot:spring-boot-starter-validation:${springBootVersion}"
 //    implementation "org.springframework.boot:spring-boot-starter-log4j2:${springBootVersion}"
-
+    // Force to use latest springVersion for CVE-2024-22262
+    implementation('org.springframework:spring-web') {
+        version {
+            strictly "${springVersion}"
+        }
+    }
     // Force to the latest Tomcat version until Spring Boot 2.7.17 is released and we can adopt it
     implementation('org.apache.tomcat.embed:tomcat-embed-core') {
         version {


### PR DESCRIPTION
#### Rationale
bump versions for OWASP warnings

#### Related Pull Requests
* https://github.com/LabKey/server/pull/800

#### Changes
* Spring Framework to 6.1.6
  * and force spring-web to use 6.1.6 as well
* Bouncy Castle to 1.78
* Joda Time to 2.12.7
  * force version for `cloud`
  * suppress CVE-2024-23080, as 2.12.5 still being detected