### PR TITLE
add additivity=false to prevent double logging

### DIFF
--- a/server/embedded/src/main/resources/log4j2.xml
+++ b/server/embedded/src/main/resources/log4j2.xml
@@ -173,19 +173,19 @@ account managers so that we can coordinate edits with other customized copies of
         </Root>
 
         <!-- category for server side script messages -->
-        <Logger name="org.labkey.api.script.ScriptService.Console" level="info">
+        <Logger name="org.labkey.api.script.ScriptService.Console" additivity="false" level="info">
             <AppenderRef ref="SessionAppender"/>
         </Logger>
 
         <!-- category for Mule messages -->
-        <Logger name="org.mule.MuleManager" level="info"/>
+        <Logger name="org.mule.MuleManager" additivity="false" level="info"/>
 
         <!--
             <Logger name="org.labkey.pipeline.mule.transformers" level="debug"/>
         -->
 
         <!-- category for jasper messages -->
-        <Logger name="org.apache.jasper" level="warn"/>
+        <Logger name="org.apache.jasper" additivity="false" level="warn"/>
 
         <Logger name="org.labkey" />
 
@@ -201,7 +201,7 @@ account managers so that we can coordinate edits with other customized copies of
             <AppenderRef ref="LABKEY"/>
         </Logger> -->
 
-        <Logger name="mondrian." level="info" />
+        <Logger name="mondrian." additivity="false" level="info" />
 
         <!--
             <Logger name="org.labkey.wiki" level="debug"/>
@@ -212,13 +212,13 @@ account managers so that we can coordinate edits with other customized copies of
         -->
 
         <!-- only show errors from PipelineJob output -->
-        <Logger name="org.labkey.api.pipeline.PipelineJob" level="error"/>
+        <Logger name="org.labkey.api.pipeline.PipelineJob" additivity="false" level="error"/>
 
         <!-- don't need to log PDFBox errors (e.g., FlateFilter, PDCIDFontType2) -->
-        <Logger name="org.apache.pdfbox" level="fatal"/>
+        <Logger name="org.apache.pdfbox" additivity="false" level="fatal"/>
 
         <!-- Suppress EHCache "maxElementsInMemory of 0" warnings, Issue 49593 -->
-        <Logger name="net.sf.ehcache.config.CacheConfiguration" level="error"/>
+        <Logger name="net.sf.ehcache.config.CacheConfiguration" additivity="false" level="error"/>
 
         <!-- this is a very verbose logger for security/permissions checking -->
         <!--
@@ -232,15 +232,15 @@ account managers so that we can coordinate edits with other customized copies of
             <Logger name="org.labkey.api.data.Table" level="debug"/>
         -->
 
-        <Logger name="org.labkey.api.data"/>
+        <Logger name="org.labkey.api.data" additivity="false"/>
 
-        <Logger name="org.labkey.api.dataiterator"/>
+        <Logger name="org.labkey.api.dataiterator" additivity="false"/>
 
-        <Logger name="org.labkey.docker">
+        <Logger name="org.labkey.docker" additivity="false">
             <level value="info"/>
         </Logger>
 
-        <Logger name="org.labkey.rstudio" level="info"/>
+        <Logger name="org.labkey.rstudio" additivity="false" level="info"/>
 
         <!--
             <Logger name="org.labkey.api.cache" level="debug"/>
@@ -274,11 +274,11 @@ account managers so that we can coordinate edits with other customized copies of
             <AppenderRef ref="INDEXED_DOCUMENTS"/>
         </Logger>
 
-        <Logger name="org.labkey.api.util.DebugInfoDumper" level="debug">
+        <Logger name="org.labkey.api.util.DebugInfoDumper" additivity="false" level="debug">
             <AppenderRef ref="THREAD_DUMP"/>
         </Logger>
 
-        <Logger name="org.labkey.core.admin.AdminController.ContentSecurityPolicyReportAction"  additivity="false" level="warn">
+        <Logger name="org.labkey.core.admin.AdminController.ContentSecurityPolicyReportAction" additivity="false" level="warn">
             <AppenderRef ref="CSP_REPORT" />
             <AppenderRef ref="CONSOLE"/>
         </Logger>
@@ -301,7 +301,7 @@ account managers so that we can coordinate edits with other customized copies of
             <AppenderRef ref="QUERY_STATS"/>
         </Logger>
 
-        <Logger name="org.labkey.audit.event" level="OFF">
+        <Logger name="org.labkey.audit.event" additivity="false" level="OFF">
             <AppenderRef ref="LABKEY_AUDIT"/>
             <AppenderRef ref="CONSOLE"/>
         </Logger>

--- a/server/embedded/src/main/resources/log4j2.xml
+++ b/server/embedded/src/main/resources/log4j2.xml
@@ -173,7 +173,7 @@ account managers so that we can coordinate edits with other customized copies of
         </Root>
 
         <!-- category for server side script messages -->
-        <Logger name="org.labkey.api.script.ScriptService.Console" additivity="false" level="info">
+        <Logger name="org.labkey.api.script.ScriptService.Console" level="info">
             <AppenderRef ref="SessionAppender"/>
         </Logger>
 
@@ -212,7 +212,7 @@ account managers so that we can coordinate edits with other customized copies of
         -->
 
         <!-- only show errors from PipelineJob output -->
-        <Logger name="org.labkey.api.pipeline.PipelineJob" additivity="false" level="error"/>
+        <Logger name="org.labkey.api.pipeline.PipelineJob" level="error"/>
 
         <!-- don't need to log PDFBox errors (e.g., FlateFilter, PDCIDFontType2) -->
         <Logger name="org.apache.pdfbox" level="fatal"/>
@@ -232,15 +232,15 @@ account managers so that we can coordinate edits with other customized copies of
             <Logger name="org.labkey.api.data.Table" level="debug"/>
         -->
 
-        <Logger name="org.labkey.api.data" additivity="false"/>
+        <Logger name="org.labkey.api.data" />
 
-        <Logger name="org.labkey.api.dataiterator" additivity="false"/>
+        <Logger name="org.labkey.api.dataiterator" />
 
-        <Logger name="org.labkey.docker" additivity="false">
+        <Logger name="org.labkey.docker" >
             <level value="info"/>
         </Logger>
 
-        <Logger name="org.labkey.rstudio" additivity="false" level="info"/>
+        <Logger name="org.labkey.rstudio" level="info"/>
 
         <!--
             <Logger name="org.labkey.api.cache" level="debug"/>
@@ -274,13 +274,12 @@ account managers so that we can coordinate edits with other customized copies of
             <AppenderRef ref="INDEXED_DOCUMENTS"/>
         </Logger>
 
-        <Logger name="org.labkey.api.util.DebugInfoDumper" additivity="false" level="debug">
+        <Logger name="org.labkey.api.util.DebugInfoDumper" level="debug">
             <AppenderRef ref="THREAD_DUMP"/>
         </Logger>
 
-        <Logger name="org.labkey.core.admin.AdminController.ContentSecurityPolicyReportAction" additivity="false" level="warn">
+        <Logger name="org.labkey.core.admin.AdminController.ContentSecurityPolicyReportAction" level="warn">
             <AppenderRef ref="CSP_REPORT" />
-            <AppenderRef ref="CONSOLE"/>
         </Logger>
 
         <!--
@@ -293,17 +292,16 @@ account managers so that we can coordinate edits with other customized copies of
             </Logger>
          -->
 
-        <Logger name="org.labkey.core.admin.ActionsTsvWriter" additivity="false" level="info">
+        <Logger name="org.labkey.core.admin.ActionsTsvWriter" level="info">
             <AppenderRef ref="ACTION_STATS"/>
         </Logger>
 
-        <Logger name="org.labkey.api.data.queryprofiler.QueryProfiler.QueryProfilerThread" additivity="false" level="info">
+        <Logger name="org.labkey.api.data.queryprofiler.QueryProfiler.QueryProfilerThread" level="info">
             <AppenderRef ref="QUERY_STATS"/>
         </Logger>
 
-        <Logger name="org.labkey.audit.event" additivity="false" level="OFF">
+        <Logger name="org.labkey.audit.event" level="OFF">
             <AppenderRef ref="LABKEY_AUDIT"/>
-            <AppenderRef ref="CONSOLE"/>
         </Logger>
 
         <!--
@@ -339,6 +337,6 @@ account managers so that we can coordinate edits with other customized copies of
             <AppenderRef ref="CONSOLE"/>
         </Logger>
 
-        <Logger name="NoOpLogger" level="OFF" additivity="false"/>
+        <Logger name="NoOpLogger" level="OFF" />
     </Loggers>
 </Configuration>

--- a/server/embedded/src/main/resources/log4j2.xml
+++ b/server/embedded/src/main/resources/log4j2.xml
@@ -292,11 +292,11 @@ account managers so that we can coordinate edits with other customized copies of
             </Logger>
          -->
 
-        <Logger name="org.labkey.core.admin.ActionsTsvWriter" level="info">
+        <Logger name="org.labkey.core.admin.ActionsTsvWriter" additivity="false" level="info">
             <AppenderRef ref="ACTION_STATS"/>
         </Logger>
 
-        <Logger name="org.labkey.api.data.queryprofiler.QueryProfiler.QueryProfilerThread" level="info">
+        <Logger name="org.labkey.api.data.queryprofiler.QueryProfiler.QueryProfilerThread" additivity="false" level="info">
             <AppenderRef ref="QUERY_STATS"/>
         </Logger>
 
@@ -337,6 +337,6 @@ account managers so that we can coordinate edits with other customized copies of
             <AppenderRef ref="CONSOLE"/>
         </Logger>
 
-        <Logger name="NoOpLogger" level="OFF" />
+        <Logger name="NoOpLogger" level="OFF" additivity="false"/>
     </Loggers>
 </Configuration>

--- a/server/embedded/src/main/resources/log4j2.xml
+++ b/server/embedded/src/main/resources/log4j2.xml
@@ -178,14 +178,14 @@ account managers so that we can coordinate edits with other customized copies of
         </Logger>
 
         <!-- category for Mule messages -->
-        <Logger name="org.mule.MuleManager" additivity="false" level="info"/>
+        <Logger name="org.mule.MuleManager" level="info"/>
 
         <!--
             <Logger name="org.labkey.pipeline.mule.transformers" level="debug"/>
         -->
 
         <!-- category for jasper messages -->
-        <Logger name="org.apache.jasper" additivity="false" level="warn"/>
+        <Logger name="org.apache.jasper" level="warn"/>
 
         <Logger name="org.labkey" />
 
@@ -201,7 +201,7 @@ account managers so that we can coordinate edits with other customized copies of
             <AppenderRef ref="LABKEY"/>
         </Logger> -->
 
-        <Logger name="mondrian." additivity="false" level="info" />
+        <Logger name="mondrian." level="info" />
 
         <!--
             <Logger name="org.labkey.wiki" level="debug"/>
@@ -215,10 +215,10 @@ account managers so that we can coordinate edits with other customized copies of
         <Logger name="org.labkey.api.pipeline.PipelineJob" additivity="false" level="error"/>
 
         <!-- don't need to log PDFBox errors (e.g., FlateFilter, PDCIDFontType2) -->
-        <Logger name="org.apache.pdfbox" additivity="false" level="fatal"/>
+        <Logger name="org.apache.pdfbox" level="fatal"/>
 
         <!-- Suppress EHCache "maxElementsInMemory of 0" warnings, Issue 49593 -->
-        <Logger name="net.sf.ehcache.config.CacheConfiguration" additivity="false" level="error"/>
+        <Logger name="net.sf.ehcache.config.CacheConfiguration" level="error"/>
 
         <!-- this is a very verbose logger for security/permissions checking -->
         <!--


### PR DESCRIPTION
#### Rationale
the <Root level="info"> block at the start of the Loggers could cause the subsequent calls to create double logs. Setting additivity="false" will prevent that.

https://logging.apache.org/log4j/2.x/manual/configuration.html#Additivity

#### Related Pull Requests
* https://github.com/LabKey/Dockerfile/pull/97
* https://github.com/LabKey/syseng-chef-server/pull/537

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
