### PR TITLE
Upgrade to Apache Tomcat 10.1.41

### DIFF
--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -194,5 +194,27 @@
         <packageUrl regex="true">^pkg:maven/io\.github\.x-stream/mxparser@.*$</packageUrl>
         <cpe>cpe:/a:xstream:xstream</cpe>
     </suppress>
-
+    
+    <!-- False positives - bzip2 from a different source -->
+    <suppress>
+       <notes><![CDATA[
+       file name: bzip2-0.9.1.jar
+       ]]></notes>
+       <packageUrl regex="true">^pkg:maven/org\.itadaki/bzip2@.*$</packageUrl>
+       <cve>CVE-2019-12900</cve>
+    </suppress>
+    <suppress>
+       <notes><![CDATA[
+       file name: bzip2-0.9.1.jar
+       ]]></notes>
+       <packageUrl regex="true">^pkg:maven/org\.itadaki/bzip2@.*$</packageUrl>
+       <cve>CVE-2010-0405</cve>
+    </suppress>
+    <suppress>
+       <notes><![CDATA[
+       file name: bzip2-0.9.1.jar
+       ]]></notes>
+       <packageUrl regex="true">^pkg:maven/org\.itadaki/bzip2@.*$</packageUrl>
+       <cve>CVE-2005-1260</cve>
+    </suppress>
 </suppressions>

--- a/gradle.properties
+++ b/gradle.properties
@@ -99,7 +99,7 @@ apacheDirectoryVersion=2.1.7
 apacheMinaVersion=2.2.4
 
 # Usually matches the version specified as a Spring Boot dependency (see springBootVersion below)
-apacheTomcatVersion=10.1.40
+apacheTomcatVersion=10.1.41
 
 # (mothership) -> json-path -> json-smart -> accessor-smart
 # (core) -> graalvm


### PR DESCRIPTION
#### Rationale
[CVE-2025-46701](https://nvd.nist.gov/vuln/detail/CVE-2025-46701) is not really a threat to us, but best to get the latest version of Tomcat just the same
- We got some false positive hits for the bzip2 library that we can safely suppress.

#### Changes
* Update Tomcat version
