### PR TITLE
Minor auto-refactor code cleanup on a massive scale

### DIFF
--- a/server/bootstrap/src/org/apache/tools/ant/util/FileUtils.java
+++ b/server/bootstrap/src/org/apache/tools/ant/util/FileUtils.java
@@ -37,8 +37,8 @@ public class FileUtils
     // constants, for use in subsequent code (e.g., resolveFile()). These simplified versions should be identical.
     private static final String OS_NAME = System.getProperty("os.name").toLowerCase(Locale.US);
     private static final String PATH_SEP = System.getProperty("path.separator");
-    private static boolean onNetWare = OS_NAME.contains("netware");     // Essentially what Os.isFamily("netware") does
-    private static boolean onDos = PATH_SEP.equals(";") && !onNetWare;  // Essentially what Os.isFamily("dos") does
+    private static final boolean onNetWare = OS_NAME.contains("netware");     // Essentially what Os.isFamily("netware") does
+    private static final boolean onDos = PATH_SEP.equals(";") && !onNetWare;  // Essentially what Os.isFamily("dos") does
 
     /**
      * Method to retrieve The FileUtils, which is shared by all users of this
@@ -109,7 +109,7 @@ public class FileUtils
      * @since Ant 1.7
      */
     public static boolean isContextRelativePath(String filename) {
-        if (!(onDos || onNetWare) || filename.length() == 0) {
+        if (!(onDos || onNetWare) || filename.isEmpty()) {
             return false;
         }
         char sep = File.separatorChar;
@@ -222,7 +222,7 @@ public class FileUtils
         if (!isAbsolutePath(path)) {
             throw new BuildException(path + " is not an absolute path");
         }
-        String root = null;
+        String root;
         int colon = path.indexOf(':');
         if (colon > 0 && (onDos || onNetWare)) {
 

--- a/server/bootstrap/src/org/labkey/bootstrap/ArgumentParser.java
+++ b/server/bootstrap/src/org/labkey/bootstrap/ArgumentParser.java
@@ -24,8 +24,8 @@ import java.util.*;
  */
 public class ArgumentParser
 {
-    private List<String> _params = new ArrayList<>();
-    private Map<String, String> _options = new HashMap<>();
+    private final List<String> _params = new ArrayList<>();
+    private final Map<String, String> _options = new HashMap<>();
 
     public ArgumentParser(String[] args)
     {

--- a/server/bootstrap/src/org/labkey/bootstrap/ExplodedModule.java
+++ b/server/bootstrap/src/org/labkey/bootstrap/ExplodedModule.java
@@ -64,9 +64,9 @@ public class ExplodedModule
 
     private static final FileComparator _fileComparator = new FileComparator();
 
-    private File _rootDirectory;
+    private final File _rootDirectory;
     private File _sourceModuleFile;
-    private Map<File, Long> _watchedFiles = new HashMap<>();
+    private final Map<File, Long> _watchedFiles = new HashMap<>();
 
     public ExplodedModule(File rootDirectory)
     {

--- a/server/bootstrap/src/org/labkey/bootstrap/ModuleArchive.java
+++ b/server/bootstrap/src/org/labkey/bootstrap/ModuleArchive.java
@@ -77,7 +77,7 @@ public class ModuleArchive
             SAXParser parser = SAXParserFactory.newDefaultInstance().newSAXParser();
             parser.parse(is, new DefaultHandler()
             {
-                ArrayList<String> elementStack = new ArrayList<>();
+                final ArrayList<String> elementStack = new ArrayList<>();
 
                 @Override
                 public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException

--- a/server/bootstrap/src/org/labkey/bootstrap/ModuleDirectories.java
+++ b/server/bootstrap/src/org/labkey/bootstrap/ModuleDirectories.java
@@ -16,7 +16,6 @@
 package org.labkey.bootstrap;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.stream.Stream;
 
 /*
@@ -33,7 +32,7 @@ public class ModuleDirectories
     public static final String DEFAULT_MODULES_DIR = "modules";
     public static final String DEFAULT_EXTERNAL_MODULES_DIR = "externalModules";
 
-    private File _modulesDirectory;
+    private final File _modulesDirectory;
     private File _externalModulesDirectory;
 
     public ModuleDirectories(File webAppDirectory)


### PR DESCRIPTION
#### Rationale
We can cleanup tens of thousands of warnings across our codebase with IntelliJ's autorefactors. In some cases, this adopts newer, leaner syntax. In others, it simply removes code that's not serving any purpose.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6742

#### Changes
- Auto-refactors
  - Eliminate redundant toString()
  - Eliminate redundant cast
  - Empty JavaDoc annotations
  - Member variable can be final
  - length() and size() -> isEmpty()
  - Add missing @Override
  - Class can be static
  - Remove unused imports
  - toArray() passed array length
  - Remove unnecessary semicolon
  - Explicit type syntax can be replaced by <>
  - Redundant access modifiers
  - Remove redundant initializer
  - "".equals() -> isEmpty()
  - StringBuilder can be replaced by String
  - Fix misordered arguments to assertEquals()
  - StringUtils.defaultString() - Objects.toString()
  - Cast can be replaced with pattern variable
  - Collapse identical catch blocks
  - Type may be primitive
- Manual fixups
  - Delete unused GWT code
  - Improve generics
  - new UnexpectedException() -> UnexpectedException.wrap()


