### PR TITLE
Revert ProtoBuf to 3.25.5 until we pick up regenerated code

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -158,7 +158,7 @@ googleAutoValueAnnotationsVersion=1.10.4
 googleErrorProneAnnotationsVersion=2.36.0
 googleHttpClientVersion=1.46.1
 googleOauthClientVersion=1.37.0
-googleProtocolBufVersion=3.25.6
+googleProtocolBufVersion=3.25.5
 
 # Cloud and SequenceAnalysis bring gson in as a transitive dependency.
 # We resolve to the later version here to keep things consistent


### PR DESCRIPTION
#### Rationale
We need to regenerate some auto-generated code before we can upgrade to the latest ProtoBuf version. I have a PR in 24.11 that's already got that.

#### Changes
* Bump back to 3.25.5 for the moment