### PR TITLE
Minor version updates for dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -304,7 +304,7 @@ allprojects {
                     force "org.bouncycastle:bcprov-jdk18on:${bouncycastleVersion}"
                     // force consistency in docker and connectors and saml
                     force "org.bouncycastle:bcpkix-jdk18on:${bouncycastleVersion}"
-                    // force consistency with netty jar files for docker and UserReg-WS
+                    // docker dependency: force to mitigate CVEs in 4.1.46
                     force "io.netty:netty-resolver:${nettyVersion}"
                     force "io.netty:netty-resolver-dns:${nettyVersion}"
                     force "io.netty:netty-handler:${nettyVersion}"

--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -122,20 +122,6 @@
     </suppress>
 
     <!--
-    GraalJS shaded and re-versioned icu4j without changing the file name, leading to many old CVEs getting tagged.
-    This should be fixed soon, but suppress all CVEs for now. https://github.com/oracle/graal/issues/8204
-    -->
-    <suppress>
-        <notes><![CDATA[
-   file name: icu4j-23.1.2.jar
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.graalvm\.shadowed/icu4j@.*$</packageUrl>
-        <cpe>cpe:/a:icu-project:international_components_for_unicode</cpe>
-        <cpe>cpe:/a:unicode:international_components_for_unicode</cpe>
-        <cpe>cpe:/a:unicode:unicode</cpe>
-    </suppress>
-
-    <!--
     The Tomcat jaspic-api and jsp-api jars are false positives, for some reason matching against Tomcat 3.0. See
     https://github.com/jeremylong/DependencyCheck/issues/5659, which has been raised, but no response.
     -->

--- a/gradle.properties
+++ b/gradle.properties
@@ -121,7 +121,7 @@ commonmarkVersion=0.24.0
 
 # the beanutils version is not the default version brought from commons-validator and/or commons-digester
 # in the :server:api module but is required for some of our code to compile
-commonsBeanutilsVersion=1.9.4
+commonsBeanutilsVersion=1.10.0
 commonsCodecVersion=1.17.1
 commonsCollections4Version=4.4
 commonsCollectionsVersion=3.2.2
@@ -139,7 +139,7 @@ commonsTextVersion=1.13.0
 commonsValidatorVersion=1.9.0
 commonsVfs2Version=2.7.0
 
-datadogVersion=1.44.1
+datadogVersion=1.45.1
 
 dom4jVersion=2.1.4
 
@@ -160,8 +160,6 @@ googleHttpClientVersion=1.45.3
 googleOauthClientVersion=1.37.0
 googleProtocolBufVersion=3.25.5
 
-graalVersion=24.1.1
-
 # Cloud and SequenceAnalysis bring gson in as a transitive dependency.
 # We resolve to the later version here to keep things consistent
 # Note: Current jclouds seems to require 2.8.9; attempting to upgrade to 2.9.0 cratered the S3 test suite with many
@@ -170,7 +168,7 @@ gsonVersion=2.8.9
 
 grpcVersion=1.69.0
 
-guavaVersion=33.3.1-jre
+guavaVersion=33.4.0-jre
 
 # Note: You won't find usages in the product sources; this property is used by the gradle plugin.
 gwtVersion=2.11.0
@@ -228,7 +226,7 @@ jodaTimeVersion=2.13.0
 # brought in transitively from guava and other google packages. Need to resolve consistently
 jsr305Version=3.0.2
 
-orgJsonVersion=20240303
+orgJsonVersion=20250107
 
 jsoupVersion=1.18.3
 
@@ -264,7 +262,7 @@ poiVersion=5.3.0
 
 pollingWatchVersion=0.2.0
 
-postgresqlDriverVersion=42.7.4
+postgresqlDriverVersion=42.7.5
 
 quartzVersion=2.5.0
 
@@ -291,7 +289,7 @@ springBootVersion=3.4.1
 # This usually matches the Spring Framework version dictated by springBootVersion
 springVersion=6.2.1
 
-sqliteJdbcVersion=3.47.1.0
+sqliteJdbcVersion=3.48.0.0
 
 # NLP and SAML bring stax2-api in as a transitive dependency but with very different versions. We force the later version.
 stax2ApiVersion=4.2.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -166,7 +166,7 @@ googleProtocolBufVersion=3.25.5
 # "java.lang.NoSuchMethodError: 'void com.google.gson.internal.ConstructorConstructor.<init>(java.util.Map)'" errors
 gsonVersion=2.8.9
 
-grpcVersion=1.69.0
+grpcVersion=1.69.1
 
 guavaVersion=33.4.0-jre
 
@@ -183,7 +183,7 @@ hamcrestVersion=2.2
 htsjdkVersion=4.0.0
 
 httpclient5Version=5.4.1
-httpcore5Version=5.3.1
+httpcore5Version=5.3.2
 
 # Not used directly, but these are widely used transitive dependencies
 httpclientVersion=4.5.14
@@ -244,8 +244,8 @@ luceneVersion=9.12.1
 
 mssqlJdbcVersion=12.8.1.jre11
 
-# forced compatibility between docker and UserReg-WS
-nettyVersion=4.1.116.Final
+# docker dependency: forced to mitigate CVEs in 4.1.46
+nettyVersion=4.1.117.Final
 
 objenesisVersion=1.0
 


### PR DESCRIPTION
#### Rationale
Updates to keep current

Also, now that GraalJS is gone, remove its version constant and CVE suppression