### PR TITLE
Update Tomcat to 10.1.34

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -100,7 +100,7 @@ apacheDirectoryVersion=2.1.3
 apacheMinaVersion=2.2.1
 
 # Usually matches the version specified as a Spring Boot dependency (see springBootVersion below)
-apacheTomcatVersion=10.1.31
+apacheTomcatVersion=10.1.34
 
 # (mothership) -> json-path -> json-smart -> accessor-smart
 # (core) -> graalvm


### PR DESCRIPTION
#### Rationale
Tomcat 10.1.34 was just released. This version fixes an issue with Tomcat 10.1.33 used with the DataDog agent. https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=51784
