### PR TITLE
Rollback Bouncy Castle Version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -110,8 +110,8 @@ asmVersion=9.8
 batikVersion=1.18
 
 # sync with Tika version (or later)
-bouncycastlePgpVersion=1.80
-bouncycastleVersion=1.80
+bouncycastlePgpVersion=1.79
+bouncycastleVersion=1.79
 
 cglibNodepVersion=2.2.3
 


### PR DESCRIPTION
#### Rationale
Bumping bouncy castle version caused test failure in NciDataIslandTransferTest.testNciDataIslandTransfer due to no longer finding cypher to decrypt a test file. Will file separate issue to regenerate the encrypted test file.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/1020

#### Changes
* Rollback bouncy castle version
