### PR TITLE
Force Tomcat version

### DIFF
--- a/server/embedded/build.gradle
+++ b/server/embedded/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web:${springBootVersion}") {
         exclude group: "org.springframework.boot", module: "spring-boot-starter-json" // Not used (?) and pulls in an old version of Jackson
         exclude group: "jakarta.annotation", module: "jakarta.annotation-api" // Already present in tomcat-annotations-api
-        exclude group: "org.apache.tomcat.embed", module: "tomcat-embed-core" // Version we want is declared in bootstrap/build.gradle
+        exclude group: "org.apache.tomcat.embed", module: "tomcat-embed-core" // We want to force apacheTomcatVersion
     }
 
     // Allows forcing a Spring Framework version that differs from spring-boot's version (e.g., to address CVEs)
@@ -65,7 +65,7 @@ dependencies {
         version {
             strictly "${apacheTomcatVersion}"
         }
-        exclude group: "org.apache.tomcat.embed", module: "tomcat-embed-core" // Version we want is declared in bootstrap/build.gradle
+        exclude group: "org.apache.tomcat.embed", module: "tomcat-embed-core" // We want to force apacheTomcatVersion
     }
     implementation('org.apache.tomcat:tomcat-annotations-api') {
         version {

--- a/server/embedded/build.gradle
+++ b/server/embedded/build.gradle
@@ -33,12 +33,27 @@ configurations {
 configurations.configureEach {
     exclude group: 'ch.qos.logback', module: 'logback-classic'
     exclude group: 'org.apache.logging.log4j', module: 'log4j-to-slf4j'
+
+    resolutionStrategy {
+        force "org.apache.tomcat.embed:tomcat-embed-core:${apacheTomcatVersion}"
+        force "org.apache.tomcat.embed:tomcat-embed-websocket:${apacheTomcatVersion}"
+    }
+}
+
+configurations.all {
+
+    resolutionStrategy {
+        force "org.apache.tomcat.embed:tomcat-embed-core:${apacheTomcatVersion}"
+        force "org.apache.tomcat.embed:tomcat-embed-websocket:${apacheTomcatVersion}"
+    }
 }
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web:${springBootVersion}") {
         exclude group: "org.springframework.boot", module: "spring-boot-starter-json" // Not used (?) and pulls in an old version of Jackson
         exclude group: "jakarta.annotation", module: "jakarta.annotation-api" // Already present in tomcat-annotations-api
+        exclude group: "org.apache.tomcat.embed", module: "tomcat-embed-core" // Version we want is declared in bootstrap/build.gradle
+        exclude group: "org.apache.tomcat.embed", module: "tomcat-embed-websocket" // Version we want is declared in bootstrap/build.gradle
     }
 
     // Allows forcing a Spring Framework version that differs from spring-boot's version (e.g., to address CVEs)

--- a/server/embedded/build.gradle
+++ b/server/embedded/build.gradle
@@ -33,19 +33,6 @@ configurations {
 configurations.configureEach {
     exclude group: 'ch.qos.logback', module: 'logback-classic'
     exclude group: 'org.apache.logging.log4j', module: 'log4j-to-slf4j'
-
-    resolutionStrategy {
-        force "org.apache.tomcat.embed:tomcat-embed-core:${apacheTomcatVersion}"
-        force "org.apache.tomcat.embed:tomcat-embed-websocket:${apacheTomcatVersion}"
-    }
-}
-
-configurations.all {
-
-    resolutionStrategy {
-        force "org.apache.tomcat.embed:tomcat-embed-core:${apacheTomcatVersion}"
-        force "org.apache.tomcat.embed:tomcat-embed-websocket:${apacheTomcatVersion}"
-    }
 }
 
 dependencies {
@@ -53,7 +40,6 @@ dependencies {
         exclude group: "org.springframework.boot", module: "spring-boot-starter-json" // Not used (?) and pulls in an old version of Jackson
         exclude group: "jakarta.annotation", module: "jakarta.annotation-api" // Already present in tomcat-annotations-api
         exclude group: "org.apache.tomcat.embed", module: "tomcat-embed-core" // Version we want is declared in bootstrap/build.gradle
-        exclude group: "org.apache.tomcat.embed", module: "tomcat-embed-websocket" // Version we want is declared in bootstrap/build.gradle
     }
 
     // Allows forcing a Spring Framework version that differs from spring-boot's version (e.g., to address CVEs)
@@ -65,6 +51,11 @@ dependencies {
 
     // Allows forcing a Tomcat version that differs from spring-boot's version (e.g., to address CVEs or regressions,
     // or to test a Tomcat release candidate)
+    implementation('org.apache.tomcat.embed:tomcat-embed-core') {
+        version {
+            strictly "${apacheTomcatVersion}"
+        }
+    }
     implementation('org.apache.tomcat.embed:tomcat-embed-el') {
         version {
             strictly "${apacheTomcatVersion}"
@@ -74,6 +65,7 @@ dependencies {
         version {
             strictly "${apacheTomcatVersion}"
         }
+        exclude group: "org.apache.tomcat.embed", module: "tomcat-embed-core" // Version we want is declared in bootstrap/build.gradle
     }
     implementation('org.apache.tomcat:tomcat-annotations-api') {
         version {


### PR DESCRIPTION
#### Rationale
Spring Boot is still pulling in its preferred version of `tomcat-embed-core.jar`. We need to force it to use the explicit Tomcat version instead.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/937