### PR TITLE
Minor dependency version bumps

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -101,7 +101,7 @@ apacheDirectoryVersion=2.1.3
 apacheMinaVersion=2.2.1
 
 # Usually matches the version specified as a Spring Boot dependency (see springBootVersion below)
-apacheTomcatVersion=10.1.31
+apacheTomcatVersion=10.1.33
 
 # (mothership) -> json-path -> json-smart -> accessor-smart
 # (core) -> graalvm
@@ -284,9 +284,9 @@ slf4jLog4jApiVersion=2.0.16
 snappyJavaVersion=1.1.10.7
 
 # Also, update apacheTomcatVersion above to match Spring Boot's Tomcat dependency version
-springBootVersion=3.3.5
+springBootVersion=3.3.6
 # This usually matches the Spring Framework version dictated by springBootVersion
-springVersion=6.1.14
+springVersion=6.1.15
 
 sqliteJdbcVersion=3.47.0.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -60,7 +60,7 @@ windowsProteomicsBinariesVersion=1.0
 artifactoryPluginVersion=5.2.5
 gradleNodePluginVersion=3.5.1
 gradlePluginsVersion=4.2.0
-owaspDependencyCheckPluginVersion=11.0.0
+owaspDependencyCheckPluginVersion=11.1.0
 versioningPluginVersion=1.1.2
 
 # Versions of node and npm to use during the build. If set, these versions
@@ -112,8 +112,8 @@ asmVersion=9.7.1
 batikVersion=1.18
 
 # sync with Tika version (or later)
-bouncycastlePgpVersion=1.78.1
-bouncycastleVersion=1.78.1
+bouncycastlePgpVersion=1.79
+bouncycastleVersion=1.79
 
 cglibNodepVersion=2.2.3
 
@@ -129,7 +129,7 @@ commonsCompressVersion=1.27.1
 commonsDbcpVersion=1.4
 commonsDiscoveryVersion=0.2
 commonsDigesterVersion=1.8.1
-commonsIoVersion=2.17.0
+commonsIoVersion=2.18.0
 commonsLangVersion=2.6
 commonsLang3Version=3.17.0
 commonsLoggingVersion=1.3.4
@@ -139,7 +139,7 @@ commonsTextVersion=1.12.0
 commonsValidatorVersion=1.9.0
 commonsVfs2Version=2.7.0
 
-datadogVersion=1.41.1
+datadogVersion=1.42.2
 
 dom4jVersion=2.1.4
 
@@ -155,8 +155,8 @@ fopVersion=2.10
 
 # Force latest for consistency
 googleAutoValueAnnotationsVersion=1.10.4
-googleErrorProneAnnotationsVersion=2.33.0
-googleHttpClientVersion=1.45.0
+googleErrorProneAnnotationsVersion=2.36.0
+googleHttpClientVersion=1.45.1
 googleOauthClientVersion=1.36.0
 googleProtocolBufVersion=3.25.5
 
@@ -168,7 +168,7 @@ graalVersion=24.1.1
 # "java.lang.NoSuchMethodError: 'void com.google.gson.internal.ConstructorConstructor.<init>(java.util.Map)'" errors
 gsonVersion=2.8.9
 
-grpcVersion=1.67.1
+grpcVersion=1.68.1
 
 guavaVersion=33.3.1-jre
 
@@ -184,15 +184,15 @@ hamcrestVersion=2.2
 # Note: if changing this, we might need to match with the picard version in the SequenceAnalysis module build.gradle
 htsjdkVersion=4.0.0
 
-httpclient5Version=5.4
-httpcore5Version=5.3
+httpclient5Version=5.4.1
+httpcore5Version=5.3.1
 
 # Not used directly, but these are widely used transitive dependencies
 httpclientVersion=4.5.14
 httpcoreVersion=4.4.16
 
 # Jackson dependencies are usually released in tandem, but occasionally one gets a patch release out-of-sync with the others
-jacksonVersion=2.18.0
+jacksonVersion=2.18.1
 jacksonAnnotationsVersion=2.18.0
 jacksonDatabindVersion=2.18.0
 jacksonJaxrsBaseVersion=2.18.0
@@ -235,9 +235,9 @@ jxlVersion=2.6.3
 
 kaptchaVersion=2.3
 
-log4j2Version=2.24.1
+log4j2Version=2.24.2
 
-lombokVersion=1.18.34
+lombokVersion=1.18.36
 
 luceneVersion=9.12.0
 
@@ -255,7 +255,7 @@ opencsvVersion=2.3
 
 openTracingVersion=0.33.0
 
-oracleJdbcVersion=23.5.0.24.07
+oracleJdbcVersion=23.6.0.24.10
 
 # sync with version Tika ships
 pdfboxVersion=3.0.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -243,8 +243,6 @@ luceneVersion=9.12.0
 
 mssqlJdbcVersion=12.8.1.jre11
 
-mysqlDriverVersion=9.1.0
-
 # forced compatibility between docker and UserReg-WS
 nettyVersion=4.1.115.Final
 
@@ -254,8 +252,6 @@ objenesisVersion=1.0
 opencsvVersion=2.3
 
 openTracingVersion=0.33.0
-
-oracleJdbcVersion=23.6.0.24.10
 
 # sync with version Tika ships
 pdfboxVersion=3.0.3


### PR DESCRIPTION
#### Rationale
Monthly maintenance

#### Changes
* Spring Boot: 3.3.6
* Spring Framework: 6.1.15
* Apache Tomcat: 10.1.33
* OWASP plugin: 11.1.0
* bouncycastle: 1.79
* commons IO: 2.18.0
* datadog: 1.42.2
* Google Error Prone Annotations: 2.36.0
* Google Http Client: 1.45.1
* grpc: 1.68.1
* http client5: 5.4.1
* http core5: 5.3.1
* jackson: 2.18.1
* log4j2: 2.24.2
* lombok: 1.18.36
* _Note: oracle and mysql driver versions moved to premiumModules_