### PR TITLE
Revert version updates

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -58,8 +58,8 @@ windowsProteomicsBinariesVersion=1.0
 
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=5.2.5
-gradleNodePluginVersion=7.1.0
-gradlePluginsVersion=5.0.0
+gradleNodePluginVersion=3.5.1
+gradlePluginsVersion=4.2.0
 owaspDependencyCheckPluginVersion=11.0.0
 versioningPluginVersion=1.1.2
 
@@ -322,4 +322,4 @@ xercesImplVersion=2.12.2
 xmlApisVersion=1.0.b2
 
 # sync with Tika/POI
-xmlbeansVersion=5.2.1
+xmlbeansVersion=5.2.0

--- a/server/embedded/build.gradle
+++ b/server/embedded/build.gradle
@@ -93,10 +93,10 @@ project.tasks.register(
     "checkVersionConflicts", CheckForVersionConflicts)
         { CheckForVersionConflicts task ->
             task.group = GroupNames.BUILD
-            task.description = "Check for conflicts in version numbers of jar file and files already in the build directory ${ServerDeployExtension.getEmbeddedServerDeployDirectoryPath(project)}. " +
+            task.description = "Check for conflicts in version numbers of jar file and files already in the build directory ${ServerDeployExtension.getEmbeddedServerDeployDirectory(project)}. " +
                     "Default action on detecting a conflict is to fail. Use -PversionConflictAction=[delete|fail|warn] to change this behavior. The value 'delete' will cause the " +
-                    "conflicting version(s) in the ${ServerDeployExtension.getEmbeddedServerDeployDirectoryPath(project)} directory to be removed."
-            task.directory = new File(ServerDeployExtension.getEmbeddedServerDeployDirectoryPath(project))
+                    "conflicting version(s) in the ${ServerDeployExtension.getEmbeddedServerDeployDirectory(project)} directory to be removed."
+            task.directory = new File(ServerDeployExtension.getEmbeddedServerDeployDirectory(project))
             task.extension = "jar"
             task.cleanTask = "server:cleanEmbeddedDeploy"
             task.collection = project.tasks.bootJar.outputs.files


### PR DESCRIPTION
#### Rationale
The version updates are causing issues. We'll revert and regroup.

#### Related Pull Requests
* https://github.com/LabKey/DiscvrLabKeyModules/pull/323

#### Changes
* Revert changes to gradleNodePluginVersion, gradlePluginsVersion, and xmlbeansVersion
