### PR TITLE
Issue 51098: Correctly spell "referer" incorrectly

### DIFF
--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -176,4 +176,4 @@ csp.report=\
 
 ## File-based Tomcat HTTP access logs are enabled by default and use our recommended pattern. Override as needed.
 #server.tomcat.accesslog.enabled=false
-#server.tomcat.accesslog.pattern=%h %l %u %t "%r" %s %b %D %S %I "%{Referrer}i" "%{User-Agent}i" %{LABKEY.username}s %{X-Forwarded-For}i
+#server.tomcat.accesslog.pattern=%h %l %u %t "%r" %s %b %D %S %I "%{Referer}i" "%{User-Agent}i" %{LABKEY.username}s %{X-Forwarded-For}i

--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -75,7 +75,7 @@ public class LabKeyServer
                 "server.compression.enabled", "true",
 
                 "server.tomcat.accesslog.enabled", "true",
-                "server.tomcat.accesslog.pattern", "%h %l %u %t \"%r\" %s %b %D %S %I \"%{Referrer}i\" \"%{User-Agent}i\" %{LABKEY.username}s %{X-Forwarded-For}i",
+                "server.tomcat.accesslog.pattern", "%h %l %u %t \"%r\" %s %b %D %S %I \"%{Referer}i\" \"%{User-Agent}i\" %{LABKEY.username}s %{X-Forwarded-For}i",
                 "jsonaccesslog.pattern", "%h %t %m %U %s %b %D %S \"%{Referer}i\" \"%{User-Agent}i\" %{LABKEY.username}s %{X-Forwarded-For}i"
         ));
         application.setBannerMode(Banner.Mode.OFF);


### PR DESCRIPTION
#### Rationale
Per the wisdom of RFC 1945, referrer is actually spelled `Referer`. We're inconsistently spelling it incorrectly, for whichever definition of "incorrect" you prefer.

#### Changes
* Use `Referer` consistently