### PR TITLE
Gradle 8.9 and gradle plugins 3.0.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -62,7 +62,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.31.9
 gradleNodePluginVersion=3.5.1
-gradlePluginsVersion=2.7.2
+gradlePluginsVersion=3.0.0-configCache-SNAPSHOT
 owaspDependencyCheckPluginVersion=10.0.1
 versioningPluginVersion=1.1.2
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -62,7 +62,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=4.31.9
 gradleNodePluginVersion=3.5.1
-gradlePluginsVersion=3.0.0-configCache-SNAPSHOT
+gradlePluginsVersion=3.0.0
 owaspDependencyCheckPluginVersion=10.0.1
 versioningPluginVersion=1.1.2
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew
+++ b/gradlew
@@ -55,7 +55,7 @@
 #       Darwin, MinGW, and NonStop.
 #
 #   (3) This script is generated from the Groovy template
-#       https://github.com/gradle/gradle/blob/HEAD/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+#       https://github.com/gradle/gradle/blob/HEAD/platforms/jvm/plugins-application/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
 #       within the Gradle project.
 #
 #       You can find Gradle at https://github.com/gradle/gradle/.


### PR DESCRIPTION
#### Rationale
- Gradle plugins version 3.0 gets us more current with our build technology, removing support for some unneeded features
- Gradle 8.9 is the latest and greatest

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/212

#### Changes
* Update gradle version
* Update gradlePluginsVersion
