### PR TITLE
Remove reference to deleted 'studyDesign' XML schema

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -84,7 +84,6 @@ if (project.findProject(schemasProjectPath))
         project.project(schemasProjectPath).file("schemas/query.xsd"),
         project.project(schemasProjectPath).file("schemas/report.xsd"),
         project.project(schemasProjectPath).file("schemas/reportProps.xsd"),
-        project.project(schemasProjectPath).file("schemas/studyDesign.xsd"),
         project.project(schemasProjectPath).file("schemas/studyViews.xsd"),
         project.project(schemasProjectPath).file("schemas/view.xsd"),
         project.project(schemasProjectPath).file("schemas/viewCategory.xsd"),


### PR DESCRIPTION
#### Rationale
`studyDesign.xsd` was removed. Need to remove this reference.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/6101

#### Changes
* Remove reference to deleted 'studyDesign' XML schema
