### PR TITLE
Update dependency checker tool to 12.1.0

### DIFF
--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -387,5 +387,30 @@
         <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat/tomcat-catalina@.*$</packageUrl>
         <vulnerabilityName>CVE-2024-56337</vulnerabilityName>
     </suppress>
+    
+    <!--
+    False positives: labkey-api-client.jar is getting tagged as an old version of LabKey Server
+    -->
+    <suppress>
+       <notes><![CDATA[
+   file name: labkey-client-api-6.2.0.jar
+   ]]></notes>
+       <packageUrl regex="true">^pkg:maven/org\.labkey\.api/labkey-client-api@.*$</packageUrl>
+       <cve>CVE-2019-3911</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: labkey-client-api-6.2.0.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.labkey\.api/labkey-client-api@.*$</packageUrl>
+        <cve>CVE-2019-3912</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: labkey-client-api-6.2.0.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.labkey\.api/labkey-client-api@.*$</packageUrl>
+        <cve>CVE-2019-3913</cve>
+    </suppress>
 </suppressions>
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -60,7 +60,7 @@ windowsProteomicsBinariesVersion=1.0
 artifactoryPluginVersion=5.2.5
 gradleNodePluginVersion=3.5.1
 gradlePluginsVersion=4.2.0
-owaspDependencyCheckPluginVersion=11.0.0
+owaspDependencyCheckPluginVersion=12.1.0
 versioningPluginVersion=1.1.2
 
 # Versions of node and npm to use during the build. If set, these versions


### PR DESCRIPTION
#### Rationale
Recent release of the dependency tool introduced a breaking change

#### Changes
* Upgrade the tool's version
* Suppress false positives