### PR TITLE
Jackson dependencies should be updated in tandem

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -191,11 +191,11 @@ httpcore5Version=5.3.1
 httpclientVersion=4.5.14
 httpcoreVersion=4.4.16
 
-# Jackson dependencies are usually released in tandem, but occasionally one gets a patch release out-of-sync with the others
+# Update all Jackson dependency versions below in tandem, unless one gets a patch release out-of-sync with the others
 jacksonVersion=2.18.1
-jacksonAnnotationsVersion=2.18.0
-jacksonDatabindVersion=2.18.0
-jacksonJaxrsBaseVersion=2.18.0
+jacksonAnnotationsVersion=2.18.1
+jacksonDatabindVersion=2.18.1
+jacksonJaxrsBaseVersion=2.18.1
 
 jamaVersion=1.0.3
 


### PR DESCRIPTION
#### Rationale
Related PR updated only one of the four Jackson versions

#### Related Pull Requests
* https://github.com/LabKey/server/pull/933