### PR TITLE
Simplify default application.properties related to Tomcat error pages

### DIFF
--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -15,9 +15,6 @@ server.port=@@serverPort@@
 #server.ssl.key-store-type=PKCS12
 #server.ssl.ciphers=HIGH:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!kRSA:!EDH:!DHE:!DH:!CAMELLIA:!ARIA:!AESCCM:!SHA:!CHACHA20
 
-server.error.include-stacktrace=always
-server.error.include-message=always
-
 ## HTTP-only port for servers that need to handle both HTTPS (configure via server.port and server.ssl above) and HTTP
 #context.httpPort=8080
 


### PR DESCRIPTION
#### Rationale
Tomcat stack traces aren't very interesting for us, and we've moved the error message setting into `LabKeyServer.java` to make it the true default

#### Changes
* Trim two Tomcat-specific error page settings