### PR TITLE
Restore http and https for font-src in CSP for app dev hot module reloading

### DIFF
--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -132,7 +132,7 @@ management.server.port=@@shutdownPort@@
 #useLocalBuild#    object-src 'none' ;\
 #useLocalBuild#    style-src 'self' https: 'unsafe-inline' ;\
 #useLocalBuild#    img-src 'self' https: data: ;\
-#useLocalBuild#    font-src 'self' data: ;\
+#useLocalBuild#    font-src 'self' http: https: data: ;\
 #useLocalBuild#    script-src 'self' 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ;\
 #useLocalBuild#    base-uri 'self' ;\
 #useLocalBuild#    frame-ancestors 'self' ;\
@@ -146,7 +146,7 @@ csp.report=\
     object-src 'none' ;                                                             /* These tags are not currently used by LKS */\
     style-src 'self' 'unsafe-inline' ;                                              /* We currently have a few inline <style> tags that we are weeding out */\
     img-src 'self' data: ;                                                          /* Limit image loading locations */\
-    font-src 'self' data: ;                                                         /* Limit font source loading locations */\
+    font-src 'self' http: https: data: ;                                                         /* Limit font source loading locations */\
     script-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ;     /* Limit scripts that are allowed to those with nonces or transitive scripts */\
     base-uri 'self' ;                                                               /* Limit the base tags to only source from current server */\
     frame-ancestors 'self' ;                                                        /* Only allow embedding resources to the current server */\


### PR DESCRIPTION
#### Rationale
The related PR made some changes to the default CSP. The change to the font-src property broke some things in the client side application hot module reloading dev experience related to how our fonts/icons are loaded.

<img width="1337" alt="Screenshot 2025-02-18 at 11 27 04 AM" src="https://github.com/user-attachments/assets/473a53ae-7621-4a93-83fe-1c6afa4fa2ce" />

#### Related Pull Requests
- https://github.com/LabKey/server/pull/984

#### Changes
- Restore http and https for font-src in CSP for app dev hot module reloading
