### PR TITLE
Ensure that response.sendError(statusCode, message) sends the message…

### DIFF
--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -15,6 +15,9 @@ server.port=@@serverPort@@
 #server.ssl.key-store-type=PKCS12
 #server.ssl.ciphers=HIGH:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!kRSA:!EDH:!DHE:!DH:!CAMELLIA:!ARIA:!AESCCM:!SHA:!CHACHA20
 
+server.error.include-stacktrace=always
+server.error.include-message=always
+
 ## HTTP-only port for servers that need to handle both HTTPS (configure via server.port and server.ssl above) and HTTP
 #context.httpPort=8080
 

--- a/server/configs/webapps/embedded/config/application.properties
+++ b/server/configs/webapps/embedded/config/application.properties
@@ -51,6 +51,9 @@ server.port=80
 #server.ssl.key-store-type=PKCS12
 #server.ssl.ciphers=HIGH:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!kRSA:!EDH:!DHE:!DH:!CAMELLIA:!ARIA:!AESCCM:!SHA:!CHACHA20
 
+server.error.include-stacktrace=always
+server.error.include-message=always
+
 ## HTTP-only port for servers that need to handle both HTTPS (configure via server.port and server.ssl above) and HTTP
 ##   This must not be the same as the server.port set above.
 #context.httpPort=80


### PR DESCRIPTION
… in the response

#### Rationale
`HttpServletResponse.sendError(statusCode, message)` has been failing to send the message by default on embedded Tomcat distributions. https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51110

Note: This should fix the tests on TeamCity, but our cloud instances will need their `application.properties` updated as well.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/5804
