### PR TITLE
Java dependency updates for 24.6

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -63,7 +63,7 @@ windowsProteomicsBinariesVersion=1.0
 artifactoryPluginVersion=4.31.9
 gradleNodePluginVersion=3.5.1
 gradlePluginsVersion=2.7.0
-owaspDependencyCheckPluginVersion=9.1.0
+owaspDependencyCheckPluginVersion=9.2.0
 versioningPluginVersion=1.1.2
 
 # Versions of node and npm to use during the build. If set, these versions
@@ -103,7 +103,7 @@ apacheDirectoryVersion=2.1.3
 apacheMinaVersion=2.2.1
 
 # Keep in sync with springBootTomcatVersion below
-apacheTomcatVersion=10.1.19
+apacheTomcatVersion=10.1.24
 
 # (mothership) -> json-path -> json-smart -> accessor-smart
 # (core) -> graalvm
@@ -126,21 +126,21 @@ checkerQualVersion=3.31.0
 commonsBeanutilsVersion=1.9.4
 commonsCollectionsVersion=3.2.2
 commonsCollections4Version=4.4
-commonsCodecVersion=1.16.1
+commonsCodecVersion=1.17.0
 commonsCompressVersion=1.26.1
 commonsDbcpVersion=1.4
 commonsDiscoveryVersion=0.2
 commonsDigesterVersion=1.8.1
-commonsIoVersion=2.15.1
+commonsIoVersion=2.16.1
 commonsLangVersion=2.6
 commonsLang3Version=3.14.0
-commonsLoggingVersion=1.3.1
+commonsLoggingVersion=1.3.2
 commonsMath3Version=3.6.1
 commonsPoolVersion=1.6
-commonsTextVersion=1.11.0
-commonsValidatorVersion=1.8.0
+commonsTextVersion=1.12.0
+commonsValidatorVersion=1.9.0
 
-datadogVersion=1.31.2
+datadogVersion=1.34.0
 
 dom4jVersion=2.1.4
 
@@ -156,9 +156,9 @@ fopVersion=2.9
 
 # Force latest for consistency
 googleAutoValueAnnotationsVersion=1.10.4
-googleErrorProneAnnotationsVersion=2.26.1
-googleHttpClientVersion=1.44.1
-googleOauthClientVersion=1.35.0
+googleErrorProneAnnotationsVersion=2.28.0
+googleHttpClientVersion=1.44.2
+googleOauthClientVersion=1.36.0
 googleProtocolBufVersion=3.25.3
 
 graalVersion=24.0.1
@@ -169,9 +169,9 @@ graalVersion=24.0.1
 # "java.lang.NoSuchMethodError: 'void com.google.gson.internal.ConstructorConstructor.<init>(java.util.Map)'" errors
 gsonVersion=2.8.9
 
-grpcVersion=1.62.2
+grpcVersion=1.64.0
 
-guavaVersion=33.1.0-jre
+guavaVersion=33.2.0-jre
 
 # Note: You won't find usages in the product sources; this property is used by the gradle plugin.
 gwtVersion=2.11.0
@@ -190,10 +190,10 @@ httpclientVersion=4.5.14
 httpcoreVersion=4.4.16
 
 # Jackson dependencies are usually released in tandem, but occasionally one gets a patch release out-of-sync with the others
-jacksonVersion=2.16.2
-jacksonAnnotationsVersion=2.16.2
-jacksonDatabindVersion=2.16.2
-jacksonJaxrsBaseVersion=2.16.2
+jacksonVersion=2.17.1
+jacksonAnnotationsVersion=2.17.1
+jacksonDatabindVersion=2.17.1
+jacksonJaxrsBaseVersion=2.17.1
 
 jamaVersion=1.0.3
 
@@ -242,11 +242,11 @@ luceneVersion=9.10.0
 
 mssqlJdbcVersion=12.4.2.jre11
 
-mysqlDriverVersion=8.3.0
+mysqlDriverVersion=8.4.0
 
 # forced compatibility between docker and UserReg-
 # update version in modules/UserReg-WS/gradle.properties as well
-nettyVersion=4.1.108.Final
+nettyVersion=4.1.110.Final
 
 objenesisVersion=1.0
 
@@ -255,7 +255,7 @@ opencsvVersion=2.3
 
 openTracingVersion=0.33.0
 
-oracleJdbcVersion=23.3.0.23.09
+oracleJdbcVersion=23.4.0.24.05
 
 # sync with version Tika ships
 pdfboxVersion=2.0.31
@@ -287,14 +287,14 @@ slf4jLog4jApiVersion=2.0.12
 # This is a dependency for HTSJDK. Force version for CVE-2023-43642
 snappyJavaVersion=1.1.10.5
 
-springBootVersion=3.2.4
+springBootVersion=3.2.6
 # This usually matches the Tomcat version dictated by springBootVersion
 # Also, keep this in sync with apacheTomcatVersion above
-springBootTomcatVersion=10.1.19
+springBootTomcatVersion=10.1.24
 
-springVersion=6.1.6
+springVersion=6.1.8
 
-sqliteJdbcVersion=3.45.2.0
+sqliteJdbcVersion=3.46.0.0
 
 # NLP and SAML bring stax2-api in as a transitive dependency but with very different versions. We force the later version.
 stax2ApiVersion=4.2.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -244,8 +244,7 @@ mssqlJdbcVersion=12.4.2.jre11
 
 mysqlDriverVersion=8.4.0
 
-# forced compatibility between docker and UserReg-
-# update version in modules/UserReg-WS/gradle.properties as well
+# forced compatibility between docker and UserReg-WS
 nettyVersion=4.1.110.Final
 
 objenesisVersion=1.0


### PR DESCRIPTION
#### Rationale
Monthly third party dependency update.

#### Changes
* Update dependencies to latest versions.