### PR TITLE
Use CODEOWNERS to notify people who care about Log4J config changes

### DIFF
--- a/server/CODEOWNERS
+++ b/server/CODEOWNERS
@@ -1,0 +1,2 @@
+# Alert people who will likely need to propagate Log4J config changes to other systems
+/embedded/src/resources/log4j2.xml @LabKey/SystemsEngineering @labkey-mohara @keith-labkey


### PR DESCRIPTION
#### Rationale
Edits to `log4j2.xml` often need to be coordinated across other systems.

#### Changes
* See if we can loop in stakeholders automatically