### PR TITLE
Roll back httpclient5 and httpcore5 versions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -183,8 +183,8 @@ hamcrestVersion=2.2
 # Note: if changing this, we might need to match with the picard version in the SequenceAnalysis module build.gradle
 htsjdkVersion=4.0.0
 
-httpclient5Version=5.4
-httpcore5Version=5.3
+httpclient5Version=5.3.1
+httpcore5Version=5.2.5
 
 # Not used directly, but these are widely used transitive dependencies
 httpclientVersion=4.5.14


### PR DESCRIPTION
#### Rationale
httpclient5 v5.4 is not working with Shiny app. Rolling back for now. 

#### Related Pull Requests
* https://github.com/LabKey/server/pull/908

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
