### PR TITLE
Slim down embedded dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -224,6 +224,8 @@ allprojects {
                     force "com.google.guava:guava:${guavaVersion}"
                     // force version for SequenceAnalysis, TargetedMS
                     force "com.google.protobuf:protobuf-java:${googleProtocolBufVersion}"
+                    // force Jakarta Activation API version used by our Angus Activation implementation
+                    force "jakarta.activation:jakarta.activation-api:${jakartaActivationApiVersion}"
                     // force version for accounts, api, query
                     force "javax.validation:validation-api:${validationApiVersion}"
                     // force version for accounts, docker, api, workflow

--- a/gradle.properties
+++ b/gradle.properties
@@ -88,6 +88,7 @@ npmWorkDirectory=.node
 # gradle.properties file to declare these version numbers. Naming
 # convention is <library name>Version camel-cased, i.e. "jacksonVersion".
 
+# The implementation of Jakarta Activation API that we use. Keep in sync with jakartaActivationApiVersion (below).
 angusActivationVersion=2.0.2
 angusMailVersion=2.0.3
 
@@ -196,6 +197,9 @@ jacksonVersion=2.18.1
 jacksonAnnotationsVersion=2.18.0
 jacksonDatabindVersion=2.18.0
 jacksonJaxrsBaseVersion=2.18.0
+
+# The Jakarta Activation API version that Angus Activation implements. Keep in sync with angusActivationVersion (above).
+jakartaActivationApiVersion=2.1.3
 
 jamaVersion=1.0.3
 

--- a/server/bootstrap/build.gradle
+++ b/server/bootstrap/build.gradle
@@ -15,14 +15,13 @@ sourceSets {
 }
 
 dependencies
-        {
-            def tomcatVersion = project.apacheTomcatVersion
-
-            implementation "org.apache.tomcat:tomcat-api:${tomcatVersion}"
-            implementation "org.apache.tomcat:tomcat-catalina:${tomcatVersion}"
-            implementation "org.apache.tomcat:tomcat-juli:${tomcatVersion}"
-            implementation "org.apache.tomcat:tomcat-util:${tomcatVersion}"
+{
+    implementation('org.apache.tomcat.embed:tomcat-embed-core') {
+        version {
+            strictly "${apacheTomcatVersion}"
         }
+    }
+}
 
 def JAR_BASE_NAME = "labkeyBootstrap"
 project.jar {
@@ -65,9 +64,6 @@ project.afterEvaluate  {
                     publications('libs')
                 }
             }
-
         }
     }
 }
-
-

--- a/server/embedded/build.gradle
+++ b/server/embedded/build.gradle
@@ -31,15 +31,15 @@ configurations {
 }
 
 configurations.configureEach {
-//    exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
     exclude group: 'ch.qos.logback', module: 'logback-classic'
     exclude group: 'org.apache.logging.log4j', module: 'log4j-to-slf4j'
 }
 
 dependencies {
-    implementation "org.springframework.boot:spring-boot-starter-web:${springBootVersion}"
-    implementation "org.springframework.boot:spring-boot-starter-actuator:${springBootVersion}"
-    implementation "org.springframework.boot:spring-boot-starter-validation:${springBootVersion}"
+    implementation("org.springframework.boot:spring-boot-starter-web:${springBootVersion}") {
+        exclude group: "org.springframework.boot", module: "spring-boot-starter-json" // Not used (?) and pulls in an old version of Jackson
+        exclude group: "jakarta.annotation", module: "jakarta.annotation-api" // Already present in tomcat-annotations-api
+    }
 
     // Allows forcing a Spring Framework version that differs from spring-boot's version (e.g., to address CVEs)
     implementation('org.springframework:spring-web') {
@@ -50,11 +50,6 @@ dependencies {
 
     // Allows forcing a Tomcat version that differs from spring-boot's version (e.g., to address CVEs or regressions,
     // or to test a Tomcat release candidate)
-    implementation('org.apache.tomcat.embed:tomcat-embed-core') {
-        version {
-            strictly "${apacheTomcatVersion}"
-        }
-    }
     implementation('org.apache.tomcat.embed:tomcat-embed-el') {
         version {
             strictly "${apacheTomcatVersion}"
@@ -70,14 +65,11 @@ dependencies {
             strictly "${apacheTomcatVersion}"
         }
     }
-    implementation('org.apache.tomcat:tomcat-jsp-api') {
-        version {
-            strictly "${apacheTomcatVersion}"
-        }
-    }
 
     runtimeOnly "org.apache.tomcat.embed:tomcat-embed-jasper:${apacheTomcatVersion}"
-    runtimeOnly group: "org.apache.tomcat", name: "tomcat-dbcp", version: "${apacheTomcatVersion}"
+    runtimeOnly("org.apache.tomcat:tomcat-dbcp:${apacheTomcatVersion}") {
+        exclude group: "org.apache.tomcat", module: "tomcat-juli"
+    }
     runtimeOnly "org.apache.logging.log4j:log4j-slf4j2-impl:${log4j2Version}"
     implementation "commons-io:commons-io:${commonsIoVersion}"
     implementation "org.apache.logging.log4j:log4j-core:${log4j2Version}"

--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -497,6 +497,8 @@ public class LabKeyServer
 
         public String getEncryptionKey()
         {
+            if (null == encryptionKey)
+                throw new RuntimeException("Must provide encryptionKey");
             return encryptionKey;
         }
 

--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -1,6 +1,5 @@
 package org.labkey.embedded;
 
-import jakarta.validation.constraints.NotNull;
 import org.apache.catalina.connector.Connector;
 import org.labkey.bootstrap.PipelineBootstrapConfig;
 import org.springframework.boot.Banner;
@@ -405,7 +404,6 @@ public class LabKeyServer
 
         private String webAppLocation;
         private String workDirLocation;
-        @NotNull (message = "Must provide encryptionKey")
         private String encryptionKey;
         private String oldEncryptionKey;
         private String legacyContextPath;

--- a/server/embedded/src/org/labkey/embedded/LabKeySpringBootClassLoader.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeySpringBootClassLoader.java
@@ -1,6 +1,7 @@
 package org.labkey.embedded;
 
-import org.jboss.logging.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.labkey.bootstrap.LabKeyBootstrapClassLoader;
 
 import java.io.IOException;
@@ -19,7 +20,7 @@ import java.util.List;
  */
 public class LabKeySpringBootClassLoader extends LabKeyBootstrapClassLoader
 {
-    private static final Logger LOG = Logger.getLogger(LabKeySpringBootClassLoader.class);
+    private static final Logger LOG = LogManager.getLogger(LabKeySpringBootClassLoader.class);
 
     public LabKeySpringBootClassLoader()
     {


### PR DESCRIPTION
#### Rationale
Some dependencies in the embedded jar were included multiple times and others appear to be unnecessary. This removes 32 (~12MB) redundant, conflicting, or unneeded jars.

It's possible that one or more of these 32 jars is actually needed; @ankurjuneja may have more history here. I also plan to run BVTs and Dailies, and will merge after 24.12 branching to provide more bake time.

It's also possible we could eliminate a few more jars, but this PR seems like a good starting point.

#### Changes
* Make `tomcat-embed-core` a dependency for `bootstrap` and stop pulling in redundant Tomcat dependencies there
* Exclude `spring-boot-starter-json`: seems unused and pulls in an old version of Jackson
* Exclude `jakarta.annotation-api`: already present in `tomcat-annotations-api`
* Exclude `tomcat-juli`: already present in `tomcat-embed-core`
* Remove `spring-boot-starter-actuator`: seems unused
* Remove `spring-boot-starter-validation`: eliminating a single `@NotNull` annotation lets us remove this and its dependencies
* Migrate a single use of `org.jboss.logging.Logger` (??) to `log4j`