### PR TITLE
Re-enable shutdown endpoint

### DIFF
--- a/server/embedded/build.gradle
+++ b/server/embedded/build.gradle
@@ -1,7 +1,8 @@
-import org.labkey.gradle.plugin.extension.ServerDeployExtension
-import org.labkey.gradle.task.CheckForVersionConflicts
 import org.labkey.gradle.util.BuildUtils
+import org.labkey.gradle.util.PomFileHelper
 import org.labkey.gradle.util.GroupNames
+import org.labkey.gradle.task.CheckForVersionConflicts
+import org.labkey.gradle.plugin.extension.ServerDeployExtension
 
 plugins {
     id "java"

--- a/server/embedded/build.gradle
+++ b/server/embedded/build.gradle
@@ -1,8 +1,7 @@
-import org.labkey.gradle.util.BuildUtils
-import org.labkey.gradle.util.PomFileHelper
-import org.labkey.gradle.util.GroupNames
-import org.labkey.gradle.task.CheckForVersionConflicts
 import org.labkey.gradle.plugin.extension.ServerDeployExtension
+import org.labkey.gradle.task.CheckForVersionConflicts
+import org.labkey.gradle.util.BuildUtils
+import org.labkey.gradle.util.GroupNames
 
 plugins {
     id "java"
@@ -36,6 +35,7 @@ configurations.configureEach {
 }
 
 dependencies {
+    implementation "org.springframework.boot:spring-boot-starter-actuator:${springBootVersion}" // Required for shutdown endpoint
     implementation("org.springframework.boot:spring-boot-starter-web:${springBootVersion}") {
         exclude group: "org.springframework.boot", module: "spring-boot-starter-json" // Not used (?) and pulls in an old version of Jackson
         exclude group: "jakarta.annotation", module: "jakarta.annotation-api" // Already present in tomcat-annotations-api


### PR DESCRIPTION
#### Rationale
[Issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53244)
The shutdown endpoint was inadvertently disabled when the `spring-boot-starter-actuator` dependency was removed in 25.1. The `stopLabkey` Gradle task requires this endpoint.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/937

#### Changes
* Add `spring-boot-starter-actuator` dependency
