### PR TITLE
Update to Postgres driver version 42.7.7

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -266,7 +266,7 @@ poiVersion=5.4.0
 
 pollingWatchVersion=0.2.0
 
-postgresqlDriverVersion=42.7.4
+postgresqlDriverVersion=42.7.7
 
 quartzVersion=2.5.0
 


### PR DESCRIPTION
#### Rationale
[CVE-2025-49146](https://ossindex.sonatype.org/vulnerability/CVE-2025-49146?component-type=maven&component-name=org.postgresql%2Fpostgresql&utm_source=dependency-check&utm_medium=integration&utm_content=12.1.1) Affects versions from 42.7.4 until 42.7.7. We are not at risk since we do not configure channel binding, but good to update just the same.

#### Changes
* Update `postgresDriverVersion`
