### PR TITLE
fix csp action; add space to trigger csp action

### DIFF
--- a/.github/workflows/copy_csp_blocks.yml
+++ b/.github/workflows/copy_csp_blocks.yml
@@ -10,7 +10,7 @@ on:
     types:
       - closed
     branches:
-      - fb_*
+      - develop
     paths:
       - server/configs/application.properties
 

--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -161,3 +161,4 @@ csp.report=\
 ## File-based Tomcat HTTP access logs are enabled by default and use our recommended pattern. Override as needed.
 #server.tomcat.accesslog.enabled=false
 #server.tomcat.accesslog.pattern=%h %l %u %t "%r" %s %b %D %S %I "%{Referer}i" "%{User-Agent}i" %{LABKEY.username}s %{X-Forwarded-For}i
+


### PR DESCRIPTION
#### Rationale
The Copy CSP action was not triggering on PR merge because I had it pointed at fb_* branches instead of develop (which worked for push triggers but not merged PRs).

I also added a newline to application.properties so that the action will trigger once this PR is merged, to copy latest updates to Chef and Dockerfile repos, which were missed by the action not firing after https://github.com/LabKey/server/pull/996 was merged.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
