### PR TITLE
force hadoop-hdfs-client to 3.4.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -335,6 +335,9 @@ allprojects {
                     // Force patched version of okhttp for CVE-2021-0341 and CVE-2023-0833
                     force "com.squareup.okhttp:okhttp:${okhttpVersion}"
 
+                    // Force latest VFS2
+                    force "org.apache.commons:commons-vfs2:${commonsVfs2Version}"
+
                     dependencySubstitution {
                         // Because the client api artifact name is not the same as the directory structure, we use
                         // Gradle's dependency substitution so the dependency will appear correctly in the pom files that

--- a/build.gradle
+++ b/build.gradle
@@ -332,11 +332,7 @@ allprojects {
                     // Force consistency for dependencies from cloud
                     force "joda-time:joda-time:${jodaTimeVersion}"
 
-                    // Force patched version of okhttp for CVE-2021-0341 and CVE-2023-0833
-                    force "com.squareup.okhttp:okhttp:${okhttpVersion}"
-
                     // Force latest VFS2
-                    // may be moot after forcing hadoop-hdfs-client to 3.4.1
                     force "org.apache.commons:commons-vfs2:${commonsVfs2Version}"
 
                     // Force latest hadoop-hdfs-client for CVE-2021-37404, CVE-2022-25168, CVE-2022-26612, CVE-2021-25642, CVE-2021-33036, CVE-2023-26031
@@ -379,9 +375,6 @@ allprojects {
                         substitute module('org.hamcrest:hamcrest-core') using module("org.hamcrest:hamcrest:${hamcrestVersion}")
                         substitute module('org.hamcrest:hamcrest-library') using module("org.hamcrest:hamcrest:${hamcrestVersion}")
 
-                        // Force patched version of okhttp in new location for CVE-2021-0341 and CVE-2023-0833
-                        // may be moot after forcing hadoop-hdfs-client to 3.4.1
-                        substitute module('com.squareup.okhttp:okhttp') using module("com.squareup.okhttp3:okhttp:${okhttpVersion}")
                     }
                 }
             }

--- a/build.gradle
+++ b/build.gradle
@@ -336,7 +336,11 @@ allprojects {
                     force "com.squareup.okhttp:okhttp:${okhttpVersion}"
 
                     // Force latest VFS2
+                    // may be moot after forcing hadoop-hdfs-client to 3.4.1
                     force "org.apache.commons:commons-vfs2:${commonsVfs2Version}"
+
+                    // Force latest hadoop-hdfs-client for CVE-2021-37404, CVE-2022-25168, CVE-2022-26612, CVE-2021-25642, CVE-2021-33036, CVE-2023-26031
+                    force "org.apache.hadoop:hadoop-hdfs-client:${hadoopHdfsClientVersion}"
 
                     dependencySubstitution {
                         // Because the client api artifact name is not the same as the directory structure, we use
@@ -376,6 +380,7 @@ allprojects {
                         substitute module('org.hamcrest:hamcrest-library') using module("org.hamcrest:hamcrest:${hamcrestVersion}")
 
                         // Force patched version of okhttp in new location for CVE-2021-0341 and CVE-2023-0833
+                        // may be moot after forcing hadoop-hdfs-client to 3.4.1
                         substitute module('com.squareup.okhttp:okhttp') using module("com.squareup.okhttp3:okhttp:${okhttpVersion}")
                     }
                 }

--- a/build.gradle
+++ b/build.gradle
@@ -332,9 +332,6 @@ allprojects {
                     // Force consistency for dependencies from cloud
                     force "joda-time:joda-time:${jodaTimeVersion}"
 
-                    // Force latest VFS2
-                    force "org.apache.commons:commons-vfs2:${commonsVfs2Version}"
-
                     // Force latest hadoop-hdfs-client for CVE-2021-37404, CVE-2022-25168, CVE-2022-26612, CVE-2021-25642, CVE-2021-33036, CVE-2023-26031
                     force "org.apache.hadoop:hadoop-hdfs-client:${hadoopHdfsClientVersion}"
 
@@ -374,7 +371,6 @@ allprojects {
 
                         substitute module('org.hamcrest:hamcrest-core') using module("org.hamcrest:hamcrest:${hamcrestVersion}")
                         substitute module('org.hamcrest:hamcrest-library') using module("org.hamcrest:hamcrest:${hamcrestVersion}")
-
                     }
                 }
             }

--- a/build.gradle
+++ b/build.gradle
@@ -332,6 +332,9 @@ allprojects {
                     // Force consistency for dependencies from cloud
                     force "joda-time:joda-time:${jodaTimeVersion}"
 
+                    // Force patched version of okhttp for CVE-2021-0341 and CVE-2023-0833
+                    force "com.squareup.okhttp:okhttp:${okhttpVersion}"
+
                     dependencySubstitution {
                         // Because the client api artifact name is not the same as the directory structure, we use
                         // Gradle's dependency substitution so the dependency will appear correctly in the pom files that
@@ -368,6 +371,9 @@ allprojects {
 
                         substitute module('org.hamcrest:hamcrest-core') using module("org.hamcrest:hamcrest:${hamcrestVersion}")
                         substitute module('org.hamcrest:hamcrest-library') using module("org.hamcrest:hamcrest:${hamcrestVersion}")
+
+                        // Force patched version of okhttp in new location for CVE-2021-0341 and CVE-2023-0833
+                        substitute module('com.squareup.okhttp:okhttp') using module("com.squareup.okhttp3:okhttp:${okhttpVersion}")
                     }
                 }
             }

--- a/gradle.properties
+++ b/gradle.properties
@@ -250,10 +250,6 @@ nettyVersion=4.1.113.Final
 
 objenesisVersion=1.0
 
-# Force patched version of okhttp for CVE-2021-0341 and CVE-2023-0833
-# may be moot after forcing hadoop-hdfs-client to 3.4.1
-okhttpVersion=4.12.0
-
 # increase from 2.0 for remoteclientapi/java
 opencsvVersion=2.3
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -136,7 +136,7 @@ commonsMath3Version=3.6.1
 commonsPoolVersion=1.6
 commonsTextVersion=1.12.0
 commonsValidatorVersion=1.9.0
-commonsVfs2Version=2.9.0
+commonsVfs2Version=2.7.0
 
 datadogVersion=1.39.1
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -136,7 +136,7 @@ commonsMath3Version=3.6.1
 commonsPoolVersion=1.6
 commonsTextVersion=1.12.0
 commonsValidatorVersion=1.9.0
-commonsVfs2Version=2.7.0
+commonsVfs2Version=2.9.0
 
 datadogVersion=1.39.1
 
@@ -246,6 +246,9 @@ mysqlDriverVersion=9.0.0
 nettyVersion=4.1.113.Final
 
 objenesisVersion=1.0
+
+# Force patched version of okhttp for CVE-2021-0341 and CVE-2023-0833
+okhttpVersion=4.12.0
 
 # increase from 2.0 for remoteclientapi/java
 opencsvVersion=2.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -175,6 +175,9 @@ guavaVersion=33.3.1-jre
 gwtVersion=2.11.0
 gwtServletJakartaVersion=2.11.0
 
+# force hadoop-hdfs-client for CVE-2021-37404, CVE-2022-25168, CVE-2022-26612, CVE-2021-25642, CVE-2021-33036, CVE-2023-26031,
+hadoopHdfsClientVersion=3.4.1
+
 hamcrestVersion=2.2
 
 # Note: if changing this, we might need to match with the picard version in the SequenceAnalysis module build.gradle
@@ -248,6 +251,7 @@ nettyVersion=4.1.113.Final
 objenesisVersion=1.0
 
 # Force patched version of okhttp for CVE-2021-0341 and CVE-2023-0833
+# may be moot after forcing hadoop-hdfs-client to 3.4.1
 okhttpVersion=4.12.0
 
 # increase from 2.0 for remoteclientapi/java


### PR DESCRIPTION
#### Rationale
Forcing hadoop-hdfs-client to 3.4.1 solves various lower version CVEs, and removes okhttp as a dependency, which had other CVEs.

note: the branch name was 'fb_bump_VFS_and_force_okhttp_CVE-2021-0341_CVE-2023-0833' as that's where the fix for this group of CVEs started, but ultimately upgrading hadoop-hdfs-client solved the okhttp issue by removing it as a dependency.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
