### PR TITLE
Remove unnecessary cast from test file template

### DIFF
--- a/.idea/fileTemplates/WebDriverTestClass.java
+++ b/.idea/fileTemplates/WebDriverTestClass.java
@@ -26,7 +26,7 @@ public class ${NAME} extends BaseWebDriverTest
     @BeforeClass
     public static void setupProject()
     {
-        ${NAME} init = (${NAME})getCurrentTest();
+        ${NAME} init = getCurrentTest();
        
         init.doSetup();
     }


### PR DESCRIPTION
#### Rationale
The casting of `getCurrentTest` is no longer necessary.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/2156

#### Changes
* Remove unnecessary cast from test file template
