### PR TITLE
Update versions of various dependencies in response to CVEs

### DIFF
--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -369,6 +369,15 @@
     </suppress>
     <!-- end of glassfish false positive suppressions -->
 
+    <!-- False positive. Only 5.3.0 - 5.3.41 are affected:
+     https://spring.io/security/cve-2024-38828 -->
+    <suppress>
+        <notes><![CDATA[
+   file name: spring-web-6.1.14.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring-web@.*$</packageUrl>
+        <vulnerabilityName>CVE-2024-38828</vulnerabilityName>
+    </suppress>
     <!-- We don't use the sun.io.useCanonCaches setting referenced by this CVE.  -->
     <suppress>
         <notes><![CDATA[

--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -369,5 +369,13 @@
     </suppress>
     <!-- end of glassfish false positive suppressions -->
 
+    <!-- We don't use the sun.io.useCanonCaches setting referenced by this CVE.  -->
+    <suppress>
+        <notes><![CDATA[
+   file name: tomcat-catalina-10.1.34.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat/tomcat-catalina@.*$</packageUrl>
+        <vulnerabilityName>CVE-2024-56337</vulnerabilityName>
+    </suppress>
 </suppressions>
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -246,7 +246,7 @@ mssqlJdbcVersion=12.8.1.jre11
 mysqlDriverVersion=9.1.0
 
 # forced compatibility between docker and UserReg-WS
-nettyVersion=4.1.114.Final
+nettyVersion=4.1.116.Final
 
 objenesisVersion=1.0
 
@@ -288,9 +288,9 @@ slf4jLog4jApiVersion=2.0.16
 snappyJavaVersion=1.1.10.7
 
 # Also, update apacheTomcatVersion above to match Spring Boot's Tomcat dependency version
-springBootVersion=3.3.5
+springBootVersion=3.4.1
 # This usually matches the Spring Framework version dictated by springBootVersion
-springVersion=6.1.14
+springVersion=6.2.1
 
 sqliteJdbcVersion=3.47.0.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -246,7 +246,7 @@ mssqlJdbcVersion=12.8.1.jre11
 mysqlDriverVersion=9.1.0
 
 # forced compatibility between docker and UserReg-WS
-nettyVersion=4.1.116.Final
+nettyVersion=4.1.115.Final
 
 objenesisVersion=1.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -95,12 +95,12 @@ annotationsVersion=15.0
 antVersion=1.10.13
 
 #Unifying version used by DISCVR and Premium
-apacheDirectoryVersion=2.1.3
+apacheDirectoryVersion=2.1.7
 #Transitive dependency of Apache directory: 2.0.18 contains some regressions
-apacheMinaVersion=2.2.1
+apacheMinaVersion=2.2.4
 
 # Usually matches the version specified as a Spring Boot dependency (see springBootVersion below)
-apacheTomcatVersion=10.1.31
+apacheTomcatVersion=10.1.34
 
 # (mothership) -> json-path -> json-smart -> accessor-smart
 # (core) -> graalvm

--- a/gradle/settings/communityArtifacts.gradle
+++ b/gradle/settings/communityArtifacts.gradle
@@ -1,2 +1,1 @@
 include ":server:testAutomation:buildTestModules:communityArtifacts"
-include ":server:minification"

--- a/gradle/settings/ehr.gradle
+++ b/gradle/settings/ehr.gradle
@@ -53,6 +53,7 @@ List<String> ehrModulesDirs = [
         "server/modules/onprcEHRModules",
         "server/modules/ehrModules",
         "server/modules/snprcEHRModules",
+        "server/modules/tnprcEHRModules",
         "server/modules/wnprc-modules",
         "server/modules/LabDevKitModules"
 ]
@@ -66,9 +67,7 @@ BuildUtils.includeModules(this.settings, rootDir, [BuildUtils.PLATFORM_MODULES_D
 BuildUtils.includeModules(this.settings, rootDir, ehrModulesDirs, excludedModules)
 
 include ":server:modules:snd"
-include ":server:modules:tnprc_ehr"
-include ":server:modules:tnprc_billing"
-include ":server:modules:dataintegration"
+include ":server:modules:premiumModules:dataintegration"
 include ":server:modules:premiumModules:premium"
 include ":server:modules:premiumModules:ldap"
 


### PR DESCRIPTION
#### Rationale

- [CVE-2024-56337](https://ossindex.sonatype.org/vulnerability/CVE-2024-56337)- suppressed because it does not apply to our usage of tomcat
- [CVE-2024-43535](https://ossindex.sonatype.org/vulnerability/CVE-2024-47535) - netty version update
- [CVE-2024-52046](https://ossindex.sonatype.org/vulnerability/CVE-2024-52046) - Apache mina-core version update (transitive dependency)
- [CVS-2024-52318](https://ossindex.sonatype.org/vulnerability/CVE-2024-52318) - tomcat version update

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Update to various dependency versions
