### PR TITLE
Issue 52855: Missing Servlet API when extracting remote pipeline resources

### DIFF
--- a/server/embedded/src/org/labkey/embedded/EmbeddedExtractor.java
+++ b/server/embedded/src/org/labkey/embedded/EmbeddedExtractor.java
@@ -224,7 +224,9 @@ public class EmbeddedExtractor
         {
             try (JarFile jar = new JarFile(verifyJar()))
             {
-                boolean foundDistributionZip = false;
+                boolean missingDistributionZip = true;
+                boolean missingBootstrapJar = remotePipeline;
+                boolean missingServletApiJar = remotePipeline;
                 var entries = jar.entries();
                 while (entries.hasMoreElements())
                 {
@@ -233,7 +235,7 @@ public class EmbeddedExtractor
 
                     if ("labkey/distribution.zip".equals(entryName))
                     {
-                        foundDistributionZip = true;
+                        missingDistributionZip = false;
                         try (var distInputStream = jar.getInputStream(entry))
                         {
                             extractDistributionZip(distInputStream, destDirectory);
@@ -241,14 +243,16 @@ public class EmbeddedExtractor
                     }
                     if (remotePipeline)
                     {
+                        // Keep this code in sync with org.labkey.pipeline.api.PipelineServiceImpl.extractBootstrapFromEmbedded()
                         if (entry.getName().contains("labkeyBootstrap") && entry.getName().toLowerCase().endsWith(".jar"))
                         {
                             try (var in = jar.getInputStream(entry))
                             {
                                 extractFile(in, new File(destDirectory, "labkeyBootstrap.jar"));
                             }
+                            missingBootstrapJar = false;
                         }
-                        if (entry.getName().contains("tomcat-servlet-api") && entry.getName().toLowerCase().endsWith(".jar"))
+                        if (entry.getName().contains("tomcat-embed-core") && entry.getName().toLowerCase().endsWith(".jar"))
                         {
                             File pipelineLib = new File(destDirectory, "pipeline-lib");
                             if (!pipelineLib.exists())
@@ -262,11 +266,20 @@ public class EmbeddedExtractor
                             {
                                 extractFile(in, new File(pipelineLib, "servletApi.jar"));
                             }
+                            missingServletApiJar = false;
                         }
                     }
                 }
 
-                if (!foundDistributionZip)
+                if (missingDistributionZip)
+                {
+                    throw new ConfigException("Unable to find distribution zip required to run LabKey Server.");
+                }
+                if (missingBootstrapJar)
+                {
+                    throw new ConfigException("Unable to find labkeyServer.jar required to run LabKey Server.");
+                }
+                if (missingServletApiJar)
                 {
                     throw new ConfigException("Unable to find distribution zip required to run LabKey Server.");
                 }

--- a/server/embedded/src/org/labkey/embedded/EmbeddedExtractor.java
+++ b/server/embedded/src/org/labkey/embedded/EmbeddedExtractor.java
@@ -277,11 +277,11 @@ public class EmbeddedExtractor
                 }
                 if (missingBootstrapJar)
                 {
-                    throw new ConfigException("Unable to find labkeyServer.jar required to run LabKey Server.");
+                    throw new ConfigException("Unable to find labkeyServer.jar required to run LabKey Server's remote pipeline code.");
                 }
                 if (missingServletApiJar)
                 {
-                    throw new ConfigException("Unable to find distribution zip required to run LabKey Server.");
+                    throw new ConfigException("Unable to find Servlet API file required to run LabKey Server's remote pipeline code.");
                 }
             }
         }


### PR DESCRIPTION
#### Rationale
We have two places that extract JARs for remote pipeline scenarios. This one, used in our tests, and another used from the command line. They should be kept in sync.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/6570

#### Changes
- Pointer to the other spot
- Stronger error checks
- Update to grab the new home for the servlet API classes
