### PR TITLE
Suppress CVE false-positive for spring-web 6.1.14

### DIFF
--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -369,5 +369,14 @@
     </suppress>
     <!-- end of glassfish false positive suppressions -->
 
+    <!-- False positive. Only 5.3.0 - 5.3.41 are affected:
+     https://spring.io/security/cve-2024-38828 -->
+    <suppress>
+        <notes><![CDATA[
+   file name: spring-web-6.1.14.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring-web@.*$</packageUrl>
+        <vulnerabilityName>CVE-2024-38828</vulnerabilityName>
+    </suppress>
 </suppressions>
 


### PR DESCRIPTION
#### Rationale
Only 5.3.0 - 5.3.41 are affected by this CVE: https://spring.io/security/cve-2024-38828
Suppressing rather than bumping `springVersion` to be out of sync with `springBootVersion`.

#### Related Pull Requests
* N/A

#### Changes
* Suppress CVE false-positive for spring-web 6.1.14
