### PR TITLE
Update netty-common to 4.1.115.Final

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -246,7 +246,7 @@ mssqlJdbcVersion=12.8.1.jre11
 mysqlDriverVersion=9.1.0
 
 # forced compatibility between docker and UserReg-WS
-nettyVersion=4.1.114.Final
+nettyVersion=4.1.115.Final
 
 objenesisVersion=1.0
 


### PR DESCRIPTION
#### Rationale
Fix denial of Service attack on windows app using netty: https://github.com/netty/netty/security/advisories/GHSA-xq3w-v528-46rv

#### Related Pull Requests
* N/A

#### Changes
* Update netty-common to `4.1.115.Final`
