### PR TITLE
CVE-2024-38816 Upgrade spring

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -100,7 +100,7 @@ apacheDirectoryVersion=2.1.3
 apacheMinaVersion=2.2.1
 
 # Keep in sync with springBootTomcatVersion below
-apacheTomcatVersion=10.1.28
+apacheTomcatVersion=10.1.30
 
 # (mothership) -> json-path -> json-smart -> accessor-smart
 # (core) -> graalvm
@@ -283,10 +283,10 @@ slf4jLog4jApiVersion=2.0.13
 # This is a dependency for HTSJDK. Force version for CVE-2023-43642
 snappyJavaVersion=1.1.10.5
 
-springBootVersion=3.3.3
+springBootVersion=3.3.4
 # This usually matches the Tomcat version dictated by springBootVersion
 # Also, keep this in sync with apacheTomcatVersion above
-springBootTomcatVersion=10.1.28
+springBootTomcatVersion=10.1.30
 # This usually matches the Spring Framework version dictated by springBootVersion
 springVersion=6.1.13
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -100,7 +100,7 @@ apacheDirectoryVersion=2.1.3
 apacheMinaVersion=2.2.1
 
 # Keep in sync with springBootTomcatVersion below
-apacheTomcatVersion=10.1.26
+apacheTomcatVersion=10.1.28
 
 # (mothership) -> json-path -> json-smart -> accessor-smart
 # (core) -> graalvm
@@ -283,10 +283,10 @@ slf4jLog4jApiVersion=2.0.13
 # This is a dependency for HTSJDK. Force version for CVE-2023-43642
 snappyJavaVersion=1.1.10.5
 
-springBootVersion=3.3.2
+springBootVersion=3.3.3
 # This usually matches the Tomcat version dictated by springBootVersion
 # Also, keep this in sync with apacheTomcatVersion above
-springBootTomcatVersion=10.1.26
+springBootTomcatVersion=10.1.28
 # This usually matches the Spring Framework version dictated by springBootVersion
 springVersion=6.1.13
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -288,7 +288,7 @@ springBootVersion=3.3.2
 # Also, keep this in sync with apacheTomcatVersion above
 springBootTomcatVersion=10.1.26
 # This usually matches the Spring Framework version dictated by springBootVersion
-springVersion=6.1.12
+springVersion=6.1.13
 
 sqliteJdbcVersion=3.46.0.0
 


### PR DESCRIPTION
#### Rationale
We don't look to be affected by this CVE, but this will clear the OWASP tests of this particular CVE and upgrade spring and tomcat to the latest versions.

#### Changes
* Upgrade spring and tomcat versions
