### PR TITLE
Test Tomcat 10.1.25

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -159,9 +159,9 @@ allprojects {
 // Temporarily uncomment the block below and update the four-digit number to allow building with Tomcat versions that
 // haven't been released yet. The "VOTE" emails sent to the Tomcat dev email list include a staging repo URL. In
 // addition to updating the url to match, you'll also need to update apacheTomcatVersion in gradle.properties.
-//                    maven {
-//                    	url "https://repository.apache.org/content/repositories/orgapachetomcat-1322/"
-//                    }
+                    maven {
+                    	url "https://repository.apache.org/content/repositories/orgapachetomcat-1498/"
+                    }
                     maven {
                         // Mondrian dependencies are available via this repository. It's a direct dependency of the Query
                         // module but is declared here as many modules depend on Query and therefore need it as well.

--- a/gradle.properties
+++ b/gradle.properties
@@ -103,7 +103,7 @@ apacheDirectoryVersion=2.1.3
 apacheMinaVersion=2.2.1
 
 # Keep in sync with springBootTomcatVersion below
-apacheTomcatVersion=10.1.24
+apacheTomcatVersion=10.1.25
 
 # (mothership) -> json-path -> json-smart -> accessor-smart
 # (core) -> graalvm
@@ -289,7 +289,7 @@ snappyJavaVersion=1.1.10.5
 springBootVersion=3.2.6
 # This usually matches the Tomcat version dictated by springBootVersion
 # Also, keep this in sync with apacheTomcatVersion above
-springBootTomcatVersion=10.1.24
+springBootTomcatVersion=10.1.25
 
 springVersion=6.1.8
 


### PR DESCRIPTION
#### Rationale
Won't be merged. Using this branch to run our test suites on the proposed Apache Tomcat 10.1.25 release.