### PR TITLE
Update labkey-client-api version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -48,7 +48,7 @@ buildFromSource=true
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
 labkeyVersion=24.9-SNAPSHOT
-labkeyClientApiVersion=6.1.0
+labkeyClientApiVersion=6.2.0
 
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.


### PR DESCRIPTION
#### Rationale
Java remote API v6.2.0 has been published

#### Related Tag
* https://github.com/LabKey/labkey-api-java/releases/tag/v6.2.0