### PR TITLE
Update commons VFS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -195,6 +195,10 @@ allprojects {
                     force "org.apache.logging.log4j:log4j-core:${log4j2Version}"
                     force "org.apache.logging.log4j:log4j-api:${log4j2Version}"
                     force "org.apache.logging.log4j:log4j-1.2-api:${log4j2Version}"
+                    force "org.apache.commons.vfs2:FileContent:${commonsVfs2Version}"
+                    force "org.apache.commons.vfs2:FileObject:${commonsVfs2Version}"
+                    force "org.apache.commons.vfs2:FileSystemException:${commonsVfs2Version}"
+                    force "org.apache.commons.vfs2:FileSystemManager:${commonsVfs2Version}"
                     // force version for consistency with saml, query, LDK, and pipeline
                     force "commons-lang:commons-lang:${commonsLangVersion}"
                     // force version for consistency with workflow, api, SequenceAnalysis

--- a/build.gradle
+++ b/build.gradle
@@ -195,10 +195,7 @@ allprojects {
                     force "org.apache.logging.log4j:log4j-core:${log4j2Version}"
                     force "org.apache.logging.log4j:log4j-api:${log4j2Version}"
                     force "org.apache.logging.log4j:log4j-1.2-api:${log4j2Version}"
-                    force "org.apache.commons.vfs2:FileContent:${commonsVfs2Version}"
-                    force "org.apache.commons.vfs2:FileObject:${commonsVfs2Version}"
-                    force "org.apache.commons.vfs2:FileSystemException:${commonsVfs2Version}"
-                    force "org.apache.commons.vfs2:FileSystemManager:${commonsVfs2Version}"
+                    force "org.apache.commons:commons-vfs2:${commonsVfs2Version}"
                     // force version for consistency with saml, query, LDK, and pipeline
                     force "commons-lang:commons-lang:${commonsLangVersion}"
                     // force version for consistency with workflow, api, SequenceAnalysis

--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -1,16 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
 
-    <!-- commons vfs features not used in LK. LK version has been bumped to 2.10.0 but this version is used by mondrian.
-     We are forcing mondrian to use 2.10.0 but still need to suppress here.-->
-    <suppress>
-        <notes><![CDATA[
-   file name: commons-vfs2-2.7.0.jar
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.commons/commons-vfs@.*$</packageUrl>
-        <vulnerabilityName>CVE-2025-27553</vulnerabilityName>
-    </suppress>
-
     <!-- Prevent match against unrelated "rengine" at https://github.com/yogeshojha/rengine -->
     <suppress>
         <notes><![CDATA[

--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -1,6 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
 
+    <!-- Tangled CVEs. See https://github.com/jeremylong/DependencyCheck/issues/4614 and https://github.com/OSSIndex/vulns/issues/316 -->
+    <suppress>
+        <notes><![CDATA[
+   file name: commons-vfs2-2.7.0.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org.apache.commons/commons-vfs@.*$</packageUrl>
+        <vulnerabilityName>CVE-2025-27553</vulnerabilityName>
+    </suppress>
+
     <!-- Prevent match against unrelated "rengine" at https://github.com/yogeshojha/rengine -->
     <suppress>
         <notes><![CDATA[

--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
 
-    <!-- Tangled CVEs. See https://github.com/jeremylong/DependencyCheck/issues/4614 and https://github.com/OSSIndex/vulns/issues/316 -->
+    <!-- commons vfs features not used in LK. LK version has been bumped to 2.10.0 but this version is used by mondrian.
+     We are forcing mondrian to use 2.10.0 but still need to suppress here.-->
     <suppress>
         <notes><![CDATA[
    file name: commons-vfs2-2.7.0.jar
    ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org.apache.commons/commons-vfs@.*$</packageUrl>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.commons/commons-vfs@.*$</packageUrl>
         <vulnerabilityName>CVE-2025-27553</vulnerabilityName>
     </suppress>
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -136,7 +136,7 @@ commonsMath3Version=3.6.1
 commonsPoolVersion=1.6
 commonsTextVersion=1.12.0
 commonsValidatorVersion=1.9.0
-commonsVfs2Version=2.7.0
+commonsVfs2Version=2.10.0
 
 datadogVersion=1.41.1
 


### PR DESCRIPTION
#### Rationale
CVE-2025-27553 and CVE-2025-30474 were evaluated and determined not to be a risk. Bumping version to clear OWASP warning.

#### Changes
* Update commonsVfs2Version
