### PR TITLE
Issue 52415:Adjust configuration for Tomcat error pages

### DIFF
--- a/server/embedded/src/org/labkey/embedded/LabKeyErrorReportValve.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyErrorReportValve.java
@@ -1,0 +1,13 @@
+package org.labkey.embedded;
+
+import org.apache.catalina.valves.ErrorReportValve;
+
+/** Issue 52415: Allow for Configuration of Default Error Page */
+public class LabKeyErrorReportValve extends ErrorReportValve
+{
+    public LabKeyErrorReportValve()
+    {
+        // Don't show Tomcat version info on its 404 and other error pages
+        setShowServerInfo(false);
+    }
+}

--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -75,7 +75,11 @@ public class LabKeyServer
 
                 "server.tomcat.accesslog.enabled", "true",
                 "server.tomcat.accesslog.pattern", "%h %l %u %t \"%r\" %s %b %D %S %I \"%{Referer}i\" \"%{User-Agent}i\" %{LABKEY.username}s %{X-Forwarded-For}i",
-                "jsonaccesslog.pattern", "%h %t %m %U %s %b %D %S \"%{Referer}i\" \"%{User-Agent}i\" %{LABKEY.username}s %{X-Forwarded-For}i"
+                "jsonaccesslog.pattern", "%h %t %m %U %s %b %D %S \"%{Referer}i\" \"%{User-Agent}i\" %{LABKEY.username}s %{X-Forwarded-For}i",
+
+                // Issue 52415: Omit stack traces from Tomcat error pages by default, but propagate error messages
+                "server.error.include-stacktrace", "never",
+                "server.error.include-message", "always"
         ));
         application.setBannerMode(Banner.Mode.OFF);
         application.run(args);

--- a/server/embedded/src/org/labkey/embedded/LabKeyTomcatServletWebServerFactory.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyTomcatServletWebServerFactory.java
@@ -1,7 +1,9 @@
 package org.labkey.embedded;
 
+import org.apache.catalina.Container;
 import org.apache.catalina.Host;
 import org.apache.catalina.core.StandardContext;
+import org.apache.catalina.core.StandardHost;
 import org.apache.catalina.loader.WebappLoader;
 import org.apache.catalina.startup.Tomcat;
 import org.apache.catalina.valves.JsonAccessLogValve;
@@ -52,6 +54,14 @@ class LabKeyTomcatServletWebServerFactory extends TomcatServletWebServerFactory
                 {
                     handler.setUseSendfile(props.getUseSendfile());
                 }
+            }
+        });
+
+        addContextCustomizers(context -> {
+            final Container parent = context.getParent();
+            if (parent instanceof StandardHost sh)
+            {
+                sh.setErrorReportValveClass(LabKeyErrorReportValve.class.getName());
             }
         });
     }


### PR DESCRIPTION
#### Rationale
We can simplify the Tomcat error page to reduce unneeded info, like the version number

#### Changes
* Suppress Tomcat version number
* Show messages by default, but not stack traces