### PR TITLE
using `logging.log4j2.config.override` requires jackson-databind

### DIFF
--- a/server/embedded/build.gradle
+++ b/server/embedded/build.gradle
@@ -81,6 +81,9 @@ dependencies {
     implementation "commons-io:commons-io:${commonsIoVersion}"
     implementation "org.apache.logging.log4j:log4j-core:${log4j2Version}"
 
+    // need jackson-databind for advanced log4j configuration options
+    implementation("com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}")
+
     developmentOnly("org.springframework.boot:spring-boot-devtools")
 }
 


### PR DESCRIPTION
#### Rationale
<!-- Rationale describing why this pull request is needed, what behavior it's adding/changing/removing, etc. (replace this comment) -->

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
