### PR TITLE
Upgrade to Angus Mail 2.0.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -88,7 +88,8 @@ npmWorkDirectory=.node
 # gradle.properties file to declare these version numbers. Naming
 # convention is <library name>Version camel-cased, i.e. "jacksonVersion".
 
-activationApiVersion=2.1.3
+angusActivationVersion=2.0.2
+angusMailVersion=2.0.3
 
 annotationsVersion=15.0
 
@@ -200,7 +201,6 @@ jamaVersion=1.0.3
 
 javassistVersion=3.20.0-GA
 
-javaMailVersion=2.0.1
 javaxAnnotationVersion=1.3.2
 
 # cloud, pipeline, query, and tests (sardine) use the old JAXB API and runtime versions

--- a/server/embedded/build.gradle
+++ b/server/embedded/build.gradle
@@ -77,9 +77,7 @@ dependencies {
     }
 
     runtimeOnly "org.apache.tomcat.embed:tomcat-embed-jasper:${apacheTomcatVersion}"
-    runtimeOnly group: "com.sun.mail", name: "jakarta.mail", version: "${javaMailVersion}"
     runtimeOnly group: "org.apache.tomcat", name: "tomcat-dbcp", version: "${apacheTomcatVersion}"
-    runtimeOnly "org.postgresql:postgresql:${postgresqlDriverVersion}"
     runtimeOnly "org.apache.logging.log4j:log4j-slf4j2-impl:${log4j2Version}"
     implementation "commons-io:commons-io:${commonsIoVersion}"
     implementation "org.apache.logging.log4j:log4j-core:${log4j2Version}"

--- a/server/embedded/src/org/labkey/embedded/LabKeyTomcatServletWebServerFactory.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyTomcatServletWebServerFactory.java
@@ -144,8 +144,6 @@ class LabKeyTomcatServletWebServerFactory extends TomcatServletWebServerFactory
                 addExtraContextResources(contextProperties, context);
 
                 // Add the SMTP config
-                // TODO: Remove or get this to work with Angus Mail. See MailHelper for more info.
-//                context.getNamingResources().addResource(getMailResource());
                 addSmtpProperties(context);
 
                 // Add the encryption key(s)

--- a/server/embedded/src/org/labkey/embedded/LabKeyTomcatServletWebServerFactory.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyTomcatServletWebServerFactory.java
@@ -144,7 +144,9 @@ class LabKeyTomcatServletWebServerFactory extends TomcatServletWebServerFactory
                 addExtraContextResources(contextProperties, context);
 
                 // Add the SMTP config
-                context.getNamingResources().addResource(getMailResource());
+                // TODO: Remove or get this to work with Angus Mail. See MailHelper for more info.
+//                context.getNamingResources().addResource(getMailResource());
+                addSmtpProperties(context);
 
                 // Add the encryption key(s)
                 context.addParameter("EncryptionKey", contextProperties.getEncryptionKey());
@@ -373,39 +375,34 @@ class LabKeyTomcatServletWebServerFactory extends TomcatServletWebServerFactory
         return val != null && !val.isBlank() ? val.trim() : defaultValue;
     }
 
-    private ContextResource getMailResource()
+    private void addSmtpProperties(StandardContext context)
     {
         // Get session/mail properties
         LabKeyServer.MailProperties mailProps = _server.smtpSource();
-        ContextResource mailResource = new ContextResource();
-        mailResource.setName("mail/Session");
-        mailResource.setAuth("Container");
-        mailResource.setType("jakarta.mail.Session");
-        mailResource.setProperty("mail.smtp.host", mailProps.getSmtpHost());
-        mailResource.setProperty("mail.smtp.user", mailProps.getSmtpUser());
-        mailResource.setProperty("mail.smtp.port", mailProps.getSmtpPort());
+
+        context.addParameter("mail.smtp.host", mailProps.getSmtpHost());
+        context.addParameter("mail.smtp.user", mailProps.getSmtpUser());
+        context.addParameter("mail.smtp.port", mailProps.getSmtpPort());
 
         if (mailProps.getSmtpFrom() != null)
         {
-            mailResource.setProperty("mail.smtp.from", mailProps.getSmtpFrom());
+            context.addParameter("mail.smtp.from", mailProps.getSmtpFrom());
         }
         if (mailProps.getSmtpPassword() != null)
         {
-            mailResource.setProperty("mail.smtp.password", mailProps.getSmtpPassword());
+            context.addParameter("mail.smtp.password", mailProps.getSmtpPassword());
         }
         if (mailProps.getSmtpStartTlsEnable() != null)
         {
-            mailResource.setProperty("mail.smtp.starttls.enable", mailProps.getSmtpStartTlsEnable());
+            context.addParameter("mail.smtp.starttls.enable", mailProps.getSmtpStartTlsEnable());
         }
         if (mailProps.getSmtpSocketFactoryClass() != null)
         {
-            mailResource.setProperty("mail.smtp.socketFactory.class", mailProps.getSmtpSocketFactoryClass());
+            context.addParameter("mail.smtp.socketFactory.class", mailProps.getSmtpSocketFactoryClass());
         }
         if (mailProps.getSmtpAuth() != null)
         {
-            mailResource.setProperty("mail.smtp.auth", mailProps.getSmtpAuth());
+            context.addParameter("mail.smtp.auth", mailProps.getSmtpAuth());
         }
-
-        return mailResource;
     }
 }


### PR DESCRIPTION
#### Rationale
Angus Mail is the direct successor to Jakarta Mail, the direct successor to JavaMail. Angus Mail is the active development project.
