### PR TITLE
replace CSP with new default, with start/end markers for auto replacement

### DIFF
--- a/.github/workflows/copy_csp_blocks.yml
+++ b/.github/workflows/copy_csp_blocks.yml
@@ -1,0 +1,190 @@
+name: Copy CSP Blocks
+# Upon merge of a PR in which 'server/configs/application.properties' was updated... 
+# this workflow copies the Content Security Policy blocks to other repos, as marked by:
+# start: "## START OF CSP COPY BLOCK" or "## START OF CSP ENFORCE BLOCK" (to only copy and uncomment the csp.enforce section)
+# end:  "## END OF CSP COPY BLOCK" or "## END OF CSP ENFORCE BLOCK"
+# note: if the contents between the start/end have not changed, it's a no-op, and no PRs are pushed to the target repos
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - fb_*
+    paths:
+      - server/configs/application.properties
+  # TODO remove 'push' later, obviously:
+  push:
+    branches:
+      - fb_*
+    paths:
+      - server/configs/application.properties
+
+jobs:
+  copy_csp:
+    # TODO: restore this: if: github.event.pull_request.merged
+    runs-on: ubuntu-latest
+    outputs:
+      csp_report_on: ${{ steps.cspvars.outputs.csp_report_on }}
+      csp_enforce_off: ${{ steps.cspvars.outputs.csp_enforce_off }}
+      csp_enforce_on: ${{ steps.cspvars.outputs.csp_enforce_on }}
+    steps:
+      - name: Check Out Code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Copy CSP blocks into vars
+        id: cspvars
+        run: |
+          # report block, fixing report-uri for non-teamcity usage:
+          CSP_REPORT_ON=$( awk '/## END OF CSP REPORT BLOCK/{p=0};p;/## START OF CSP REPORT BLOCK/{p=1}' server/configs/application.properties |\
+            sed 's/report-uri /report-uri https:\/\/www.labkey.org/' )
+
+          # enforce block, fixing report-uri for non-teamcity usage, removing useLocalBuild comment, adding upgrade-insecure-requests:
+          CSP_ENFORCE_OFF=$( awk '/## END OF CSP ENFORCE BLOCK/{p=0};p;/## START OF CSP ENFORCE BLOCK/{p=1}' server/configs/application.properties |\
+            sed 's/^#useLocalBuild#/# /' |\
+            sed '/base-uri/a#     upgrade-insecure-requests ;\\' |\
+            sed 's/report-uri /report-uri https:\/\/www.labkey.org/' )
+
+          # enforce block, uncommented:
+          CSP_ENFORCE_ON=$( awk '/## END OF CSP ENFORCE BLOCK/{p=0};p;/## START OF CSP ENFORCE BLOCK/{p=1}' server/configs/application.properties |\
+            sed 's/^#useLocalBuild#//' |\
+            sed '/base-uri/a\    upgrade-insecure-requests ;\\' |\
+            sed 's/report-uri /report-uri https:\/\/www.labkey.org/' )
+        
+          # use unique delimiter for multiline outputs: https://stackoverflow.com/a/74256214
+          delimiter="$(openssl rand -hex 8)"
+
+          echo "csp_report_on<<${delimiter}" >> "${GITHUB_OUTPUT}"
+          echo "$CSP_REPORT_ON" >> "${GITHUB_OUTPUT}"
+          echo "${delimiter}" >> "${GITHUB_OUTPUT}"
+
+          echo "csp_enforce_off<<${delimiter}" >> "${GITHUB_OUTPUT}"
+          echo "$CSP_ENFORCE_OFF" >> "${GITHUB_OUTPUT}"
+          echo "${delimiter}" >> "${GITHUB_OUTPUT}"
+
+          echo "csp_enforce_on<<${delimiter}" >> "${GITHUB_OUTPUT}"
+          echo "$CSP_ENFORCE_ON" >> "${GITHUB_OUTPUT}"
+          echo "${delimiter}" >> "${GITHUB_OUTPUT}"
+
+  paste_csp_into_chef_repo:
+    needs: copy_csp
+    runs-on: ubuntu-latest
+    env:
+      csp_report_on: ${{ needs.copy_csp.outputs.csp_report_on }}
+      csp_enforce_off: ${{ needs.copy_csp.outputs.csp_enforce_off }}
+      ap_file: "cookbooks/lk_appserver/templates/default/application.properties.erb"
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+        with: 
+          repository: labkey-willm/syseng-chef-server # TODO: LabKey/syseng-chef-server
+          token: ${{ secrets.TERRAFORM_TOKEN }}      
+      - name: Paste Into Chef Repo
+        run: |
+          printf "\n\n>>>> $ap_file before I change it:   <<<<\n\n"
+          cat $ap_file
+
+          printf "\n\n>>>> caught csp_report_on env var: <<<<\n$csp_report_on n\n"
+          printf "\n\n>>>> caught csp_enforce_off env var: <<<<\n$csp_enforce_off n\n"
+
+          printf "\n\n>>>> replacing csp blocks in $ap_file <<<<\n\n"
+
+          python <<EOF
+          import os, sys, re
+          fname = os.environ.get('ap_file')
+          os.rename(fname, fname + '.orig')
+          with open(fname + '.orig', 'r') as fin, open(fname, 'w') as fout:
+              data = fin.read()
+              data = re.sub(r'(## START OF CSP REPORT BLOCK \\(DO NOT CHANGE THIS TEXT\\)).*?(## END OF CSP REPORT BLOCK \\(DO NOT CHANGE THIS TEXT\\))',
+                r'\1\n' +
+                os.environ.get('csp_report_on') +
+                r'\n\2', data, flags=re.DOTALL)
+
+              data = re.sub(r'(## START OF CSP ENFORCE BLOCK \\(DO NOT CHANGE THIS TEXT\\)).*?(## END OF CSP ENFORCE BLOCK \\(DO NOT CHANGE THIS TEXT\\))',
+                r'\1\n' +
+                os.environ.get('csp_enforce_off') +
+                r'\n\2', data, flags=re.DOTALL)              
+              fout.write(data)
+          EOF
+
+          printf "\n\n>>>> updated $ap_file:  <<<<\n\n"
+          cat $ap_file
+
+          printf "\n\n>>>> updating chef recipe version <<<<\n\n"
+          NEW_VER=$(grep version cookbooks/lk_appserver/metadata.rb |cut -d '"' -f 2 |awk -F. -v OFS=. '{$NF += 1 ; print}')
+          sed -i 's/\(version.*\)".*"/\1"'$NEW_VER'"/' cookbooks/lk_appserver/metadata.rb
+          sed -i 's/\(lk_appserver .*\)([0-9]*.[0-9]*.[0-9]*)/\1('$NEW_VER')/' Berksfile.lock 
+
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.TERRAFORM_TOKEN }}
+          branch: fb_update_csp_per_${{ github.sha }}
+          title: "update CSP to match commit ${{ github.sha }}"
+          body:  "update CSP to match commit ${{ github.sha }}"
+          commit-message: "update CSP to match commit ${{ github.sha }}"
+          add-paths: |
+            ${{ env.ap_file }}
+            cookbooks/lk_appserver/metadata.rb
+            Berksfile.lock
+          
+      - name: Check outputs
+        if: ${{ steps.cpr.outputs.pull-request-number }}
+        run: |
+          echo "Server Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}" >> $GITHUB_STEP_SUMMARY
+
+  paste_enforce_csp_into_dockerfile_repo:
+    needs: copy_csp
+    runs-on: ubuntu-latest
+    env:
+      csp_enforce_on: ${{ needs.copy_csp.outputs.csp_enforce_on }}
+      ap_file: "application.properties"
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+        with: 
+          repository: labkey-willm/Dockerfile # TODO: Labkey/Dockerfile
+          token: ${{ secrets.TERRAFORM_TOKEN }}
+      - name: Paste Into Dockerfile Repo
+        run: |
+          printf "\n\n>>>> $ap_file before I change it: <<<<\n\n"
+          cat $ap_file
+
+          printf "\n\n>>>> caught csp_enforce_on env var:<<<<\n$csp_enforce_on\n\n"
+
+          printf "\n\n>>>> replacing csp block in $ap_file <<<<\n\n"
+
+          python <<EOF
+          import os, sys, re
+          fname = os.environ.get('ap_file')
+          os.rename(fname, fname + '.orig')
+          with open(fname + '.orig', 'r') as fin, open(fname, 'w') as fout:
+              data = fin.read()
+              data = re.sub(r'(## START OF CSP ENFORCE BLOCK \\(DO NOT CHANGE THIS TEXT\\)).*?(## END OF CSP ENFORCE BLOCK \\(DO NOT CHANGE THIS TEXT\\))',
+                r'\1\n' +
+                os.environ.get('csp_enforce_on') +
+                r'\n\2', data, flags=re.DOTALL)
+              fout.write(data)
+          EOF
+
+          printf "\n\n>>>> updated $ap_file:  <<<<\n\n"
+          cat $ap_file
+
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.TERRAFORM_TOKEN }}
+          branch: fb_update_csp_per_${{ github.sha }}
+          title: "update CSP to match commit ${{ github.sha }}"
+          body:  "update CSP to match commit ${{ github.sha }}"
+          commit-message: "update CSP to match commit ${{ github.sha }}"
+          add-paths: ${{ env.ap_file }}
+
+      - name: Check outputs
+        if: ${{ steps.cpr.outputs.pull-request-number }}
+        run: |
+          echo "Dockerfile Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/copy_csp_blocks.yml
+++ b/.github/workflows/copy_csp_blocks.yml
@@ -13,16 +13,10 @@ on:
       - fb_*
     paths:
       - server/configs/application.properties
-  # TODO remove 'push' later, obviously:
-  push:
-    branches:
-      - fb_*
-    paths:
-      - server/configs/application.properties
 
 jobs:
   copy_csp:
-    # TODO: restore this: if: github.event.pull_request.merged
+    if: github.event.pull_request.merged
     runs-on: ubuntu-latest
     outputs:
       csp_report_on: ${{ steps.cspvars.outputs.csp_report_on }}
@@ -79,7 +73,7 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v4
         with: 
-          repository: labkey-willm/syseng-chef-server # TODO: LabKey/syseng-chef-server
+          repository: LabKey/syseng-chef-server
           token: ${{ secrets.TERRAFORM_TOKEN }}      
       - name: Paste Into Chef Repo
         run: |
@@ -146,7 +140,7 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v4
         with: 
-          repository: labkey-willm/Dockerfile # TODO: Labkey/Dockerfile
+          repository: Labkey/Dockerfile
           token: ${{ secrets.TERRAFORM_TOKEN }}
       - name: Paste Into Dockerfile Repo
         run: |

--- a/.github/workflows/copy_csp_blocks.yml
+++ b/.github/workflows/copy_csp_blocks.yml
@@ -106,10 +106,13 @@ jobs:
           printf "\n\n>>>> updated $ap_file:  <<<<\n\n"
           cat $ap_file
 
-          printf "\n\n>>>> updating chef recipe version <<<<\n\n"
-          NEW_VER=$(grep version cookbooks/lk_appserver/metadata.rb |cut -d '"' -f 2 |awk -F. -v OFS=. '{$NF += 1 ; print}')
-          sed -i 's/\(version.*\)".*"/\1"'$NEW_VER'"/' cookbooks/lk_appserver/metadata.rb
-          sed -i 's/\(lk_appserver .*\)([0-9]*.[0-9]*.[0-9]*)/\1('$NEW_VER')/' Berksfile.lock 
+          git status
+          if [[ $(git diff-index --name-only HEAD |grep application.properties) ]]; then
+            printf "\n\n>>>> changes detected, so updating chef recipe version <<<<\n\n"
+            NEW_VER=$(grep version cookbooks/lk_appserver/metadata.rb |cut -d '"' -f 2 |awk -F. -v OFS=. '{$NF += 1 ; print}') 
+            sed -i 's/\(version.*\)".*"/\1"'$NEW_VER'"/' cookbooks/lk_appserver/metadata.rb
+            sed -i 's/\(lk_appserver .*\)([0-9]*.[0-9]*.[0-9]*)/\1('$NEW_VER')/' Berksfile.lock 
+          fi
 
       - name: Create Pull Request
         id: cpr
@@ -128,7 +131,7 @@ jobs:
       - name: Check outputs
         if: ${{ steps.cpr.outputs.pull-request-number }}
         run: |
-          echo "Server Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}" >> $GITHUB_STEP_SUMMARY
+          echo "Chef Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}" >> $GITHUB_STEP_SUMMARY
 
   paste_enforce_csp_into_dockerfile_repo:
     needs: copy_csp

--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -149,7 +149,6 @@ csp.report=\
 #useLocalBuild#    font-src 'self' data: ;\
 #useLocalBuild#    script-src 'self' 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ;\
 #useLocalBuild#    base-uri 'self' ;\
-#useLocalBuild#    upgrade-insecure-requests ;\
 #useLocalBuild#    frame-ancestors 'self' ;\
 #useLocalBuild#    report-uri /admin-contentsecuritypolicyreport.api?${CSP.REPORT.PARAMS} ;
 ## END OF CSP ENFORCE BLOCK (DO NOT CHANGE THIS TEXT)

--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -125,26 +125,15 @@ management.server.port=@@shutdownPort@@
 #jsonaccesslog.condition-if=attributeName
 #jsonaccesslog.condition-unless=attributeName
 
+## START OF CSP COPY BLOCK (DO NOT CHANGE THIS TEXT)
+
 ## Define one or both of 'csp.report' and 'csp.enforce' to enable Content Security Policy (CSP) headers
 ## Do not use these examples for any production environment without understanding the meaning of each directive!
 
-## Default enforce CSP for dev deployments
-#useLocalBuild#csp.enforce=\
-#useLocalBuild#    default-src 'self' https: http: ;\
-#useLocalBuild#    connect-src 'self' localhost:* ws: ${LABKEY.ALLOWED.CONNECTIONS} ;\
-#useLocalBuild#    object-src 'none' ;\
-#useLocalBuild#    style-src 'self' https: 'unsafe-inline' ;\
-#useLocalBuild#    img-src 'self' https: data: ;\
-#useLocalBuild#    font-src 'self' http: https: data: ;\
-#useLocalBuild#    script-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ;\
-#useLocalBuild#    base-uri 'self' ;\
-#useLocalBuild#    frame-ancestors 'self' ;\
-#useLocalBuild#    report-uri /admin-contentsecuritypolicyreport.api?${CSP.REPORT.PARAMS} ;
-
-## Default report CSP for TeamCity and dev deployments
+## Default CSP for LabKey Cloud deployments
 csp.report=\
     default-src 'self' https: http: ;\
-    connect-src 'self' localhost:* ws: ${LABKEY.ALLOWED.CONNECTIONS} ;\
+    connect-src 'self' localhost:* ${LABKEY.ALLOWED.CONNECTIONS} ;\
     object-src 'none' ;\
     style-src 'self' https: 'unsafe-inline' ;\
     img-src 'self' https: data: ;\
@@ -152,7 +141,23 @@ csp.report=\
     script-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ;\
     base-uri 'self' ;\
     frame-ancestors 'self' ;\
-    report-uri /admin-contentsecuritypolicyreport.api?${CSP.REPORT.PARAMS} ;
+    report-uri https://www.labkey.org/admin-contentsecuritypolicyreport.api?${CSP.REPORT.PARAMS} ;
+
+## START OF CSP ENFORCE BLOCK (DO NOT CHANGE THIS TEXT)
+# csp.enforce=\
+#    default-src 'self';\
+#    connect-src 'self' ${LABKEY.ALLOWED.CONNECTIONS} ;\
+#    object-src 'none' ;\
+#    style-src 'self' 'unsafe-inline' ;\
+#    img-src 'self' data: ;\
+#    font-src 'self' data: ;\
+#    script-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}';\
+#    base-uri 'self' ;\
+#    upgrade-insecure-requests ;\
+#    frame-ancestors 'self' ;\
+#    report-uri https://www.labkey.org/admin-contentsecuritypolicyreport.api?${CSP.REPORT.PARAMS} ;
+
+## END OF CSP COPY BLOCK (DO NOT CHANGE THIS TEXT)
 
 ## Use a custom logging configuration
 #logging.config=path/to/alternative/log4j2.xml

--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -125,20 +125,6 @@ management.server.port=@@shutdownPort@@
 #jsonaccesslog.condition-if=attributeName
 #jsonaccesslog.condition-unless=attributeName
 
-## START OF CSP REPORT BLOCK (DO NOT CHANGE THIS TEXT)
-csp.report=\
-    default-src 'self' ;\
-    connect-src 'self' ${LABKEY.ALLOWED.CONNECTIONS} ;\
-    object-src 'none' ;\
-    style-src 'self' 'unsafe-inline' ;\
-    img-src 'self' data: ;\
-    font-src 'self' data: ;\
-    script-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ;\
-    base-uri 'self' ;\
-    frame-ancestors 'self' ;\
-    report-uri /admin-contentsecuritypolicyreport.api?${CSP.REPORT.PARAMS} ;
-## END OF CSP REPORT BLOCK (DO NOT CHANGE THIS TEXT)
-
 ## START OF CSP ENFORCE BLOCK (DO NOT CHANGE THIS TEXT)
 #useLocalBuild#csp.enforce=\
 #useLocalBuild#    default-src 'self' https: ;\
@@ -152,6 +138,20 @@ csp.report=\
 #useLocalBuild#    frame-ancestors 'self' ;\
 #useLocalBuild#    report-uri /admin-contentsecuritypolicyreport.api?${CSP.REPORT.PARAMS} ;
 ## END OF CSP ENFORCE BLOCK (DO NOT CHANGE THIS TEXT)
+
+## START OF CSP REPORT BLOCK (DO NOT CHANGE THIS TEXT)
+csp.report=\
+    default-src 'self' ;\
+    connect-src 'self' ${LABKEY.ALLOWED.CONNECTIONS} ;\
+    object-src 'none' ;\
+    style-src 'self' 'unsafe-inline' ;\
+    img-src 'self' data: ;\
+    font-src 'self' data: ;\
+    script-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ;\
+    base-uri 'self' ;\
+    frame-ancestors 'self' ;\
+    report-uri /admin-contentsecuritypolicyreport.api?${CSP.REPORT.PARAMS} ;
+## END OF CSP REPORT BLOCK (DO NOT CHANGE THIS TEXT)
 
 ## Use a custom logging configuration
 #logging.config=path/to/alternative/log4j2.xml

--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -125,39 +125,34 @@ management.server.port=@@shutdownPort@@
 #jsonaccesslog.condition-if=attributeName
 #jsonaccesslog.condition-unless=attributeName
 
-## START OF CSP COPY BLOCK (DO NOT CHANGE THIS TEXT)
-
-## Define one or both of 'csp.report' and 'csp.enforce' to enable Content Security Policy (CSP) headers
-## Do not use these examples for any production environment without understanding the meaning of each directive!
-
-## Default CSP for LabKey Cloud deployments
+## START OF CSP REPORT BLOCK (DO NOT CHANGE THIS TEXT)
 csp.report=\
-    default-src 'self' https: http: ;\
-    connect-src 'self' localhost:* ${LABKEY.ALLOWED.CONNECTIONS} ;\
+    default-src 'self' ;\
+    connect-src 'self' ${LABKEY.ALLOWED.CONNECTIONS} ;\
     object-src 'none' ;\
-    style-src 'self' https: 'unsafe-inline' ;\
-    img-src 'self' https: data: ;\
-    font-src 'self' http: https: data: ;\
+    style-src 'self' 'unsafe-inline' ;\
+    img-src 'self' data: ;\
+    font-src 'self' data: ;\
     script-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ;\
     base-uri 'self' ;\
     frame-ancestors 'self' ;\
-    report-uri https://www.labkey.org/admin-contentsecuritypolicyreport.api?${CSP.REPORT.PARAMS} ;
+    report-uri /admin-contentsecuritypolicyreport.api?${CSP.REPORT.PARAMS} ;
+## END OF CSP REPORT BLOCK (DO NOT CHANGE THIS TEXT)
 
 ## START OF CSP ENFORCE BLOCK (DO NOT CHANGE THIS TEXT)
-# csp.enforce=\
-#    default-src 'self';\
-#    connect-src 'self' ${LABKEY.ALLOWED.CONNECTIONS} ;\
-#    object-src 'none' ;\
-#    style-src 'self' 'unsafe-inline' ;\
-#    img-src 'self' data: ;\
-#    font-src 'self' data: ;\
-#    script-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}';\
-#    base-uri 'self' ;\
-#    upgrade-insecure-requests ;\
-#    frame-ancestors 'self' ;\
-#    report-uri https://www.labkey.org/admin-contentsecuritypolicyreport.api?${CSP.REPORT.PARAMS} ;
-
-## END OF CSP COPY BLOCK (DO NOT CHANGE THIS TEXT)
+#useLocalBuild#csp.enforce=\
+#useLocalBuild#    default-src 'self' https: ;\
+#useLocalBuild#    connect-src 'self' ${LABKEY.ALLOWED.CONNECTIONS} ;\
+#useLocalBuild#    object-src 'none' ;\
+#useLocalBuild#    style-src 'self' https: 'unsafe-inline' ;\
+#useLocalBuild#    img-src 'self' https: data: ;\
+#useLocalBuild#    font-src 'self' data: ;\
+#useLocalBuild#    script-src 'self' 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ;\
+#useLocalBuild#    base-uri 'self' ;\
+#useLocalBuild#    upgrade-insecure-requests ;\
+#useLocalBuild#    frame-ancestors 'self' ;\
+#useLocalBuild#    report-uri /admin-contentsecuritypolicyreport.api?${CSP.REPORT.PARAMS} ;
+## END OF CSP ENFORCE BLOCK (DO NOT CHANGE THIS TEXT)
 
 ## Use a custom logging configuration
 #logging.config=path/to/alternative/log4j2.xml


### PR DESCRIPTION
#### Rationale
https://github.com/LabKey/kanban/issues/362

we're going to use the `server` repo's Content Security Policy as the source going forward. Updates there will be automatically sent to `syseng-chef-server` and `Dockerfile` repos.

Both report and enforce policies are copied in full to `syseng-chef-server`, with minor changes performed by the action. The 'enforce' policy is copied and uncommented to LabKey/Dockerfile/application.properties.

more on the action:

* Upon merge of a PR in which 'server/configs/application.properties' was updated, it copies the Content Security Policy blocks to other repos, as marked by:
* start: "## START OF CSP COPY BLOCK" or "## START OF CSP ENFORCE BLOCK" (to only copy and uncomment the csp.enforce section)
* end:  "## END OF CSP COPY BLOCK" or "## START OF CSP ENFORCE BLOCK"
* note: if the contents between the start/end have not changed, it's a no-op, and no PRs are pushed to the target repos

#### Related Pull Requests
* https://github.com/LabKey/terraform_module_ecs_service_lkapps/pull/30
* https://github.com/LabKey/syseng-chef-server/pull/608
* https://github.com/LabKey/Dockerfile/pull/135
* https://github.com/LabKey/terraform_cloud/pull/2073

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
