### PR TITLE
Update to latest OWASP Dependency-Check

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -63,7 +63,7 @@ windowsProteomicsBinariesVersion=1.0
 artifactoryPluginVersion=4.31.9
 gradleNodePluginVersion=3.5.1
 gradlePluginsVersion=2.7.2
-owaspDependencyCheckPluginVersion=9.2.0
+owaspDependencyCheckPluginVersion=10.0.2
 versioningPluginVersion=1.1.2
 
 # Versions of node and npm to use during the build. If set, these versions


### PR DESCRIPTION
#### Rationale
Latest version is labeled "Mandatory Update" and seems to fix an API key problem we started seeing on this release branch
