### PR TITLE
Revert postgres JDBC driver to 42.7.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -121,7 +121,7 @@ commonmarkVersion=0.24.0
 
 # the beanutils version is not the default version brought from commons-validator and/or commons-digester
 # in the :server:api module but is required for some of our code to compile
-commonsBeanutilsVersion=1.9.4
+commonsBeanutilsVersion=1.10.0
 commonsCodecVersion=1.17.1
 commonsCollections4Version=4.4
 commonsCollectionsVersion=3.2.2
@@ -139,7 +139,7 @@ commonsTextVersion=1.13.0
 commonsValidatorVersion=1.9.0
 commonsVfs2Version=2.7.0
 
-datadogVersion=1.44.1
+datadogVersion=1.45.1
 
 dom4jVersion=2.1.4
 
@@ -166,9 +166,9 @@ googleProtocolBufVersion=3.25.5
 # "java.lang.NoSuchMethodError: 'void com.google.gson.internal.ConstructorConstructor.<init>(java.util.Map)'" errors
 gsonVersion=2.8.9
 
-grpcVersion=1.69.0
+grpcVersion=1.69.1
 
-guavaVersion=33.3.1-jre
+guavaVersion=33.4.0-jre
 
 # Note: You won't find usages in the product sources; this property is used by the gradle plugin.
 gwtVersion=2.11.0
@@ -183,7 +183,7 @@ hamcrestVersion=2.2
 htsjdkVersion=4.0.0
 
 httpclient5Version=5.4.1
-httpcore5Version=5.3.1
+httpcore5Version=5.3.2
 
 # Not used directly, but these are widely used transitive dependencies
 httpclientVersion=4.5.14
@@ -264,7 +264,7 @@ poiVersion=5.3.0
 
 pollingWatchVersion=0.2.0
 
-postgresqlDriverVersion=42.7.5
+postgresqlDriverVersion=42.7.4
 
 quartzVersion=2.5.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -228,7 +228,7 @@ jodaTimeVersion=2.13.0
 # brought in transitively from guava and other google packages. Need to resolve consistently
 jsr305Version=3.0.2
 
-orgJsonVersion=20240303
+orgJsonVersion=20250107
 
 jsoupVersion=1.18.3
 
@@ -246,8 +246,8 @@ luceneVersion=9.12.1
 
 mssqlJdbcVersion=12.8.1.jre11
 
-# forced compatibility between docker and UserReg-WS
-nettyVersion=4.1.116.Final
+# docker dependency: forced to mitigate CVEs in 4.1.46
+nettyVersion=4.1.117.Final
 
 objenesisVersion=1.0
 
@@ -264,7 +264,7 @@ poiVersion=5.3.0
 
 pollingWatchVersion=0.2.0
 
-postgresqlDriverVersion=42.7.4
+postgresqlDriverVersion=42.7.5
 
 quartzVersion=2.5.0
 
@@ -291,7 +291,7 @@ springBootVersion=3.4.1
 # This usually matches the Spring Framework version dictated by springBootVersion
 springVersion=6.2.1
 
-sqliteJdbcVersion=3.47.1.0
+sqliteJdbcVersion=3.48.0.0
 
 # NLP and SAML bring stax2-api in as a transitive dependency but with very different versions. We force the later version.
 stax2ApiVersion=4.2.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -121,7 +121,7 @@ commonmarkVersion=0.24.0
 
 # the beanutils version is not the default version brought from commons-validator and/or commons-digester
 # in the :server:api module but is required for some of our code to compile
-commonsBeanutilsVersion=1.10.0
+commonsBeanutilsVersion=1.9.4
 commonsCodecVersion=1.17.1
 commonsCollections4Version=4.4
 commonsCollectionsVersion=3.2.2
@@ -139,7 +139,7 @@ commonsTextVersion=1.13.0
 commonsValidatorVersion=1.9.0
 commonsVfs2Version=2.7.0
 
-datadogVersion=1.45.1
+datadogVersion=1.44.1
 
 dom4jVersion=2.1.4
 
@@ -166,9 +166,9 @@ googleProtocolBufVersion=3.25.5
 # "java.lang.NoSuchMethodError: 'void com.google.gson.internal.ConstructorConstructor.<init>(java.util.Map)'" errors
 gsonVersion=2.8.9
 
-grpcVersion=1.69.1
+grpcVersion=1.69.0
 
-guavaVersion=33.4.0-jre
+guavaVersion=33.3.1-jre
 
 # Note: You won't find usages in the product sources; this property is used by the gradle plugin.
 gwtVersion=2.11.0
@@ -183,7 +183,7 @@ hamcrestVersion=2.2
 htsjdkVersion=4.0.0
 
 httpclient5Version=5.4.1
-httpcore5Version=5.3.2
+httpcore5Version=5.3.1
 
 # Not used directly, but these are widely used transitive dependencies
 httpclientVersion=4.5.14
@@ -228,7 +228,7 @@ jodaTimeVersion=2.13.0
 # brought in transitively from guava and other google packages. Need to resolve consistently
 jsr305Version=3.0.2
 
-orgJsonVersion=20250107
+orgJsonVersion=20240303
 
 jsoupVersion=1.18.3
 
@@ -246,8 +246,8 @@ luceneVersion=9.12.1
 
 mssqlJdbcVersion=12.8.1.jre11
 
-# docker dependency: forced to mitigate CVEs in 4.1.46
-nettyVersion=4.1.117.Final
+# forced compatibility between docker and UserReg-WS
+nettyVersion=4.1.116.Final
 
 objenesisVersion=1.0
 
@@ -264,7 +264,7 @@ poiVersion=5.3.0
 
 pollingWatchVersion=0.2.0
 
-postgresqlDriverVersion=42.7.5
+postgresqlDriverVersion=42.7.4
 
 quartzVersion=2.5.0
 
@@ -291,7 +291,7 @@ springBootVersion=3.4.1
 # This usually matches the Spring Framework version dictated by springBootVersion
 springVersion=6.2.1
 
-sqliteJdbcVersion=3.48.0.0
+sqliteJdbcVersion=3.47.1.0
 
 # NLP and SAML bring stax2-api in as a transitive dependency but with very different versions. We force the later version.
 stax2ApiVersion=4.2.2


### PR DESCRIPTION
#### Rationale
The 42.7.5 update of the postgres JDBC driver has been causing widespread failures on TeamCity. Reverting temporarily to clean things up while I investigate further.

#### Related Pull Requests
* #970 

#### Changes
* Revert postgres JDBC driver to 42.7.4
