### PR TITLE
Adopt gradle plugins v4.2.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -57,10 +57,10 @@ osxProteomicsBinariesVersion=1.0
 windowsProteomicsBinariesVersion=1.0
 
 # The current version numbers for the gradle plugins.
-artifactoryPluginVersion=4.31.9
+artifactoryPluginVersion=5.2.5
 gradleNodePluginVersion=3.5.1
-gradlePluginsVersion=4.1.0
-owaspDependencyCheckPluginVersion=10.0.3
+gradlePluginsVersion=4.2.0
+owaspDependencyCheckPluginVersion=10.0.4
 versioningPluginVersion=1.1.2
 
 # Versions of node and npm to use during the build. If set, these versions


### PR DESCRIPTION
#### Rationale
It's the latest version. Among other benefits, it allows us to bump the OWASP plugin to its latest version (v10.0.4).

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/220
