### PR TITLE
Migrate to Spring Boot 3.3.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -286,11 +286,11 @@ slf4jLog4jApiVersion=2.0.12
 # This is a dependency for HTSJDK. Force version for CVE-2023-43642
 snappyJavaVersion=1.1.10.5
 
-springBootVersion=3.2.6
+springBootVersion=3.3.0
 # This usually matches the Tomcat version dictated by springBootVersion
 # Also, keep this in sync with apacheTomcatVersion above
 springBootTomcatVersion=10.1.24
-
+# This usually matches the Spring Framework version dictated by springBootVersion
 springVersion=6.1.8
 
 sqliteJdbcVersion=3.46.0.0

--- a/server/embedded/build.gradle
+++ b/server/embedded/build.gradle
@@ -40,14 +40,15 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-web:${springBootVersion}"
     implementation "org.springframework.boot:spring-boot-starter-actuator:${springBootVersion}"
     implementation "org.springframework.boot:spring-boot-starter-validation:${springBootVersion}"
-//    implementation "org.springframework.boot:spring-boot-starter-log4j2:${springBootVersion}"
-    // Force to use latest springVersion for CVE-2024-22262
+
+    // Allows forcing a Spring Framework version that differs from spring-boot's version (e.g., to address CVEs)
     implementation('org.springframework:spring-web') {
         version {
             strictly "${springVersion}"
         }
     }
-    // Force to the latest Tomcat version until Spring Boot 2.7.17 is released and we can adopt it
+
+    // Allows forcing a Tomcat version that differs from spring-boot's version (e.g., to address CVEs or test a release candidate)
     implementation('org.apache.tomcat.embed:tomcat-embed-core') {
         version {
             strictly "${springBootTomcatVersion}"


### PR DESCRIPTION
#### Rationale
Latest version of Spring Boot. Lots of changes in 3.3.x, but I don't see anything particularly relevant to LabKey Server. https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.3-Release-Notes