### PR TITLE
Force more recent version of jetbrains.kotlin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -288,6 +288,8 @@ allprojects {
                     // force consistency in TCRdb, WNPRC
                     force "org.javassist:javassist:${javassistVersion}"
                     force "org.jetbrains:annotations:${annotationsVersion}"
+                    // force consistency in TCRdb, mfa (Duo SDK)
+                    force "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${intellijKotlinVersion}"
                     // force consistency between API and Java remote API
                     force "org.json:json:${orgJsonVersion}"
                     force "org.ow2.asm:asm:${asmVersion}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -190,6 +190,8 @@ httpcore5Version=5.3
 httpclientVersion=4.5.14
 httpcoreVersion=4.4.16
 
+intellijKotlinVersion=1.9.10
+
 # Jackson dependencies are usually released in tandem, but occasionally one gets a patch release out-of-sync with the others
 jacksonVersion=2.18.0
 jacksonAnnotationsVersion=2.18.0


### PR DESCRIPTION
#### Rationale
With the new Duo SDK, we're seeing discrepancies with kotlin dependencies from tcrdb