### PR TITLE
Revert to Tomcat 10.1.31

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -100,7 +100,7 @@ apacheDirectoryVersion=2.1.3
 apacheMinaVersion=2.2.1
 
 # Usually matches the version specified as a Spring Boot dependency (see springBootVersion below)
-apacheTomcatVersion=10.1.33
+apacheTomcatVersion=10.1.31
 
 # (mothership) -> json-path -> json-smart -> accessor-smart
 # (core) -> graalvm


### PR DESCRIPTION
#### Rationale
10.1.33 causes problems when datadog is running.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/932

#### Changes
* Downgrade to Tomcat 10.1.31
