### PR TITLE
Upgrade tomcat version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -100,7 +100,7 @@ apacheDirectoryVersion=2.1.7
 apacheMinaVersion=2.2.4
 
 # Usually matches the version specified as a Spring Boot dependency (see springBootVersion below)
-apacheTomcatVersion=10.1.34
+apacheTomcatVersion=10.1.39
 
 # (mothership) -> json-path -> json-smart -> accessor-smart
 # (core) -> graalvm


### PR DESCRIPTION
#### Rationale
CVE-2025-24813 was evaluated and determined not to be a vulnerability, but upgrading tomcat to clear the OWASP warning.

#### Changes
* Upgrade tomcat
