### PR TITLE
Update NodeJS/NPM

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -69,8 +69,8 @@ versioningPluginVersion=1.1.2
 # Versions of node and npm to use during the build. If set, these versions
 # will be downloaded and used. If not set, the existing local installations will be used
 # The version of npm corresponds to the given version of node
-npmVersion=9.8.1
-nodeVersion=18.18.1
+npmVersion=10.7.0
+nodeVersion=20.15.1
 nodeRepo=https://nodejs.org/dist
 # Directory in a project's build directory where the node binary will be placed
 nodeWorkDirectory=.node


### PR DESCRIPTION
#### Rationale
This updates NodeJS to the current release. Our version of NodeJS `v18+`will enter maintenance mode for support in October 2024. The following versions have been determined based on their pairing in [previous releases](https://nodejs.org/en/download/releases).

- NodeJS: `20.15.1`
- NPM: `10.7.0`

#### Previous Update
- https://github.com/LabKey/server/pull/590

#### Related Pull Requests
- https://github.com/LabKey/server/pull/854
- https://github.com/LabKey/labkey-api-js/pull/179
- https://github.com/LabKey/labkey-ui-components/pull/1536
- https://github.com/LabKey/labkey-ui-premium/pull/475
- https://github.com/LabKey/platform/pull/5705
- https://github.com/LabKey/limsModules/pull/493
- https://github.com/LabKey/ontology/pull/141
- https://github.com/LabKey/commonAssays/pull/781
- https://github.com/LabKey/moduleEditor/pull/111
- https://github.com/LabKey/provenance/pull/181
- https://github.com/LabKey/DiscvrLabKeyModules/pull/301

#### Changes
- Bump NodeJS to `v20.15.1`
- Bump NPM to `v10.7.0`
