### PR TITLE
Update GSON and JClouds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -243,6 +243,10 @@ allprojects {
                     // cloud and SequenceAnalysis bring this in as a transitive dependency. We resolve to the later version here to keep things consistent
                     force "com.google.code.gson:gson:${gsonVersion}"
 
+                    // docker and cloud bring in different versions
+                    force "jakarta.ws.rs:jakarta.ws.rs-api:${jakartaWsRsApiVersion}"
+                    force "jakarta.annotation:jakarta.annotation-api:${jakartaWsAnnotationApiVersion}"
+
                     // Google oauth2-http Library and api-common (via Picard, and perhaps others) bring in different versions; force the latest
                     force "com.google.auto.value:auto-value-annotations:${googleAutoValueAnnotationsVersion}"
                     force "com.google.http-client:google-http-client-apache-v2:${googleHttpClientVersion}"
@@ -330,6 +334,7 @@ allprojects {
                     force "javax.xml.bind:jaxb-api:${jaxbApiOldVersion}"
 
                     // Force consistency for dependencies from cloud
+                    force "joda-time:joda-time:${jodaTimeVersion}"
                     force "joda-time:joda-time:${jodaTimeVersion}"
 
                     // Force latest hadoop-hdfs-client for CVE-2021-37404, CVE-2022-25168, CVE-2022-26612, CVE-2021-25642, CVE-2021-33036, CVE-2023-26031

--- a/build.gradle
+++ b/build.gradle
@@ -335,7 +335,6 @@ allprojects {
 
                     // Force consistency for dependencies from cloud
                     force "joda-time:joda-time:${jodaTimeVersion}"
-                    force "joda-time:joda-time:${jodaTimeVersion}"
 
                     // Force latest hadoop-hdfs-client for CVE-2021-37404, CVE-2022-25168, CVE-2022-26612, CVE-2021-25642, CVE-2021-33036, CVE-2023-26031
                     force "org.apache.hadoop:hadoop-hdfs-client:${hadoopHdfsClientVersion}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -162,10 +162,7 @@ googleProtocolBufVersion=3.25.5
 graalVersion=24.1.1
 
 # Cloud and SequenceAnalysis bring gson in as a transitive dependency.
-# We resolve to the later version here to keep things consistent
-# Note: Current jclouds seems to require 2.8.9; attempting to upgrade to 2.9.0 cratered the S3 test suite with many
-# "java.lang.NoSuchMethodError: 'void com.google.gson.internal.ConstructorConstructor.<init>(java.util.Map)'" errors
-gsonVersion=2.8.9
+gsonVersion=2.11.0
 
 grpcVersion=1.67.1
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -193,6 +193,9 @@ jacksonAnnotationsVersion=2.18.0
 jacksonDatabindVersion=2.18.0
 jacksonJaxrsBaseVersion=2.18.0
 
+jakartaWsRsApiVersion=3.0.0
+jakartaWsAnnotationApiVersion=2.0.0
+
 jamaVersion=1.0.3
 
 javassistVersion=3.20.0-GA


### PR DESCRIPTION
#### Rationale
We can move GSON forward now that we're using the newest JClouds release

#### Changes
* Update GSON version