### PR TITLE
Support adding module-specific resource hosts to more CSP directives

### DIFF
--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -128,30 +128,30 @@ management.server.port=@@shutdownPort@@
 ## START OF CSP ENFORCE BLOCK (DO NOT CHANGE THIS TEXT)
 #useLocalBuild#csp.enforce=\
 #useLocalBuild#    default-src 'self' https: ;\
-#useLocalBuild#    connect-src 'self' ${LABKEY.ALLOWED.CONNECTION.SOURCES} ;\
+#useLocalBuild#    connect-src 'self' ${CONNECTION.SOURCES} ;\
 #useLocalBuild#    object-src 'none' ;\
-#useLocalBuild#    style-src 'self' https: 'unsafe-inline' ${LABKEY.ALLOWED.STYLE.SOURCES} ;\
+#useLocalBuild#    style-src 'self' https: 'unsafe-inline' ${STYLE.SOURCES} ;\
 #useLocalBuild#    img-src 'self' https: data: ;\
-#useLocalBuild#    font-src 'self' data: ${LABKEY.ALLOWED.FONT.SOURCES} ;\
+#useLocalBuild#    font-src 'self' data: ${FONT.SOURCES} ;\
 #useLocalBuild#    script-src 'self' 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ;\
 #useLocalBuild#    base-uri 'self' ;\
 #useLocalBuild#    frame-ancestors 'self' ;\
-#useLocalBuild#    frame-src ${LABKEY.ALLOWED.FRAME.SOURCES} ;\
+#useLocalBuild#    frame-src ${FRAME.SOURCES} ;\
 #useLocalBuild#    report-uri /admin-contentsecuritypolicyreport.api?${CSP.REPORT.PARAMS} ;
 ## END OF CSP ENFORCE BLOCK (DO NOT CHANGE THIS TEXT)
 
 ## START OF CSP REPORT BLOCK (DO NOT CHANGE THIS TEXT)
 csp.report=\
     default-src 'self' ;                                                            /* Limit the default to only the current server */\
-    connect-src 'self' ${LABKEY.ALLOWED.CONNECTION.SOURCES} ;                       /* For security purposes limit allowed connection sources, can be substituted and appended via the LabKey Admin UI */\
+    connect-src 'self' ${CONNECTION.SOURCES} ;                                      /* For security purposes limit allowed connection sources, can be substituted and appended via the LabKey Admin UI */\
     object-src 'none' ;                                                             /* These tags are not currently used by LKS */\
-    style-src 'self' 'unsafe-inline' ${LABKEY.ALLOWED.STYLE.SOURCES} ;              /* We currently have a few inline <style> tags that we are weeding out */\
+    style-src 'self' 'unsafe-inline' ${STYLE.SOURCES} ;                             /* We currently have a few inline <style> tags that we are weeding out */\
     img-src 'self' data: ;                                                          /* Limit image loading locations */\
-    font-src 'self' data: ${LABKEY.ALLOWED.FONT.SOURCES} ;                          /* Limit font source loading locations */\
+    font-src 'self' data: ${FONT.SOURCES} ;                                         /* Limit font source loading locations */\
     script-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ;     /* Limit scripts that are allowed to those with nonces or transitive scripts */\
     base-uri 'self' ;                                                               /* Limit the base tags to only source from current server */\
     frame-ancestors 'self' ;                                                        /* Only allow embedding resources to the current server */\
-    frame-src ${LABKEY.ALLOWED.FRAME.SOURCES} ;                                     /* Only allow explicitly declared frame sources */\
+    frame-src ${FRAME.SOURCES} ;                                                    /* Only allow explicitly declared frame sources */\
     report-uri /admin-contentsecuritypolicyreport.api?${CSP.REPORT.PARAMS} ;        /* Reports any encountered CSP conflicts to the supplied URL */
 ## END OF CSP REPORT BLOCK (DO NOT CHANGE THIS TEXT)
 

--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -128,28 +128,30 @@ management.server.port=@@shutdownPort@@
 ## START OF CSP ENFORCE BLOCK (DO NOT CHANGE THIS TEXT)
 #useLocalBuild#csp.enforce=\
 #useLocalBuild#    default-src 'self' https: ;\
-#useLocalBuild#    connect-src 'self' ${LABKEY.ALLOWED.CONNECTIONS} ;\
+#useLocalBuild#    connect-src 'self' ${LABKEY.ALLOWED.CONNECTION.SOURCES} ;\
 #useLocalBuild#    object-src 'none' ;\
-#useLocalBuild#    style-src 'self' https: 'unsafe-inline' ;\
+#useLocalBuild#    style-src 'self' https: 'unsafe-inline' ${LABKEY.ALLOWED.STYLE.SOURCES} ;\
 #useLocalBuild#    img-src 'self' https: data: ;\
-#useLocalBuild#    font-src 'self' data: ;\
+#useLocalBuild#    font-src 'self' data: ${LABKEY.ALLOWED.FONT.SOURCES} ;\
 #useLocalBuild#    script-src 'self' 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ;\
 #useLocalBuild#    base-uri 'self' ;\
 #useLocalBuild#    frame-ancestors 'self' ;\
+#useLocalBuild#    frame-src ${LABKEY.ALLOWED.FRAME.SOURCES} ;\
 #useLocalBuild#    report-uri /admin-contentsecuritypolicyreport.api?${CSP.REPORT.PARAMS} ;
 ## END OF CSP ENFORCE BLOCK (DO NOT CHANGE THIS TEXT)
 
 ## START OF CSP REPORT BLOCK (DO NOT CHANGE THIS TEXT)
 csp.report=\
     default-src 'self' ;                                                            /* Limit the default to only the current server */\
-    connect-src 'self' ${LABKEY.ALLOWED.CONNECTIONS} ;                              /* For security purposes limit allowed connection sources, can be substituted and appended via the LabKey Admin UI */\
+    connect-src 'self' ${LABKEY.ALLOWED.CONNECTION.SOURCES} ;                       /* For security purposes limit allowed connection sources, can be substituted and appended via the LabKey Admin UI */\
     object-src 'none' ;                                                             /* These tags are not currently used by LKS */\
-    style-src 'self' 'unsafe-inline' ;                                              /* We currently have a few inline <style> tags that we are weeding out */\
+    style-src 'self' 'unsafe-inline' ${LABKEY.ALLOWED.STYLE.SOURCES} ;              /* We currently have a few inline <style> tags that we are weeding out */\
     img-src 'self' data: ;                                                          /* Limit image loading locations */\
-    font-src 'self' data: ;                                                         /* Limit font source loading locations */\
+    font-src 'self' data: ${LABKEY.ALLOWED.FONT.SOURCES} ;                          /* Limit font source loading locations */\
     script-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ;     /* Limit scripts that are allowed to those with nonces or transitive scripts */\
     base-uri 'self' ;                                                               /* Limit the base tags to only source from current server */\
     frame-ancestors 'self' ;                                                        /* Only allow embedding resources to the current server */\
+    frame-src ${LABKEY.ALLOWED.FRAME.SOURCES} ;                                     /* Only allow explicitly declared frame sources */\
     report-uri /admin-contentsecuritypolicyreport.api?${CSP.REPORT.PARAMS} ;        /* Reports any encountered CSP conflicts to the supplied URL */
 ## END OF CSP REPORT BLOCK (DO NOT CHANGE THIS TEXT)
 

--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -136,7 +136,7 @@ management.server.port=@@shutdownPort@@
 #useLocalBuild#    script-src 'self' 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ;\
 #useLocalBuild#    base-uri 'self' ;\
 #useLocalBuild#    frame-ancestors 'self' ;\
-#useLocalBuild#    frame-src ${FRAME.SOURCES} ;\
+#useLocalBuild#    frame-src 'self' ${FRAME.SOURCES} ;\
 #useLocalBuild#    report-uri /admin-contentsecuritypolicyreport.api?${CSP.REPORT.PARAMS} ;
 ## END OF CSP ENFORCE BLOCK (DO NOT CHANGE THIS TEXT)
 
@@ -150,8 +150,8 @@ csp.report=\
     font-src 'self' data: ${FONT.SOURCES} ;                                         /* Limit font source loading locations */\
     script-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ;     /* Limit scripts that are allowed to those with nonces or transitive scripts */\
     base-uri 'self' ;                                                               /* Limit the base tags to only source from current server */\
-    frame-ancestors 'self' ;                                                        /* Only allow embedding resources to the current server */\
-    frame-src ${FRAME.SOURCES} ;                                                    /* Only allow explicitly declared frame sources */\
+    frame-ancestors 'self' ;                                                        /* Only allow iframe resources to the current server */\
+    frame-src 'self' ${FRAME.SOURCES} ;                                             /* Only allow iframe resources from the current server plus explicitly declared external sources */\
     report-uri /admin-contentsecuritypolicyreport.api?${CSP.REPORT.PARAMS} ;        /* Reports any encountered CSP conflicts to the supplied URL */
 ## END OF CSP REPORT BLOCK (DO NOT CHANGE THIS TEXT)
 


### PR DESCRIPTION
#### Rationale
Modules need the ability to allow specific font, style, frame, etc. hosts that they require

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/6345