### PR TITLE
Set strong CSP: enforce for development, report-only for production

### DIFF
--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -124,17 +124,17 @@ management.server.port=@@shutdownPort@@
 
 ## START OF CSP ENFORCE BLOCK (DO NOT CHANGE THIS TEXT)
 #useLocalBuild#csp.enforce=\
-#useLocalBuild#    default-src 'self' https: ; \
-#useLocalBuild#    connect-src 'self' ${CONNECTION.SOURCES} ; \
-#useLocalBuild#    object-src 'none' ; \
-#useLocalBuild#    style-src 'self' https: 'unsafe-inline' ${STYLE.SOURCES} ; \
-#useLocalBuild#    img-src 'self' https: data: ${IMAGE.SOURCES} ; \
-#useLocalBuild#    font-src 'self' data: ${FONT.SOURCES} ; \
-#useLocalBuild#    script-src 'self' 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ; \
-#useLocalBuild#    base-uri 'self' ; \
-#useLocalBuild#    frame-ancestors 'self' ; \
-#useLocalBuild#    frame-src 'self' ${FRAME.SOURCES} ; \
-#useLocalBuild#    report-uri /admin-contentSecurityPolicyReport.api?cspVersion=e10&${CSP.REPORT.PARAMS} ;
+#useLocalBuild#    default-src 'self' ;                                                                    /* Limit the default to only the current server */\
+#useLocalBuild#    connect-src 'self' ${CONNECTION.SOURCES} ;                                              /* Limit allowed connection sources */\
+#useLocalBuild#    object-src 'none' ;                                                                     /* These tags are not currently used by LKS */\
+#useLocalBuild#    style-src 'self' 'unsafe-inline' ${STYLE.SOURCES} ;                                     /* We currently have a few inline <style> tags that we are weeding out */\
+#useLocalBuild#    img-src 'self' data: ${IMAGE.SOURCES} ;                                                 /* Limit image loading locations */\
+#useLocalBuild#    font-src 'self' data: ${FONT.SOURCES} ;                                                 /* Limit font source loading locations */\
+#useLocalBuild#    script-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ;             /* Limit scripts to those with nonces or transitive scripts */\
+#useLocalBuild#    base-uri 'self' ;                                                                       /* Limit the base tags to only source from current server */\
+#useLocalBuild#    frame-ancestors 'self' ;                                                                /* Limit iframe content destinations (who can load this server's content into an iframe) */\
+#useLocalBuild#    frame-src 'self' ${FRAME.SOURCES} ;                                                     /* Limit iframe content sources (from what servers can this server's iframe content be loaded) */\
+#useLocalBuild#    report-uri /admin-contentSecurityPolicyReport.api?cspVersion=e11&${CSP.REPORT.PARAMS} ; /* Report any encountered CSP violations to the supplied URL */
 ## END OF CSP ENFORCE BLOCK (DO NOT CHANGE THIS TEXT)
 
 ## START OF CSP REPORT BLOCK (DO NOT CHANGE THIS TEXT)

--- a/server/configs/webapps/embedded/config/application.properties
+++ b/server/configs/webapps/embedded/config/application.properties
@@ -108,8 +108,8 @@ mail.smtpUser=Anonymous
 #context.additionalWebapps.firstContextPath=@@/my/webapp/path@@
 #context.additionalWebapps.secondContextPath=@@/my/other/webapp/path@@
 
-## Strict enforce content security policy. Uncomment this when you've tested the report policy below (which is identical
-## except for the version designation).
+## Strong enforce content security policy. Uncomment this when you've tested the strong report-only policy (configured
+## by default via server code and shown below).
 #csp.enforce=\
 #    default-src 'self' ;                                                                    /* Limit the default to only the current server */\
 #    connect-src 'self' ${CONNECTION.SOURCES} ;                                              /* Limit allowed connection sources */\
@@ -123,7 +123,9 @@ mail.smtpUser=Anonymous
 #    frame-src 'self' ${FRAME.SOURCES} ;                                                     /* Limit iframe content sources (from what servers can this server's iframe content be loaded) */\
 #    report-uri /admin-contentSecurityPolicyReport.api?cspVersion=e11&${CSP.REPORT.PARAMS} ; /* Report any encountered CSP violations to the supplied URL */
 
-## Strict report-only content security policy that reports violations to this server
+## Strict report-only content security policy that reports violations to this server. This matches the default report
+## policy that's configured via server code; provided here to document the details and provide a starting point if
+## overriding the default CSP is needed. This CSP will become the default *enforce* policy for 25.4 and beyond.
 csp.report=\
     default-src 'self' ;                                                                    /* Limit the default to only the current server */\
     connect-src 'self' ${CONNECTION.SOURCES} ;                                              /* Limit allowed connection sources */\

--- a/server/configs/webapps/embedded/config/application.properties
+++ b/server/configs/webapps/embedded/config/application.properties
@@ -107,3 +107,32 @@ mail.smtpUser=Anonymous
 ## property name after the "context.additionalWebapps." prefix, and the value is the location of the webapp on disk
 #context.additionalWebapps.firstContextPath=@@/my/webapp/path@@
 #context.additionalWebapps.secondContextPath=@@/my/other/webapp/path@@
+
+## Strict enforce content security policy. Uncomment this when you've tested the report policy below (which is identical
+## except for the version designation).
+#csp.enforce=\
+#    default-src 'self' ;                                                                    /* Limit the default to only the current server */\
+#    connect-src 'self' ${CONNECTION.SOURCES} ;                                              /* Limit allowed connection sources */\
+#    object-src 'none' ;                                                                     /* These tags are not currently used by LKS */\
+#    style-src 'self' 'unsafe-inline' ${STYLE.SOURCES} ;                                     /* We currently have a few inline <style> tags that we are weeding out */\
+#    img-src 'self' data: ${IMAGE.SOURCES} ;                                                 /* Limit image loading locations */\
+#    font-src 'self' data: ${FONT.SOURCES} ;                                                 /* Limit font source loading locations */\
+#    script-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ;             /* Limit scripts to those with nonces or transitive scripts */\
+#    base-uri 'self' ;                                                                       /* Limit the base tags to only source from current server */\
+#    frame-ancestors 'self' ;                                                                /* Limit iframe content destinations (who can load this server's content into an iframe) */\
+#    frame-src 'self' ${FRAME.SOURCES} ;                                                     /* Limit iframe content sources (from what servers can this server's iframe content be loaded) */\
+#    report-uri /admin-contentSecurityPolicyReport.api?cspVersion=e11&${CSP.REPORT.PARAMS} ; /* Report any encountered CSP violations to the supplied URL */
+
+## Strict report-only content security policy that reports violations to this server
+csp.report=\
+    default-src 'self' ;                                                                    /* Limit the default to only the current server */\
+    connect-src 'self' ${CONNECTION.SOURCES} ;                                              /* Limit allowed connection sources */\
+    object-src 'none' ;                                                                     /* These tags are not currently used by LKS */\
+    style-src 'self' 'unsafe-inline' ${STYLE.SOURCES} ;                                     /* We currently have a few inline <style> tags that we are weeding out */\
+    img-src 'self' data: ${IMAGE.SOURCES} ;                                                 /* Limit image loading locations */\
+    font-src 'self' data: ${FONT.SOURCES} ;                                                 /* Limit font source loading locations */\
+    script-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ;             /* Limit scripts to those with nonces or transitive scripts */\
+    base-uri 'self' ;                                                                       /* Limit the base tags to only source from current server */\
+    frame-ancestors 'self' ;                                                                /* Limit iframe content destinations (who can load this server's content into an iframe) */\
+    frame-src 'self' ${FRAME.SOURCES} ;                                                     /* Limit iframe content sources (from what servers can this server's iframe content be loaded) */\
+    report-uri /admin-contentSecurityPolicyReport.api?cspVersion=r11&${CSP.REPORT.PARAMS} ; /* Report any encountered CSP violations to the supplied URL */

--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -79,7 +79,22 @@ public class LabKeyServer
 
                 // Issue 52415: Omit stack traces from Tomcat error pages by default, but propagate error messages
                 "server.error.include-stacktrace", "never",
-                "server.error.include-message", "always"
+                "server.error.include-message", "always",
+
+                // A strong report-only Content Security Policy that reports violations to this server
+                "csp.report", """
+                        default-src 'self' ;
+                        connect-src 'self' ${CONNECTION.SOURCES} ;
+                        object-src 'none' ;
+                        style-src 'self' 'unsafe-inline' ${STYLE.SOURCES} ;
+                        img-src 'self' data: ${IMAGE.SOURCES} ;
+                        font-src 'self' data: ${FONT.SOURCES} ;
+                        script-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ;
+                        base-uri 'self' ;
+                        frame-ancestors 'self' ;
+                        frame-src 'self' ${FRAME.SOURCES} ;
+                        report-uri /admin-contentSecurityPolicyReport.api?cspVersion=r11&${CSP.REPORT.PARAMS}
+                    """
         ));
         application.setBannerMode(Banner.Mode.OFF);
         application.run(args);


### PR DESCRIPTION
#### Rationale
For 25.3, we've decided to configure CSP r11 (report-only) by default for all on-premise deployments and CSP e11 (enforce) for all development deployments