### PR TITLE
Gradle 8.11.1

### DIFF
--- a/.idea/codeInsightSettings.xml
+++ b/.idea/codeInsightSettings.xml
@@ -31,6 +31,7 @@
       <name>org.slf4j.Logger</name>
       <name>org.springframework.lang.Nullable</name>
       <name>org.springframework.util.StringUtils</name>
+      <name>com.sun.istack.Nullable</name>
     </excluded-names>
   </component>
 </project>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
#### Rationale
Update to [Gradle 8.11.1](https://docs.gradle.org/current/release-notes.html)

#### Changes
* Gradle 8.11.1 is the latest
* Add exclusion for different `Nullable` class
