### PR TITLE
CVE 2024-7254 Protobuf

### DIFF
--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -33,6 +33,15 @@
         <vulnerabilityName>CVE-2021-22569</vulnerabilityName>
     </suppress>
 
+    <suppress>
+        <notes><![CDATA[
+   file name: gwt-servlet-jakarta-2.11.0.jar (shaded: com.google.protobuf:protobuf-java:2.5.0)
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.google\.protobuf/protobuf\-java@.*$</packageUrl>
+        <cpe>cpe:/a:google:protobuf-java</cpe>
+        <vulnerabilityName>CVE-2024-7254</vulnerabilityName>
+    </suppress>
+
     <!-- Tangled CVEs. See https://github.com/jeremylong/DependencyCheck/issues/4614 and https://github.com/OSSIndex/vulns/issues/316 -->
     <suppress>
         <notes><![CDATA[

--- a/gradle.properties
+++ b/gradle.properties
@@ -159,7 +159,7 @@ googleAutoValueAnnotationsVersion=1.10.4
 googleErrorProneAnnotationsVersion=2.28.0
 googleHttpClientVersion=1.44.2
 googleOauthClientVersion=1.36.0
-googleProtocolBufVersion=3.25.3
+googleProtocolBufVersion=3.25.5
 
 graalVersion=24.0.1
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -103,7 +103,7 @@ apacheDirectoryVersion=2.1.3
 apacheMinaVersion=2.2.1
 
 # Keep in sync with springBootTomcatVersion below
-apacheTomcatVersion=10.1.25
+apacheTomcatVersion=10.1.30
 
 # (mothership) -> json-path -> json-smart -> accessor-smart
 # (core) -> graalvm
@@ -286,12 +286,12 @@ slf4jLog4jApiVersion=2.0.12
 # This is a dependency for HTSJDK. Force version for CVE-2023-43642
 snappyJavaVersion=1.1.10.5
 
-springBootVersion=3.3.0
+springBootVersion=3.3.4
 # This usually matches the Tomcat version dictated by springBootVersion
 # Also, keep this in sync with apacheTomcatVersion above
-springBootTomcatVersion=10.1.25
+springBootTomcatVersion=10.1.30
 # This usually matches the Spring Framework version dictated by springBootVersion
-springVersion=6.1.12
+springVersion=6.1.13
 
 sqliteJdbcVersion=3.46.0.0
 


### PR DESCRIPTION
#### Rationale
Update protobuf-java version where possible. Suppress related gwt cve as it does not expose protobuf. Backport spring version bumps to completely clear OWASP test failures.

#### Changes
* Bump protobuf and spring/tomcat versions
* Suppress GWT cve
