### PR TITLE
Suppress dependency check false-positive for mxparser

### DIFF
--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -185,4 +185,14 @@
         <packageUrl regex="true">^pkg:maven/org\.labkey\.api/labkey-client-api@.*$</packageUrl>
         <cve>CVE-2019-3913</cve>
     </suppress>
+
+    <!-- False positive - mxparser is not XStream -->
+    <suppress>
+        <notes><![CDATA[
+    file name: mxparser-1.2.2.jar
+    ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.github\.x-stream/mxparser@.*$</packageUrl>
+        <cpe>cpe:/a:xstream:xstream</cpe>
+    </suppress>
+
 </suppressions>


### PR DESCRIPTION
#### Rationale
The OWASP checker started matching numerous XStream CVEs to mxparser. None of the CVEs are actually associated with mxparser.

#### Related Pull Requests
* N/A

#### Changes
* Suppress OWASP false-positive for mxparser
