### PR TITLE
Enable "enforce" CSP for dev deployments

### DIFF
--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -128,35 +128,18 @@ management.server.port=@@shutdownPort@@
 ## Define one or both of 'csp.report' and 'csp.enforce' to enable Content Security Policy (CSP) headers
 ## Do not use these examples for any production environment without understanding the meaning of each directive!
 
-## example usage 1 - very strict, disallows 'external' websites, disallows unsafe-inline, but only reports violations (does not enforce)
-
-#csp.report=\
-#    default-src 'self';\
-#    connect-src 'self' ${LABKEY.ALLOWED.CONNECTIONS} ;\
-#    object-src 'none' ;\
-#    style-src 'self' 'unsafe-inline' ;\
-#    img-src 'self' data: ;\
-#    font-src 'self' data: ;\
-#    script-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}';\
-#    base-uri 'self' ;\
-#    upgrade-insecure-requests ;\
-#    frame-ancestors 'self' ;\
-#    report-uri https://www.labkey.org/admin-contentsecuritypolicyreport.api?${CSP.REPORT.PARAMS} ;
-
-## example usage 2 - less strict but enforces directives, (NOTE: unsafe-inline is still required for many modules)
-
-#csp.enforce=\
-#    default-src 'self' https: ;\
-#    connect-src 'self' https: ${LABKEY.ALLOWED.CONNECTIONS};\
-#    object-src 'none' ;\
-#    style-src 'self' https: 'unsafe-inline' ;\
-#    img-src 'self' data: ;\
-#    font-src 'self' data: ;\
-#    script-src 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}';\
-#    base-uri 'self' ;\
-#    upgrade-insecure-requests ;\
-#    frame-ancestors 'self' ;\
-#    report-uri  https://www.labkey.org/admin-contentsecuritypolicyreport.api?${CSP.REPORT.PARAMS} ;
+## Default CSP for dev deployments
+#useLocalBuild#csp.enforce=\
+#useLocalBuild#    default-src 'self' https: http: ;\
+#useLocalBuild#    connect-src 'self' localhost:* ws: ${LABKEY.ALLOWED.CONNECTIONS} ;\
+#useLocalBuild#    object-src 'none' ;\
+#useLocalBuild#    style-src 'self' https: 'unsafe-inline' ;\
+#useLocalBuild#    img-src 'self' https: data: ;\
+#useLocalBuild#    font-src 'self' http: https: data: ;\
+#useLocalBuild#    script-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ;\
+#useLocalBuild#    base-uri 'self' ;\
+#useLocalBuild#    frame-ancestors 'self' ;\
+#useLocalBuild#    report-uri /admin-contentsecuritypolicyreport.api?${CSP.REPORT.PARAMS} ;
 
 ## Default CSP for TeamCity and dev deployments
 csp.report=\

--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -128,7 +128,7 @@ management.server.port=@@shutdownPort@@
 ## Define one or both of 'csp.report' and 'csp.enforce' to enable Content Security Policy (CSP) headers
 ## Do not use these examples for any production environment without understanding the meaning of each directive!
 
-## Default CSP for dev deployments
+## Default enforce CSP for dev deployments
 #useLocalBuild#csp.enforce=\
 #useLocalBuild#    default-src 'self' https: http: ;\
 #useLocalBuild#    connect-src 'self' localhost:* ws: ${LABKEY.ALLOWED.CONNECTIONS} ;\
@@ -141,7 +141,7 @@ management.server.port=@@shutdownPort@@
 #useLocalBuild#    frame-ancestors 'self' ;\
 #useLocalBuild#    report-uri /admin-contentsecuritypolicyreport.api?${CSP.REPORT.PARAMS} ;
 
-## Default CSP for TeamCity and dev deployments
+## Default report CSP for TeamCity and dev deployments
 csp.report=\
     default-src 'self' https: http: ;\
     connect-src 'self' localhost:* ws: ${LABKEY.ALLOWED.CONNECTIONS} ;\


### PR DESCRIPTION
#### Rationale
Now that we've deployed "enforce" CSP to production servers, we should have developers run with it locally. Not enabling it by default on TeamCity because tests reliably check for CSP errors where developers might not.
The `useLocalBuild` parameter is a good proxy for non-TeamCity dev deployments.

#### Related Pull Requests
* N/A

#### Changes
* Enable the "enforce" CSP when deploying locally
* Remove example CSPs from dev `application.properties`
