### PR TITLE
Issue 53209: Allow externalModules folder to be dictated via application.properties file

### DIFF
--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -58,7 +58,7 @@ context.encryptionKey=@@encryptionKey@@
 #context.additionalWebapps.firstContextPath=/my/webapp/path
 #context.additionalWebapps.secondContextPath=/my/other/webapp/path
 
-context.externalModules=/Users/jeckels/externalModules
+#context.externalModules=/path/to/external/modules/dir
 #context.requiredModules=
 #context.pipelineConfig=/path/to/pipeline/config/dir
 #context.serverGUID=

--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -58,6 +58,7 @@ context.encryptionKey=@@encryptionKey@@
 #context.additionalWebapps.firstContextPath=/my/webapp/path
 #context.additionalWebapps.secondContextPath=/my/other/webapp/path
 
+context.externalModules=/Users/jeckels/externalModules
 #context.requiredModules=
 #context.pipelineConfig=/path/to/pipeline/config/dir
 #context.serverGUID=

--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -431,6 +431,8 @@ public class LabKeyServer
         private String contextPath = "";
         private String pipelineConfig;
         private String requiredModules;
+        /** Path to external modules directory */
+        private String externalModules;
         private boolean bypass2FA = false;
         private String serverGUID;
         private Integer httpPort;
@@ -574,6 +576,16 @@ public class LabKeyServer
         public void setRequiredModules(String requiredModules)
         {
             this.requiredModules = requiredModules;
+        }
+
+        public String getExternalModules()
+        {
+            return externalModules;
+        }
+
+        public void setExternalModules(String externalModules)
+        {
+            this.externalModules = externalModules;
         }
 
         public boolean isBypass2FA()

--- a/server/embedded/src/org/labkey/embedded/LabKeyTomcatServletWebServerFactory.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyTomcatServletWebServerFactory.java
@@ -175,6 +175,11 @@ class LabKeyTomcatServletWebServerFactory extends TomcatServletWebServerFactory
                 {
                     context.addParameter("requiredModules", contextProperties.getRequiredModules());
                 }
+                if (contextProperties.getExternalModules() != null)
+                {
+                    // We've long supported configuring this via a system property so propagate the value
+                    System.setProperty("labkey.externalModulesDir", contextProperties.getExternalModules());
+                }
                 if (contextProperties.getPipelineConfig() != null)
                 {
                     context.addParameter("org.labkey.api.pipeline.config", contextProperties.getPipelineConfig());


### PR DESCRIPTION
#### Rationale
We've long supported pointing to a custom external modules directory via a system property. We can also support using `application.properties`

#### Changes
* Look for `context.externalModules` in `application.properties` and use it to set the system property