### PR TITLE
backport httpclient5Version bump

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -182,8 +182,8 @@ hamcrestVersion=2.2
 # Note: if changing this, we might need to match with the picard version in the SequenceAnalysis module build.gradle
 htsjdkVersion=4.0.0
 
-httpclient5Version=5.4.1
-httpcore5Version=5.3.2
+httpclient5Version=5.4.3
+httpcore5Version=5.3.4
 
 # Not used directly, but these are widely used transitive dependencies
 httpclientVersion=4.5.14


### PR DESCRIPTION
to match https://github.com/LabKey/server/pull/1026 for CVE-2025-27820

#### Rationale
<!-- Rationale describing why this pull request is needed, what behavior it's adding/changing/removing, etc. (replace this comment) -->

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
