### PR TITLE
Simplify EmbeddedExtractor

### DIFF
--- a/server/embedded/src/org/labkey/embedded/EmbeddedExtractor.java
+++ b/server/embedded/src/org/labkey/embedded/EmbeddedExtractor.java
@@ -4,18 +4,15 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.labkey.bootstrap.ConfigException;
-import org.springframework.util.StreamUtils;
 
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.jar.JarFile;
@@ -78,45 +75,24 @@ public class EmbeddedExtractor
 
     private boolean shouldExtract(File webAppLocation)
     {
-        File existingVersionFile = new File(webAppLocation, "WEB-INF/classes/VERSION");
         File existingDistributionFile = new File(webAppLocation, "WEB-INF/classes/distribution.properties");
 
         LabKeyDistributionInfo incomingDistribution = getDistributionInfo();
 
         // Fresh installation or upgrading from a pre-distribution.properties distribution
-        if (!existingVersionFile.exists() || !existingDistributionFile.exists())
+        if (!existingDistributionFile.exists())
         {
             LOG.info("Extracting new LabKey distribution - %s".formatted(incomingDistribution));
             return true;
         }
 
-        String existingVersion;
-        String existingBuildUrl;
-        String existingDistributionName;
+        LabKeyDistributionInfo existingDistribution;
+
         try
         {
             try (InputStream is = Files.newInputStream(existingDistributionFile.toPath()))
             {
-                LabKeyDistributionInfo info = getFromProperties(is);
-                existingVersion = info.version;
-                existingBuildUrl = info.buildUrl;
-                existingDistributionName = info.distributionName;
-            }
-
-            // TODO: Stop reading VERSION file
-            if (existingVersion.isEmpty())
-            {
-                String versionFileContents = Files.readString(existingVersionFile.toPath()).trim();
-                String[] splitVersion = versionFileContents.trim().split("\\n");
-                existingVersion = splitVersion[0];
-                if (splitVersion.length > 1)
-                {
-                    existingBuildUrl = splitVersion[1];
-                }
-                else
-                {
-                    existingBuildUrl = null;
-                }
+                existingDistribution = getFromProperties(is);
             }
         }
         catch (IOException e)
@@ -124,14 +100,12 @@ public class EmbeddedExtractor
             throw new RuntimeException(e);
         }
 
-        LabKeyDistributionInfo existingDistribution = new LabKeyDistributionInfo(existingVersion, existingBuildUrl, existingDistributionName);
-
         if (!existingDistribution.equals(incomingDistribution))
         {
             LOG.info("Updating LabKey (%s -> %s)".formatted(existingDistribution, incomingDistribution));
             return true;
         }
-        else if (incomingDistribution.buildUrl == null)
+        else if (incomingDistribution.buildUrl() == null)
         {
             LOG.info("Extracting custom-build LabKey distribution (%s)".formatted(existingDistribution));
             return true;
@@ -149,9 +123,7 @@ public class EmbeddedExtractor
      */
     private LabKeyDistributionInfo getDistributionInfo()
     {
-        String version = "";
-        String buildUrl = null;
-        String distributionName = "";
+        LabKeyDistributionInfo info = null;
 
         try
         {
@@ -173,47 +145,15 @@ public class EmbeddedExtractor
                             while (zipEntry != null)
                             {
                                 distributionDirs.add(zipEntry.getName().split("/", 2)[0]);
-                                // TODO: Remove this branch once newest gradle plugins version is adopted
-                                if (!zipEntry.isDirectory() && zipEntry.getName().equals(LABKEYWEBAPP + "/WEB-INF/classes/VERSION"))
+                                if (!zipEntry.isDirectory() && zipEntry.getName().equals(LABKEYWEBAPP + "/WEB-INF/classes/distribution.properties"))
                                 {
-                                    // Don't overwrite values from distribution.properties
-                                    if (version.isEmpty())
-                                    {
-                                        String versionFileContents = StreamUtils.copyToString(zipIn, StandardCharsets.UTF_8).trim();
-
-                                        String[] splitVersion = versionFileContents.trim().split("\\n");
-                                        version = splitVersion[0];
-                                        if (splitVersion.length > 1)
-                                        {
-                                            buildUrl = splitVersion[1];
-                                        }
-                                        else
-                                        {
-                                            buildUrl = null;
-                                        }
-                                    }
-                                }
-                                else if (!zipEntry.isDirectory() && zipEntry.getName().equals(LABKEYWEBAPP + "/WEB-INF/classes/distribution.properties"))
-                                {
-                                    LabKeyDistributionInfo info = getFromProperties(zipIn);
-                                    distributionName = info.distributionName;
-                                    if (!info.version.isEmpty())
-                                        version = info.version;
-                                    if (info.buildUrl != null)
-                                        buildUrl = info.buildUrl;
+                                    info = getFromProperties(zipIn);
                                 }
                                 zipIn.closeEntry();
                                 zipEntry = zipIn.getNextEntry();
                             }
                         }
-                        if (version.isEmpty())
-                        {
-                            throw new ConfigException("Unable to determine version of distribution.");
-                        }
-                        if (distributionName.isEmpty())
-                        {
-                            throw new ConfigException("Unable to determine name of distribution.");
-                        }
+
                         if (!distributionDirs.equals(EXPECTED_DIST_DIRS))
                         {
                             StringBuilder msg = new StringBuilder("Corrupted distribution; contents are not as expected.");
@@ -236,7 +176,11 @@ public class EmbeddedExtractor
 
                             throw new IllegalStateException(msg.toString());
                         }
-                        return new LabKeyDistributionInfo(version, buildUrl, distributionName);
+
+                        if (null == info)
+                            throw new IllegalStateException("distribution.properties file was not found!");
+
+                        return info;
                     }
                 }
 
@@ -258,7 +202,10 @@ public class EmbeddedExtractor
         String version = props.getProperty("version", "").trim();
         String buildUrl = props.containsKey("buildUrl") ? props.getProperty("buildUrl").trim() : null;
 
-        return new LabKeyDistributionInfo(version, buildUrl, distributionName);
+        var info = new LabKeyDistributionInfo(version, buildUrl, distributionName);
+        LOG.info("LabKeyDistributionInfo: " + info);
+
+        return info;
     }
 
     public void extractDistribution(File webAppLocation)
@@ -416,50 +363,18 @@ public class EmbeddedExtractor
     }
 }
 
-class LabKeyDistributionInfo
+/**
+ * Build properties from 'distribution.properties' file
+ *
+ * @param version          the LabKey version (e.g. 24.3-SNAPSHOT)
+ * @param buildUrl         optional TeamCity BUILD_URL, if distribution was produced by TeamCity
+ * @param distributionName value of the 'name' property
+ */
+record LabKeyDistributionInfo(String version, String buildUrl, String distributionName)
 {
-    final String version;
-    final String buildUrl;
-    final String distributionName;
-
-    /**
-     * Build properties from 'distribution.properties' file
-     * @param version the LabKey version (e.g. 24.3-SNAPSHOT)
-     * @param buildUrl TeamCity BUILD_URL, if distribution was produced by TeamCity
-     * @param distributionName value of the 'name' property
-     */
-    public LabKeyDistributionInfo(String version, String buildUrl, String distributionName)
-    {
-        this.version = version;
-        this.buildUrl = buildUrl;
-        this.distributionName = distributionName;
-    }
-
-    @Override
-    public boolean equals(Object o)
-    {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        LabKeyDistributionInfo that = (LabKeyDistributionInfo) o;
-
-        if (!version.equals(that.version)) return false;
-        if (!Objects.equals(buildUrl, that.buildUrl)) return false;
-        return distributionName.equals(that.distributionName);
-    }
-
-    @Override
-    public int hashCode()
-    {
-        int result = version.hashCode();
-        result = 31 * result + (buildUrl != null ? buildUrl.hashCode() : 0);
-        result = 31 * result + distributionName.hashCode();
-        return result;
-    }
-
     @Override
     public String toString()
     {
-        return distributionName + ":" + version;
+        return distributionName + ":" + version + (buildUrl != null ? ":" + buildUrl : "");
     }
 }


### PR DESCRIPTION
#### Rationale
Stop reading properties from `VERSION` file. Latest gradle plugin now writes all properties to `distribution.properties` file, so read them from there exclusively.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/220