### PR TITLE
suppress multiple CVEs for jfreechart

### DIFF
--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -336,5 +336,27 @@
         <vulnerabilityName>CVE-2024-22949</vulnerabilityName>
     </suppress>
 
+    <!--
+    suppress CVE-2023-52070 for jfreechart, may become moot after subsequent upgrades
+    -->
+    <suppress>
+        <notes><![CDATA[
+   file name: jfreechart-1.0.19.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.jfree/jfreechart@.*$</packageUrl>
+        <vulnerabilityName>CVE-2023-52070</vulnerabilityName>
+    </suppress>
+
+    <!--
+    suppress CVE-2024-23076 for jfreechart, may become moot after subsequent upgrades
+    -->
+    <suppress>
+        <notes><![CDATA[
+   file name: jfreechart-1.0.19.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.jfree/jfreechart@.*$</packageUrl>
+        <vulnerabilityName>CVE-2024-23076</vulnerabilityName>
+    </suppress>
+
 </suppressions>
 

--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -325,5 +325,16 @@
         <vulnerabilityName>CVE-2024-23080</vulnerabilityName>
     </suppress>
 
+    <!--
+    suppress CVE-2024-22949 for jfreechart, may become moot after subsequent upgrades
+    -->
+    <suppress>
+        <notes><![CDATA[
+   file name: jfreechart-1.0.19.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.jfree/jfreechart@.*$</packageUrl>
+        <vulnerabilityName>CVE-2024-22949</vulnerabilityName>
+    </suppress>
+
 </suppressions>
 


### PR DESCRIPTION
#### Rationale
multiple disputed CVEs are being flagged by OWASP for jfreechart. Suppressing all for now, though they may become moot in a subsequent upgrade.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
