### PR TITLE
Update project paths in moduleSet files

### DIFF
--- a/gradle/settings/communityArtifacts.gradle
+++ b/gradle/settings/communityArtifacts.gradle
@@ -1,2 +1,1 @@
 include ":server:testAutomation:buildTestModules:communityArtifacts"
-include ":server:minification"

--- a/gradle/settings/ehr.gradle
+++ b/gradle/settings/ehr.gradle
@@ -53,6 +53,7 @@ List<String> ehrModulesDirs = [
         "server/modules/onprcEHRModules",
         "server/modules/ehrModules",
         "server/modules/snprcEHRModules",
+        "server/modules/tnprcEHRModules",
         "server/modules/wnprc-modules",
         "server/modules/LabDevKitModules"
 ]
@@ -66,9 +67,7 @@ BuildUtils.includeModules(this.settings, rootDir, [BuildUtils.PLATFORM_MODULES_D
 BuildUtils.includeModules(this.settings, rootDir, ehrModulesDirs, excludedModules)
 
 include ":server:modules:snd"
-include ":server:modules:tnprc_ehr"
-include ":server:modules:tnprc_billing"
-include ":server:modules:dataintegration"
+include ":server:modules:premiumModules:dataintegration"
 include ":server:modules:premiumModules:premium"
 include ":server:modules:premiumModules:ldap"
 


### PR DESCRIPTION
#### Rationale
Building with `-PmoduleSet=ehr` might not include all of the desired modules because some of them have moved. TNPRC, recently; and dataintegration earlier this year.

#### Related Pull Requests
* https://github.com/LabKey/tnprcEHRModules/pull/1

#### Changes
* Update project paths in moduleSet files
