### PR TITLE
Use Log4J consistently

### DIFF
--- a/server/embedded/src/org/labkey/embedded/EmbeddedExtractor.java
+++ b/server/embedded/src/org/labkey/embedded/EmbeddedExtractor.java
@@ -1,8 +1,8 @@
 package org.labkey.embedded;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.labkey.bootstrap.ConfigException;
 
 import java.io.BufferedOutputStream;
@@ -22,7 +22,7 @@ import java.util.zip.ZipInputStream;
 
 public class EmbeddedExtractor
 {
-    private static final Log LOG = LogFactory.getLog(EmbeddedExtractor.class);
+    private static final Logger LOG = LogManager.getLogger(EmbeddedExtractor.class);
     private static final int BUFFER_SIZE = 1024 * 64;
     public static final String LABKEYWEBAPP = "labkeywebapp";
     /**

--- a/server/embedded/src/org/labkey/embedded/LabKeyTomcatServletWebServerFactory.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyTomcatServletWebServerFactory.java
@@ -5,9 +5,9 @@ import org.apache.catalina.core.StandardContext;
 import org.apache.catalina.loader.WebappLoader;
 import org.apache.catalina.startup.Tomcat;
 import org.apache.catalina.valves.JsonAccessLogValve;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.coyote.http11.AbstractHttp11Protocol;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.tomcat.util.descriptor.web.ContextResource;
 import org.labkey.bootstrap.ConfigException;
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
@@ -27,7 +27,7 @@ import static org.labkey.embedded.LabKeyServer.SERVER_SSL_KEYSTORE;
 
 class LabKeyTomcatServletWebServerFactory extends TomcatServletWebServerFactory
 {
-    private static final Log LOG = LogFactory.getLog(LabKeyTomcatServletWebServerFactory.class);
+    private static final Logger LOG = LogManager.getLogger(LabKeyTomcatServletWebServerFactory.class);
     private final LabKeyServer _server;
 
     public LabKeyTomcatServletWebServerFactory(LabKeyServer server)


### PR DESCRIPTION
#### Rationale
We're accidentally using Apache Commons Logging in a couple of classes in the embedded Tomcat code

#### Changes
* Swap in Log4J so we get consistently formatted messages