### PR TITLE
Make gradle `excludedModules` property work

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -106,7 +106,7 @@ include BuildUtils.getMinificationProjectPath(gradle)
 List<String> excludedModules = []
 if (hasProperty('excludedModules'))
 {
-    excludedModules.addAll("${excludedModules}".split(","))
+    excludedModules.addAll("${getProperty('excludedModules')}".split(","))
 }
 
 if (new File(getRootDir(), BuildUtils.convertPathToRelativeDir(BuildUtils.getPlatformProjectPath(gradle))).exists()


### PR DESCRIPTION
#### Rationale
I tried switching my build to use the `excludedModules` property but it doesn't work as written. `"${excludedModules}"` always resolves to the declared List, not the system property. Calling `getProperty` explicitly seems to work for me.

#### Related Pull Requests
* #621 

#### Changes
* Make gradle `excludedModules` property work
