### PR TITLE
Version update and CVE suppression

### DIFF
--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -378,5 +378,14 @@
         <packageUrl regex="true">^pkg:maven/org\.springframework/spring-web@.*$</packageUrl>
         <vulnerabilityName>CVE-2024-38828</vulnerabilityName>
     </suppress>
+
+    <!-- We don't use the sun.io.useCanonCaches setting referenced by this CVE.  -->
+    <suppress>
+        <notes><![CDATA[
+   file name: tomcat-catalina-10.1.34.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat/tomcat-catalina@.*$</packageUrl>
+        <vulnerabilityName>CVE-2024-56337</vulnerabilityName>
+    </suppress>
 </suppressions>
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -95,9 +95,9 @@ annotationsVersion=15.0
 antVersion=1.10.13
 
 #Unifying version used by DISCVR and Premium
-apacheDirectoryVersion=2.1.3
+apacheDirectoryVersion=2.1.7
 #Transitive dependency of Apache directory: 2.0.18 contains some regressions
-apacheMinaVersion=2.2.1
+apacheMinaVersion=2.2.4
 
 # Usually matches the version specified as a Spring Boot dependency (see springBootVersion below)
 apacheTomcatVersion=10.1.34


### PR DESCRIPTION
#### Rationale
- [CVE-2024-52046](https://ossindex.sonatype.org/vulnerability/CVE-2024-52046)
- [CVE-2024-56337](https://ossindex.sonatype.org/vulnerability/CVE-2024-56337)

#### Changes
* Suppress CVE that does not apply
* Update version of Apache MINA and directory
