### PR TITLE
Make embedded tomcat the default for dev deployments

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,21 +21,13 @@ org.gradle.jvmargs=-Xmx2048m -XX:+UseParallelGC
 # The value 'delete' will cause the conflicting version(s) in the build directory to be removed.
 versionConflictAction=delete
 
-# uncomment the following line for running the application with standalone tomcat
-#useEmbeddedTomcat=false
+# Comment the following line to deploy the application with standalone tomcat
+useEmbeddedTomcat=true
 
-# Used by 'startTomcat' task to permit reflection operations required by Tomcat
-embeddedReflectionArgs=\
-  --add-opens=java.base/java.lang=ALL-UNNAMED \
-  --add-opens=java.base/java.io=ALL-UNNAMED \
-  --add-opens=java.base/java.util=ALL-UNNAMED \
-  --add-opens=java.desktop/java.awt.font=ALL-UNNAMED \
-  --add-opens=java.base/java.text=ALL-UNNAMED
-
-# Comment the following line when using a pre-build distribution with embedded tomcat
+# Comment the following line when deploying a pre-build distribution with embedded tomcat
 useLocalBuild
 
-# uncomment the following line when using SSL for your embedded tomcat server
+# Uncomment the following line when using SSL for your embedded tomcat server
 #useSsl
 
 # the URL for the artifact repository where our build plugins are housed

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,11 +21,19 @@ org.gradle.jvmargs=-Xmx2048m -XX:+UseParallelGC
 # The value 'delete' will cause the conflicting version(s) in the build directory to be removed.
 versionConflictAction=delete
 
-# uncomment the following line for running the application with embedded tomcat
-#useEmbeddedTomcat
+# uncomment the following line for running the application with standalone tomcat
+#useEmbeddedTomcat=false
 
-# uncomment the following line when using a local build of a server with embedded tomcat
-#useLocalBuild
+# Used by 'startTomcat' task to permit reflection operations required by Tomcat
+embeddedReflectionArgs=\
+  --add-opens=java.base/java.lang=ALL-UNNAMED \
+  --add-opens=java.base/java.io=ALL-UNNAMED \
+  --add-opens=java.base/java.util=ALL-UNNAMED \
+  --add-opens=java.desktop/java.awt.font=ALL-UNNAMED \
+  --add-opens=java.base/java.text=ALL-UNNAMED
+
+# Comment the following line when using a pre-build distribution with embedded tomcat
+useLocalBuild
 
 # uncomment the following line when using SSL for your embedded tomcat server
 #useSsl
@@ -62,7 +70,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.31.9
 gradleNodePluginVersion=3.5.1
-gradlePluginsVersion=2.6.4
+gradlePluginsVersion=2.7.0-embeddedDistFlags-SNAPSHOT
 owaspDependencyCheckPluginVersion=9.1.0
 versioningPluginVersion=1.1.2
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -62,7 +62,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.31.9
 gradleNodePluginVersion=3.5.1
-gradlePluginsVersion=2.7.0-embeddedDistFlags-SNAPSHOT
+gradlePluginsVersion=2.7.0
 owaspDependencyCheckPluginVersion=9.1.0
 versioningPluginVersion=1.1.2
 

--- a/gradle/settings/ehr.gradle
+++ b/gradle/settings/ehr.gradle
@@ -69,8 +69,8 @@ include ":server:modules:snd"
 include ":server:modules:tnprc_ehr"
 include ":server:modules:tnprc_billing"
 include ":server:modules:dataintegration"
-include ":server:modules:premium"
-include ":server:modules:ldap"
+include ":server:modules:premiumModules:premium"
+include ":server:modules:premiumModules:ldap"
 
 // include the test distribution, which is used to create an artifact for TeamCity to pass around to the agents
 include "${BuildUtils.getTestProjectPath(this.settings.gradle)}:distributions:teamcity"

--- a/settings.gradle
+++ b/settings.gradle
@@ -96,11 +96,8 @@ import org.labkey.gradle.util.BuildUtils
   node in the tree with these leaves (e.g., 'server:modules:core' will create projects for ":server"
   ":server:modules" and ":server:modules:core").
  */
-if (BuildUtils.useEmbeddedTomcat(this.settings))
-{
-    include ":server:embedded"
-}
 
+include BuildUtils.getEmbeddedProjectPath(gradle)
 include BuildUtils.getMinificationProjectPath(gradle)
 
 // A list of directory names or fully qualified module paths that correspond to modules to be excluded from configuration.


### PR DESCRIPTION
#### Rationale
Now that embedded Tomcat is the default for development environments, we can eliminate some setup steps by flipping the default values for `useEmbeddedTomcat` and `useLocalBuild`.
Also, unconditionally including the `:server:embedded` will ensure that embedded distributions are always able to be created (along with some gradle plugin tweaks).

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/209

#### Changes
* Make embedded tomcat the default for dev deployments
* Always include `:server:embedded` project to allow embedded deployments to always be created
* Update project paths in `ehr` module set