### PR TITLE
Gradle 8.12

### DIFF
--- a/gradle/settings/all.gradle
+++ b/gradle/settings/all.gradle
@@ -11,7 +11,7 @@ buildscript {
             }
         }
         maven {
-            url "${artifactory_contextUrl}/plugins-release-no-proxy"
+            url = "${artifactory_contextUrl}/plugins-release-no-proxy"
             mavenContent {
                 releasesOnly()
             }

--- a/gradle/settings/distributions.gradle
+++ b/gradle/settings/distributions.gradle
@@ -7,7 +7,7 @@ buildscript {
             }
         }
         maven {
-            url "${artifactory_contextUrl}/plugins-release-no-proxy"
+            url = "${artifactory_contextUrl}/plugins-release-no-proxy"
             mavenContent {
                 releasesOnly()
             }
@@ -20,7 +20,7 @@ buildscript {
         {
             mavenLocal()
             maven {
-                url "${artifactory_contextUrl}/plugins-snapshot-local"
+                url = "${artifactory_contextUrl}/plugins-snapshot-local"
                 mavenContent {
                     snapshotsOnly()
                 }

--- a/gradle/settings/ehr.gradle
+++ b/gradle/settings/ehr.gradle
@@ -7,7 +7,7 @@ buildscript {
             }
         }
         maven {
-            url "${artifactory_contextUrl}/plugins-release-no-proxy"
+            url = "${artifactory_contextUrl}/plugins-release-no-proxy"
             mavenContent {
                 releasesOnly()
             }
@@ -20,7 +20,7 @@ buildscript {
         {
             mavenLocal()
             maven {
-                url "${artifactory_contextUrl}/plugins-snapshot-local"
+                url = "${artifactory_contextUrl}/plugins-snapshot-local"
                 mavenContent {
                     snapshotsOnly()
                 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
#### Rationale
It's the [latest version](https://docs.gradle.org/8.12/release-notes.html)

#### Changes
* Gradle version update
* Update some syntax to non-deprecated versions
