### PR TITLE
backport poiVersion bump

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -262,7 +262,7 @@ openTracingVersion=0.33.0
 pdfboxVersion=3.0.3
 
 # sync with version Tika ships
-poiVersion=5.3.0
+poiVersion=5.4.0
 
 pollingWatchVersion=0.2.0
 


### PR DESCRIPTION
#### Rationale
to match https://github.com/LabKey/server/pull/1020 for [CVE-2025-31672](https://ossindex.sonatype.org/vulnerability/CVE-2025-31672?component-type=maven&component-name=org.apache.poi%2Fpoi-ooxml&utm_source=dependency-check&utm_medium=integration&utm_content=12.1.0)

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
