### PR TITLE
Add metric to track custom Log4J configs

### DIFF
--- a/server/configs/webapps/embedded/labkey_server.service
+++ b/server/configs/webapps/embedded/labkey_server.service
@@ -21,7 +21,6 @@ ExecStart=<JAVA_HOME>/bin/java \
     -Xms2G \
     -Xmx2G \
     -XX:+HeapDumpOnOutOfMemoryError \
-    -XX:ErrorFile=$LABKEY_HOME/logs/error_%p.log \
     -Djava.io.tmpdir=$LABKEY_HOME/labkey-tmp \
     $JAVA_FLAGS_JAR_OPS \
     $JAVA_REFLECTION_JAR_OPS \

--- a/server/configs/webapps/embedded/labkey_server.service
+++ b/server/configs/webapps/embedded/labkey_server.service
@@ -21,7 +21,7 @@ ExecStart=<JAVA_HOME>/bin/java \
     -Xms2G \
     -Xmx2G \
     -XX:+HeapDumpOnOutOfMemoryError \
-    -XX:ErrorFile=/labkey/labkey/logs/error_%p.log \
+    -XX:ErrorFile=$LABKEY_HOME/logs/error_%p.log \
     -Djava.io.tmpdir=$LABKEY_HOME/labkey-tmp \
     $JAVA_FLAGS_JAR_OPS \
     $JAVA_REFLECTION_JAR_OPS \

--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -28,6 +28,7 @@ public class LabKeyServer
     private static final String SERVER_GUID = "serverGUID";
     public static final String SERVER_GUID_PARAMETER_NAME = "org.labkey.mothership." + SERVER_GUID;
     public static final String SERVER_SSL_KEYSTORE = "org.labkey.serverSslKeystore";
+    public static final String CUSTOM_LOG4J_CONFIG = "org.labkey.customLog4JConfig";
     static final String MAX_TOTAL_CONNECTIONS_DEFAULT = "50";
     static final String MAX_IDLE_DEFAULT = "10";
     static final String MAX_WAIT_MILLIS_DEFAULT = "120000";
@@ -187,6 +188,12 @@ public class LabKeyServer
         return new ManagementProperties();
     }
 
+    @Bean
+    public LoggingProperties loggingSource()
+    {
+        return new LoggingProperties();
+    }
+
 
     /**
      * This lets us snoop on the Spring Boot config for deploying the management endpoint on a different port, as
@@ -221,6 +228,26 @@ public class LabKeyServer
         public void setPort(int port)
         {
             _port = port;
+        }
+    }
+
+    /**
+     * This lets us snoop on the Spring Boot config for log4j so we can report it via a mothership metric
+     */
+    @Configuration
+    @ConfigurationProperties("logging")
+    public static class LoggingProperties
+    {
+        private String _config;
+
+        public String getConfig()
+        {
+            return _config;
+        }
+
+        public void setConfig(String config)
+        {
+            _config = config;
         }
     }
 

--- a/server/embedded/src/org/labkey/embedded/LabKeyTomcatServletWebServerFactory.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyTomcatServletWebServerFactory.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
+import static org.labkey.embedded.LabKeyServer.CUSTOM_LOG4J_CONFIG;
 import static org.labkey.embedded.LabKeyServer.SERVER_GUID_PARAMETER_NAME;
 import static org.labkey.embedded.LabKeyServer.SERVER_SSL_KEYSTORE;
 
@@ -155,6 +156,13 @@ class LabKeyTomcatServletWebServerFactory extends TomcatServletWebServerFactory
                     context.addParameter("org.labkey.authentication.totp.Bypass", "true");
                     context.addParameter("org.labkey.authentication.duo.Bypass", "true");
                 }
+
+                boolean customLog4J = System.getProperty("log4j.configurationFile") != null;
+                if (!customLog4J)
+                {
+                    customLog4J = _server.loggingSource().getConfig() != null;
+                }
+                context.addParameter(CUSTOM_LOG4J_CONFIG, Boolean.toString(customLog4J));
 
                 // Add serverGUID for mothership - it tells mothership that 2 instances of a server should be considered the same for metrics gathering purposes.
                 if (null != contextProperties.getServerGUID())


### PR DESCRIPTION
#### Rationale
We want to be more proactive in coordinating edits to `log4j2.xml` configs for on-premise and cloud deployments

#### Changes
* Capture whether the config is custom so it can be used for a metric
* Use environment variable in another spot to simplify service configuration