### PR TITLE
fix exception when loading log4j2

### DIFF
--- a/server/embedded/src/main/resources/log4j2.xml
+++ b/server/embedded/src/main/resources/log4j2.xml
@@ -239,9 +239,7 @@ account managers so that we can coordinate edits with other customized copies of
 
         <Logger name="org.labkey.api.dataiterator" />
 
-        <Logger name="org.labkey.docker" >
-            <level value="info"/>
-        </Logger>
+        <Logger name="org.labkey.docker" level="info"/>
 
         <Logger name="org.labkey.rstudio" level="info"/>
 


### PR DESCRIPTION
#### Rationale
[Issue 52671](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52671): TeamCity logs are complaining about the logging configuration

#### Changes
* adjust level declaration
