### PR TITLE
Supress bzip errors

### DIFF
--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -223,5 +223,19 @@
         <vulnerabilityName>CVE-2024-23076</vulnerabilityName>
     </suppress>
 
+    <!--
+    suppress CVEs bzip2-0.9.1.jar which enters through DiscvrLabKeyModules/SequenceAnalysis
+    -->
+    <suppress>
+        <notes><![CDATA[
+   file name: bzip2-0.9.1.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.itadaki/bzip2@.*$</packageUrl>
+        <cve>CVE-2019-12900</cve>
+        <cve>CVE-2011-4089</cve>
+        <cve>CVE-2010-0405</cve>
+        <cve>CVE-2005-1260</cve>
+    </suppress>
+
 </suppressions>
 

--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -224,7 +224,7 @@
     </suppress>
 
     <!--
-    suppress CVEs bzip2-0.9.1.jar which enters through DiscvrLabKeyModules/SequenceAnalysis
+    suppress CVEs bzip2-0.9.1.jar which enters through DiscvrLabKeyModules/SequenceAnalysis and is matching CVEs from the bzip2 command-line utility
     -->
     <suppress>
         <notes><![CDATA[


### PR DESCRIPTION
#### Rationale
[Supress warnings from external modules](https://teamcity-artifacts.labkey.org/presignedTokenAuth/6f100ed7-734c-4485-968f-31ec0ae54c51/repository/download/LabKey_247Release_Internal_InternalSuites_OwaspDependencyCheck/3154259:id/dependencyCheck.tar.gz!/server/dependency-check-report.html?__nodeId=secondary)

#### Changes
* Added suppression for Bzip lib errors
