### PR TITLE
Temporarily reduce PDFBox logging level

### DIFF
--- a/server/embedded/src/main/resources/log4j2.xml
+++ b/server/embedded/src/main/resources/log4j2.xml
@@ -215,7 +215,7 @@ account managers so that we can coordinate edits with other customized copies of
         <Logger name="org.labkey.api.pipeline.PipelineJob" level="error"/>
 
         <!-- don't need to log PDFBox errors (e.g., FlateFilter, PDCIDFontType2) -->
-        <Logger name="org.apache.pdfbox" level="fatal"/>
+        <Logger name="org.apache.pdfbox" level="debug"/>
 
         <!-- Suppress EHCache "maxElementsInMemory of 0" warnings, Issue 49593 -->
         <Logger name="net.sf.ehcache.config.CacheConfiguration" level="error"/>


### PR DESCRIPTION
#### Rationale
Collect more information regarding slow font cache population on Windows
