### PR TITLE
Minor version updates for 25.1

### DIFF
--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -355,5 +355,13 @@
     </suppress>
     <!-- end of glassfish false positive suppressions -->
 
+    <!-- We don't use the sun.io.useCanonCaches setting referenced by this CVE.  -->
+    <suppress>
+        <notes><![CDATA[
+   file name: tomcat-catalina-10.1.34.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat/tomcat-catalina@.*$</packageUrl>
+        <vulnerabilityName>CVE-2024-56337</vulnerabilityName>
+    </suppress>
 </suppressions>
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -60,7 +60,7 @@ windowsProteomicsBinariesVersion=1.0
 artifactoryPluginVersion=5.2.5
 gradleNodePluginVersion=7.1.0
 gradlePluginsVersion=6.0.0
-owaspDependencyCheckPluginVersion=11.1.1
+owaspDependencyCheckPluginVersion=11.1.0
 versioningPluginVersion=1.1.2
 
 # Versions of node and npm to use during the build. If set, these versions

--- a/gradle.properties
+++ b/gradle.properties
@@ -102,7 +102,7 @@ apacheDirectoryVersion=2.1.7
 apacheMinaVersion=2.2.4
 
 # Usually matches the version specified as a Spring Boot dependency (see springBootVersion below)
-apacheTomcatVersion=10.1.35
+apacheTomcatVersion=10.1.34
 
 # (mothership) -> json-path -> json-smart -> accessor-smart
 # (core) -> graalvm

--- a/gradle.properties
+++ b/gradle.properties
@@ -60,7 +60,7 @@ windowsProteomicsBinariesVersion=1.0
 artifactoryPluginVersion=5.2.5
 gradleNodePluginVersion=7.1.0
 gradlePluginsVersion=6.0.0
-owaspDependencyCheckPluginVersion=11.1.0
+owaspDependencyCheckPluginVersion=11.1.1
 versioningPluginVersion=1.1.2
 
 # Versions of node and npm to use during the build. If set, these versions
@@ -133,11 +133,11 @@ commonsLang3Version=3.17.0
 commonsLoggingVersion=1.3.4
 commonsMath3Version=3.6.1
 commonsPoolVersion=1.6
-commonsTextVersion=1.12.0
+commonsTextVersion=1.13.0
 commonsValidatorVersion=1.9.0
 commonsVfs2Version=2.7.0
 
-datadogVersion=1.42.2
+datadogVersion=1.44.1
 
 dom4jVersion=2.1.4
 
@@ -154,8 +154,8 @@ fopVersion=2.10
 # Force latest for consistency
 googleAutoValueAnnotationsVersion=1.10.4
 googleErrorProneAnnotationsVersion=2.36.0
-googleHttpClientVersion=1.45.1
-googleOauthClientVersion=1.36.0
+googleHttpClientVersion=1.45.3
+googleOauthClientVersion=1.37.0
 googleProtocolBufVersion=3.25.5
 
 graalVersion=24.1.1
@@ -166,7 +166,7 @@ graalVersion=24.1.1
 # "java.lang.NoSuchMethodError: 'void com.google.gson.internal.ConstructorConstructor.<init>(java.util.Map)'" errors
 gsonVersion=2.8.9
 
-grpcVersion=1.68.1
+grpcVersion=1.69.0
 
 guavaVersion=33.3.1-jre
 
@@ -190,10 +190,10 @@ httpclientVersion=4.5.14
 httpcoreVersion=4.4.16
 
 # Update all Jackson dependency versions below in tandem, unless one gets a patch release out-of-sync with the others
-jacksonVersion=2.18.1
-jacksonAnnotationsVersion=2.18.1
-jacksonDatabindVersion=2.18.1
-jacksonJaxrsBaseVersion=2.18.1
+jacksonVersion=2.18.2
+jacksonAnnotationsVersion=2.18.2
+jacksonDatabindVersion=2.18.2
+jacksonJaxrsBaseVersion=2.18.2
 
 # The Jakarta Activation API version that Angus Activation implements. Keep in sync with angusActivationVersion (above).
 jakartaActivationApiVersion=2.1.3
@@ -228,7 +228,7 @@ jsr305Version=3.0.2
 
 orgJsonVersion=20240303
 
-jsoupVersion=1.18.1
+jsoupVersion=1.18.3
 
 junitVersion=4.13.2
 
@@ -236,16 +236,16 @@ jxlVersion=2.6.3
 
 kaptchaVersion=2.3
 
-log4j2Version=2.24.2
+log4j2Version=2.24.3
 
 lombokVersion=1.18.36
 
-luceneVersion=9.12.0
+luceneVersion=9.12.1
 
 mssqlJdbcVersion=12.8.1.jre11
 
 # forced compatibility between docker and UserReg-WS
-nettyVersion=4.1.115.Final
+nettyVersion=4.1.116.Final
 
 objenesisVersion=1.0
 
@@ -289,7 +289,7 @@ springBootVersion=3.4.1
 # This usually matches the Spring Framework version dictated by springBootVersion
 springVersion=6.2.1
 
-sqliteJdbcVersion=3.47.0.0
+sqliteJdbcVersion=3.47.1.0
 
 # NLP and SAML bring stax2-api in as a transitive dependency but with very different versions. We force the later version.
 stax2ApiVersion=4.2.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -97,12 +97,12 @@ annotationsVersion=15.0
 antVersion=1.10.13
 
 #Unifying version used by DISCVR and Premium
-apacheDirectoryVersion=2.1.3
+apacheDirectoryVersion=2.1.7
 #Transitive dependency of Apache directory: 2.0.18 contains some regressions
-apacheMinaVersion=2.2.1
+apacheMinaVersion=2.2.4
 
 # Usually matches the version specified as a Spring Boot dependency (see springBootVersion below)
-apacheTomcatVersion=10.1.34
+apacheTomcatVersion=10.1.35
 
 # (mothership) -> json-path -> json-smart -> accessor-smart
 # (core) -> graalvm
@@ -288,9 +288,9 @@ slf4jLog4jApiVersion=2.0.16
 snappyJavaVersion=1.1.10.7
 
 # Also, update apacheTomcatVersion above to match Spring Boot's Tomcat dependency version
-springBootVersion=3.4.0
+springBootVersion=3.4.1
 # This usually matches the Spring Framework version dictated by springBootVersion
-springVersion=6.2.0
+springVersion=6.2.1
 
 sqliteJdbcVersion=3.47.0.0
 


### PR DESCRIPTION
#### Rationale
Keeping current. Leaving the OWASP version update out for now as it caused failures that it seems it should not have.

This includes changes that will get merged forward from 24.11 just to quiet the OWASP check earlier than it might otherwise be.

#### Related Pull Requests
* https://github.com/LabKey/premiumModules/pull/132 (related in name only)
* https://github.com/LabKey/testAutomation/pull/2211 (related in name only)

#### Changes
* Update most dependencies to their latest versions
