### PR TITLE
Issue 51098: Update HTTP access logging to capture true client IP (backport)

### DIFF
--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -121,7 +121,7 @@ management.server.port=@@shutdownPort@@
 
 ## Optional configuration, modeled on the non-JSON Spring Boot properties
 ## https://docs.spring.io/spring-boot/docs/current/reference/html/application-properties.html#application-properties.server.server.tomcat.accesslog.buffered
-#jsonaccesslog.pattern=%h %t %m %U %s %b %D %S "%{Referer}i" "%{User-Agent}i" %{LABKEY.username}s
+#jsonaccesslog.pattern=%h %t %m %U %s %b %D %S "%{Referer}i" "%{User-Agent}i" %{LABKEY.username}s %{X-Forwarded-For}i
 #jsonaccesslog.condition-if=attributeName
 #jsonaccesslog.condition-unless=attributeName
 
@@ -174,6 +174,6 @@ csp.report=\
 ## Use a custom logging configuration
 #logging.config=path/to/alternative/log4j2.xml
 
-## Enable tomcat access log
-server.tomcat.accesslog.enabled=true
-server.tomcat.accesslog.pattern=%h %l %u %t "%r" %s %b %D %S %I "%{Referrer}i" "%{User-Agent}i" %{LABKEY.username}s
+## File-based Tomcat HTTP access logs are enabled by default and use our recommended pattern. Override as needed.
+#server.tomcat.accesslog.enabled=false
+#server.tomcat.accesslog.pattern=%h %l %u %t "%r" %s %b %D %S %I "%{Referrer}i" "%{User-Agent}i" %{LABKEY.username}s %{X-Forwarded-For}i

--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -176,4 +176,4 @@ csp.report=\
 
 ## File-based Tomcat HTTP access logs are enabled by default and use our recommended pattern. Override as needed.
 #server.tomcat.accesslog.enabled=false
-#server.tomcat.accesslog.pattern=%h %l %u %t "%r" %s %b %D %S %I "%{Referrer}i" "%{User-Agent}i" %{LABKEY.username}s %{X-Forwarded-For}i
+#server.tomcat.accesslog.pattern=%h %l %u %t "%r" %s %b %D %S %I "%{Referer}i" "%{User-Agent}i" %{LABKEY.username}s %{X-Forwarded-For}i

--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -72,8 +72,12 @@ public class LabKeyServer
                 "server.tomcat.accesslog.directory", logHome,
 
                 // Enable HTTP compression for response content
-                "server.compression.enabled", "true"
-                ));
+                "server.compression.enabled", "true",
+
+                "server.tomcat.accesslog.enabled", "true",
+                "server.tomcat.accesslog.pattern", "%h %l %u %t \"%r\" %s %b %D %S %I \"%{Referrer}i\" \"%{User-Agent}i\" %{LABKEY.username}s %{X-Forwarded-For}i",
+                "jsonaccesslog.pattern", "%h %t %m %U %s %b %D %S \"%{Referer}i\" \"%{User-Agent}i\" %{LABKEY.username}s %{X-Forwarded-For}i"
+        ));
         application.setBannerMode(Banner.Mode.OFF);
         application.run(args);
     }

--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -75,7 +75,7 @@ public class LabKeyServer
                 "server.compression.enabled", "true",
 
                 "server.tomcat.accesslog.enabled", "true",
-                "server.tomcat.accesslog.pattern", "%h %l %u %t \"%r\" %s %b %D %S %I \"%{Referrer}i\" \"%{User-Agent}i\" %{LABKEY.username}s %{X-Forwarded-For}i",
+                "server.tomcat.accesslog.pattern", "%h %l %u %t \"%r\" %s %b %D %S %I \"%{Referer}i\" \"%{User-Agent}i\" %{LABKEY.username}s %{X-Forwarded-For}i",
                 "jsonaccesslog.pattern", "%h %t %m %U %s %b %D %S \"%{Referer}i\" \"%{User-Agent}i\" %{LABKEY.username}s %{X-Forwarded-For}i"
         ));
         application.setBannerMode(Banner.Mode.OFF);


### PR DESCRIPTION
#### Rationale
Many instances run behind a load balancer or similar network infrastructure. We want to log both the IP of the host making the request to the server, and original client's IP.

#### Changes
* Enable file-based HTTP access logging by default
* Log the `X-Forwarded-For` request header in both JSON and plain text variants
* Adopt the standard, misspelled header `Referer` consistently