### PR TITLE
Make `ModuleDistribution` tasks more efficient with disk space

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -62,7 +62,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.31.9
 gradleNodePluginVersion=3.5.1
-gradlePluginsVersion=2.7.2-distDiskSpace-SNAPSHOT
+gradlePluginsVersion=2.7.2
 owaspDependencyCheckPluginVersion=9.2.0
 versioningPluginVersion=1.1.2
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -62,7 +62,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.31.9
 gradleNodePluginVersion=3.5.1
-gradlePluginsVersion=2.7.1
+gradlePluginsVersion=2.7.2-distDiskSpace-SNAPSHOT
 owaspDependencyCheckPluginVersion=9.2.0
 versioningPluginVersion=1.1.2
 


### PR DESCRIPTION
#### Rationale
Building distributions on TeamCity fills up the disk. We shouldn't do that.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/211

#### Changes
* Update gradle plugin version
