### PR TITLE
24.7 CVE fixes for lucene, glassfish, batik/fop

### DIFF
--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -257,5 +257,76 @@
         <cve>CVE-2024-45772</cve>
     </suppress>
 
+    <!--
+    suppress glassfish false positives, being corrected in:
+    https://github.com/jeremylong/DependencyCheck/issues/7015
+    https://github.com/jeremylong/DependencyCheck/pull/7016
+    https://github.com/jeremylong/DependencyCheck/pull/7024
+    -->
+    <suppress>
+        <notes><![CDATA[
+   file name: jaxb-core-4.0.3.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.glassfish\.jaxb/jaxb-core@.*$</packageUrl>
+        <cve>CVE-2024-9329</cve>
+    </suppress>
+
+    <suppress>
+        <notes><![CDATA[
+   file name: jaxb-core-4.0.5.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.glassfish\.jaxb/jaxb-core@.*$</packageUrl>
+        <cve>CVE-2024-9329</cve>
+    </suppress>
+
+    <suppress>
+        <notes><![CDATA[
+   file name: jaxb-core-4.0.5.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.glassfish\.jaxb/jaxb-core@.*$</packageUrl>
+        <cve>CVE-2024-9329</cve>
+    </suppress>
+
+    <suppress>
+        <notes><![CDATA[
+   file name: jaxb-runtime-4.0.3.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.glassfish\.jaxb/jaxb-runtime@.*$</packageUrl>
+        <cve>CVE-2024-9329</cve>
+    </suppress>
+
+    <suppress>
+        <notes><![CDATA[
+   file name: jaxb-runtime-4.0.5.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.glassfish\.jaxb/jaxb-runtime@.*$</packageUrl>
+        <cve>CVE-2024-9329</cve>
+    </suppress>
+
+    <suppress>
+        <notes><![CDATA[
+   file name: osgi-resource-locator-1.0.3.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.glassfish\.hk2/osgi-resource-locator@.*$</packageUrl>
+        <cve>CVE-2024-9329</cve>
+    </suppress>
+
+    <suppress>
+        <notes><![CDATA[
+   file name: txw2-4.0.3.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.glassfish\.jaxb/txw2@.*$</packageUrl>
+        <cve>CVE-2024-9329</cve>
+    </suppress>
+
+    <suppress>
+        <notes><![CDATA[
+   file name: txw2-4.0.5.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.glassfish\.jaxb/txw2@.*$</packageUrl>
+        <cve>CVE-2024-9329</cve>
+    </suppress>
+    <!-- end of glassfish false positive suppressions -->
+
 </suppressions>
 

--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -257,6 +257,47 @@
         <cve>CVE-2024-45772</cve>
     </suppress>
 
+    <suppress>
+        <notes><![CDATA[
+   file name: lucene-backward-codecs-9.10.0.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.lucene/lucene-backward-codecs@.*$</packageUrl>
+        <cve>CVE-2024-45772</cve>
+    </suppress>
+
+    <suppress>
+        <notes><![CDATA[
+   file name: lucene-core-9.10.0.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.lucene/lucene-core@.*$</packageUrl>
+        <cve>CVE-2024-45772</cve>
+    </suppress>
+
+    <suppress>
+        <notes><![CDATA[
+   file name: lucene-queries-9.10.0.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.lucene/lucene-queries@.*$</packageUrl>
+        <cve>CVE-2024-45772</cve>
+    </suppress>
+
+    <suppress>
+        <notes><![CDATA[
+   file name: lucene-queryparser-9.10.0.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.lucene/lucene-queryparser@.*$</packageUrl>
+        <cve>CVE-2024-45772</cve>
+    </suppress>
+
+    <suppress>
+        <notes><![CDATA[
+   file name: lucene-sandbox-9.10.0.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.lucene/lucene-sandbox@.*$</packageUrl>
+        <cve>CVE-2024-45772</cve>
+    </suppress>
+    <!-- end of lucene suppressions -->
+
     <!--
     suppress glassfish false positives, being corrected in:
     https://github.com/jeremylong/DependencyCheck/issues/7015

--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -246,5 +246,16 @@
         <cve>CVE-2005-1260</cve>
     </suppress>
 
+    <!--
+    suppress CVE-2024-45772 for lucene 9.10, fixed in develop with bump to 9.12
+    -->
+    <suppress>
+        <notes><![CDATA[
+   file name: lucene-analysis-common-9.10.0.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.lucene/lucene-analysis-common@.*$</packageUrl>
+        <cve>CVE-2024-45772</cve>
+    </suppress>
+
 </suppressions>
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -111,7 +111,7 @@ apacheTomcatVersion=10.1.30
 asmVersion=9.7
 
 # Apache Batik -- Batik version needs to be compatible with Apache FOP, but we need to pull in batik-codec separately
-batikVersion=1.17
+batikVersion=1.18
 
 # sync with Tika version (or later)
 bouncycastlePgpVersion=1.78
@@ -152,7 +152,7 @@ eigenbaseXomVersion=1.3.7
 flyingsaucerVersion=R8
 
 # Apache FOP -- linked to Apache Batik version above
-fopVersion=2.9
+fopVersion=2.10
 
 # Force latest for consistency
 googleAutoValueAnnotationsVersion=1.10.4


### PR DESCRIPTION
#### Rationale
* suppress lucene alerts for CVE-2024-45772: not applicable (we don't distribute the Lucene Replicator JAR). Addressed in develop w/ a bump to 9.12.
* bump apache batik and fop for CVE-2024-28168
* suppress glassfish false positives

#### Related Pull Requests
* glassfish: 
  * https://github.com/jeremylong/DependencyCheck/issues/7015
  * https://github.com/jeremylong/DependencyCheck/pull/7016
  * https://github.com/jeremylong/DependencyCheck/pull/7024 
  
#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
