### PR TITLE
Update Spring Boot to 3.4.0

### DIFF
--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -129,20 +129,6 @@
         <vulnerabilityName>CVE-2023-35116</vulnerabilityName>
     </suppress>
 
-    <!-- The CVE is against Quartz Jobs, not the core Quartz library, so this is a false positive given our actual dependency.
-     For additional info see: Issue #48405
-    -->
-    <suppress>
-        <notes>
-            <![CDATA[
-                file name: quartz-2.3.2.jar
-            ]]>
-        </notes>
-        <packageUrl regex="true">^pkg:maven/org\.quartz\-scheduler/quartz@.*$</packageUrl>
-        <cve>CVE-2023-39017</cve>
-        <cpe>cpe:/a:softwareag:quartz</cpe>
-    </suppress>
-
     <!--
     GraalJS shaded and re-versioned icu4j without changing the file name, leading to many old CVEs getting tagged.
     This should be fixed soon, but suppress all CVEs for now. https://github.com/oracle/graal/issues/8204
@@ -369,14 +355,5 @@
     </suppress>
     <!-- end of glassfish false positive suppressions -->
 
-    <!-- False positive. Only 5.3.0 - 5.3.41 are affected:
-     https://spring.io/security/cve-2024-38828 -->
-    <suppress>
-        <notes><![CDATA[
-   file name: spring-web-6.1.14.jar
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.springframework/spring-web@.*$</packageUrl>
-        <vulnerabilityName>CVE-2024-38828</vulnerabilityName>
-    </suppress>
 </suppressions>
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -101,7 +101,7 @@ apacheDirectoryVersion=2.1.3
 apacheMinaVersion=2.2.1
 
 # Usually matches the version specified as a Spring Boot dependency (see springBootVersion below)
-apacheTomcatVersion=10.1.31
+apacheTomcatVersion=10.1.33
 
 # (mothership) -> json-path -> json-smart -> accessor-smart
 # (core) -> graalvm
@@ -267,7 +267,7 @@ pollingWatchVersion=0.2.0
 
 postgresqlDriverVersion=42.7.4
 
-quartzVersion=2.3.2
+quartzVersion=2.5.0
 
 reflectionsVersion=0.10.2
 
@@ -288,9 +288,9 @@ slf4jLog4jApiVersion=2.0.16
 snappyJavaVersion=1.1.10.7
 
 # Also, update apacheTomcatVersion above to match Spring Boot's Tomcat dependency version
-springBootVersion=3.3.5
+springBootVersion=3.4.0
 # This usually matches the Spring Framework version dictated by springBootVersion
-springVersion=6.1.14
+springVersion=6.2.0
 
 sqliteJdbcVersion=3.47.0.0
 


### PR DESCRIPTION
#### Rationale
There are some larger version bumps available for Spring and Quartz. Making these updates in a separate PR to reduce the number of variables in case something goes awry.
These changes also remove the need for a couple of dependency check suppressions.

#### Related Pull Requests
* #933

#### Changes
* Spring Boot: 3.4.0
* Spring Framework: 6.2.0
* Quartz: 2.5.0
* Remove obsolete dependency check suppressions
