### PR TITLE
add comments to help explain usages of the various CSP declarations

### DIFF
--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -125,7 +125,6 @@ management.server.port=@@shutdownPort@@
 #jsonaccesslog.condition-if=attributeName
 #jsonaccesslog.condition-unless=attributeName
 
-#### Example enforced CSP for local development
 ## START OF CSP ENFORCE BLOCK (DO NOT CHANGE THIS TEXT)
 #useLocalBuild#csp.enforce=\
 #useLocalBuild#    default-src 'self' https: ;\

--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -150,7 +150,7 @@ csp.report=\
     font-src 'self' data: ;                                                         /* Allowed font sources */\
     script-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ;     /* Allowed sources for script tags */\
     base-uri 'self' ;                                                               /* Allowed sources for base tags */\
-    frame-ancestors 'self' ;                                                        /* Allowed sources for embeded and other framed resourcees */\
+    frame-ancestors 'self' ;                                                        /* Allowed parents for embedding or framing the current resource */\
     report-uri /admin-contentsecuritypolicyreport.api?${CSP.REPORT.PARAMS} ;        /* Enables browser generated reports of any encountered CSP conflicts to the supplied URL */
 ## END OF CSP REPORT BLOCK (DO NOT CHANGE THIS TEXT)
 

--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -141,16 +141,16 @@ management.server.port=@@shutdownPort@@
 
 ## START OF CSP REPORT BLOCK (DO NOT CHANGE THIS TEXT)
 csp.report=\
-    default-src 'self' ;                                                            /* Default sourcing locations for resources if explicit declarations not present */\
-    connect-src 'self' ${LABKEY.ALLOWED.CONNECTIONS} ;                              /* Allowed connection sources, can be substituted and appended via the LabKey Admin UI */\
-    object-src 'none' ;                                                             /* Allowed sources for object, embed, and applet tags */\
-    style-src 'self' 'unsafe-inline' ;                                              /* Allowed sources for style tags */\
-    img-src 'self' data: ;                                                          /* Allowed sources for imgages */\
-    font-src 'self' data: ;                                                         /* Allowed font sources */\
-    script-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ;     /* Allowed sources for script tags */\
-    base-uri 'self' ;                                                               /* Allowed sources for base tags */\
-    frame-ancestors 'self' ;                                                        /* Allowed parents for embedding or framing the current resource */\
-    report-uri /admin-contentsecuritypolicyreport.api?${CSP.REPORT.PARAMS} ;        /* Enables browser generated reports of any encountered CSP conflicts to the supplied URL */
+    default-src 'self' ;                                                            /* Limit the default to only the current server */\
+    connect-src 'self' ${LABKEY.ALLOWED.CONNECTIONS} ;                              /* For security purposes limit allowed connection sources, can be substituted and appended via the LabKey Admin UI */\
+    object-src 'none' ;                                                             /* These tags are not currently used by LKS */\
+    style-src 'self' 'unsafe-inline' ;                                              /* We currently have a few inline <style> tags that we are weeding out */\
+    img-src 'self' data: ;                                                          /* Limit image loading locations */\
+    font-src 'self' data: ;                                                         /* Limit font source loading locations */\
+    script-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ;     /* Limit scripts that are allowed to those with nonces or transitive scripts */\
+    base-uri 'self' ;                                                               /* Limit the base tags to only source from current server */\
+    frame-ancestors 'self' ;                                                        /* Only allow embedding resources to the current server */\
+    report-uri /admin-contentsecuritypolicyreport.api?${CSP.REPORT.PARAMS} ;        /* Reports any encountered CSP conflicts to the supplied URL */
 ## END OF CSP REPORT BLOCK (DO NOT CHANGE THIS TEXT)
 
 ## Use a custom logging configuration

--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -125,6 +125,7 @@ management.server.port=@@shutdownPort@@
 #jsonaccesslog.condition-if=attributeName
 #jsonaccesslog.condition-unless=attributeName
 
+#### Example enforced CSP for local development
 ## START OF CSP ENFORCE BLOCK (DO NOT CHANGE THIS TEXT)
 #useLocalBuild#csp.enforce=\
 #useLocalBuild#    default-src 'self' https: ;\
@@ -141,16 +142,16 @@ management.server.port=@@shutdownPort@@
 
 ## START OF CSP REPORT BLOCK (DO NOT CHANGE THIS TEXT)
 csp.report=\
-    default-src 'self' ;\
-    connect-src 'self' ${LABKEY.ALLOWED.CONNECTIONS} ;\
-    object-src 'none' ;\
-    style-src 'self' 'unsafe-inline' ;\
-    img-src 'self' data: ;\
-    font-src 'self' data: ;\
-    script-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ;\
-    base-uri 'self' ;\
-    frame-ancestors 'self' ;\
-    report-uri /admin-contentsecuritypolicyreport.api?${CSP.REPORT.PARAMS} ;
+    default-src 'self' ;                                                            /* Default sourcing locations for resources if explicit declarations not present */\
+    connect-src 'self' ${LABKEY.ALLOWED.CONNECTIONS} ;                              /* Allowed connection sources, can be substituted and appended via the LabKey Admin UI */\
+    object-src 'none' ;                                                             /* Allowed sources for object, embed, and applet tags */\
+    style-src 'self' 'unsafe-inline' ;                                              /* Allowed sources for style tags */\
+    img-src 'self' data: ;                                                          /* Allowed sources for imgages */\
+    font-src 'self' data: ;                                                         /* Allowed font sources */\
+    script-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ;     /* Allowed sources for script tags */\
+    base-uri 'self' ;                                                               /* Allowed sources for base tags */\
+    frame-ancestors 'self' ;                                                        /* Allowed sources for embeded and other framed resourcees */\
+    report-uri /admin-contentsecuritypolicyreport.api?${CSP.REPORT.PARAMS} ;        /* Enables browser generated reports of any encountered CSP conflicts to the supplied URL */
 ## END OF CSP REPORT BLOCK (DO NOT CHANGE THIS TEXT)
 
 ## Use a custom logging configuration


### PR DESCRIPTION
-- Note: comments are removed during application execution, so they do not appear in the Response Header

#### Rationale
Add comments to the CSP

#### Changes
* add explanatory comments to the CSP declarations