### PR TITLE
Clean up previous embedded installation before extracting upgrade

### DIFF
--- a/server/embedded/src/org/labkey/embedded/EmbeddedExtractor.java
+++ b/server/embedded/src/org/labkey/embedded/EmbeddedExtractor.java
@@ -27,6 +27,9 @@ public class EmbeddedExtractor
     private static final Log LOG = LogFactory.getLog(EmbeddedExtractor.class);
     private static final int BUFFER_SIZE = 1024 * 64;
     public static final String LABKEYWEBAPP = "labkeywebapp";
+    /**
+     * Directories that are expected to exist in 'distribution.zip'.
+     */
     private static final Set<String> EXPECTED_DIST_DIRS = Set.of(LABKEYWEBAPP, "modules");
 
     private final File currentDir = new File("").getAbsoluteFile();

--- a/server/embedded/src/org/labkey/embedded/EmbeddedExtractor.java
+++ b/server/embedded/src/org/labkey/embedded/EmbeddedExtractor.java
@@ -82,7 +82,7 @@ public class EmbeddedExtractor
 
         LabKeyDistributionInfo incomingDistribution = getDistributionInfo();
 
-        // Likely upgrading from standalone Tomcat installation or webAppLocation doesn't exist.
+        // Fresh installation or upgrading from non-embedded Tomcat
         if (!existingVersionFile.exists() || !existingDistributionFile.exists())
         {
             LOG.info("Extracting new LabKey distribution - %s".formatted(incomingDistribution));
@@ -105,15 +105,18 @@ public class EmbeddedExtractor
 
         if (!existingDistribution.equals(incomingDistribution))
         {
-            LOG.info("Updating LabKey deployment (%s -> %s)".formatted(existingDistribution, incomingDistribution));
+            LOG.info("Updating LabKey (%s -> %s)".formatted(existingDistribution, incomingDistribution));
             return true;
         }
         else if (incomingDistribution.buildUrl == null)
         {
-            LOG.info("Updating LabKey deployment (%s -> %s)".formatted(existingDistribution, incomingDistribution));
+            LOG.info("Extracting custom-build LabKey distribution (%s)".formatted(existingDistribution));
             return true;
         }
-        return false;
+        else
+        {
+            return false;
+        }
     }
 
     /**

--- a/server/embedded/src/org/labkey/embedded/EmbeddedExtractor.java
+++ b/server/embedded/src/org/labkey/embedded/EmbeddedExtractor.java
@@ -1,6 +1,5 @@
 package org.labkey.embedded;
 
-import io.micrometer.common.util.StringUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -119,8 +118,8 @@ public class EmbeddedExtractor
      */
     private LabKeyDistributionInfo getDistributionInfo()
     {
-        String version = null;
-        String distributionName = null;
+        String version = "";
+        String distributionName = "";
 
         try
         {
@@ -144,21 +143,21 @@ public class EmbeddedExtractor
                                 distributionDirs.add(zipEntry.getName().split("/", 2)[0]);
                                 if (!zipEntry.isDirectory() && zipEntry.getName().equals("labkeywebapp/WEB-INF/classes/VERSION"))
                                 {
-                                    version = StreamUtils.copyToString(zipIn, StandardCharsets.UTF_8);
+                                    version = StreamUtils.copyToString(zipIn, StandardCharsets.UTF_8).trim();
                                 }
                                 else if (!zipEntry.isDirectory() && zipEntry.getName().equals("labkeywebapp/WEB-INF/classes/distribution"))
                                 {
-                                    distributionName = StreamUtils.copyToString(zipIn, StandardCharsets.UTF_8);
+                                    distributionName = StreamUtils.copyToString(zipIn, StandardCharsets.UTF_8).trim();
                                 }
                                 zipIn.closeEntry();
                                 zipEntry = zipIn.getNextEntry();
                             }
                         }
-                        if (StringUtils.isBlank(version))
+                        if (version.isEmpty())
                         {
                             throw new ConfigException("Unable to determine version of distribution.");
                         }
-                        if (StringUtils.isBlank(distributionName))
+                        if (distributionName.isEmpty())
                         {
                             throw new ConfigException("Unable to determine name of distribution.");
                         }


### PR DESCRIPTION
#### Rationale
[Issue 50481: Upgrades from 24.3 to 24.4/24.5 need manual cleanup first, otherwise org.labkey.bootstrap.ConfigException](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50481)

The backup step we used to perform before attempting to self-deploy also served as a method of clearing the way for the new installation. Removing the backup step broke the upgrade process (making the upgrade require manual cleanup of the existing install).
```
org.labkey.bootstrap.ConfigException: Delete or backup existing LabKey deployment at: /usr/local/labkey/labkey/labkeywebapp
                at org.labkey.embedded.EmbeddedExtractor.extractDistributionZip(EmbeddedExtractor.java:255) ~[!/:24.5.0]
                at org.labkey.embedded.EmbeddedExtractor.extractExecutableJar(EmbeddedExtractor.java:187) ~[!/:24.5.0]
                at org.labkey.embedded.EmbeddedExtractor.extractDistribution(EmbeddedExtractor.java:165) ~[!/:24.5.0]
                at org.labkey.embedded.LabKeyTomcatServletWebServerFactory.getTomcatWebServer(LabKeyTomcatServletWebServerFactory.java:78) ~[!/:24.5.0]
```
I'm also adding validation of the contents of the `distribution.zip` to ensure we are backing up everything we should ( currently just the `modules` and `labkeywebapp` directories). This check should fail on TeamCity before a change to distribution structure could ever cause problems in the wild.

#### Related Pull Requests
* #775 

#### Changes
* Create a temporary backup while unzipping the LabKey distribution
* Add validation of distribution.zip contents (`modules` and `labkeywebapp`)
