### PR TITLE
Suppress CVE-2025-49146

### DIFF
--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -217,4 +217,13 @@
        <packageUrl regex="true">^pkg:maven/org\.itadaki/bzip2@.*$</packageUrl>
        <cve>CVE-2005-1260</cve>
     </suppress>
+
+    <!-- Related to the setting of channel binding as required, which is not relevant to us. -->
+    <suppress>
+        <notes><![CDATA[
+       file name: postgresql-42.7.4.jar
+       ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.postgresql/postgresql@.*$</packageUrl>
+        <vulnerabilityName>CVE-2025-49146</vulnerabilityName>
+    </suppress>
 </suppressions>

--- a/gradle.properties
+++ b/gradle.properties
@@ -266,6 +266,7 @@ poiVersion=5.4.0
 
 pollingWatchVersion=0.2.0
 
+# Newer versions of the driver have a perf degradation that's important for us. https://github.com/pgjdbc/pgjdbc/issues/3505
 postgresqlDriverVersion=42.7.4
 
 quartzVersion=2.5.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -266,7 +266,7 @@ poiVersion=5.4.0
 
 pollingWatchVersion=0.2.0
 
-postgresqlDriverVersion=42.7.7
+postgresqlDriverVersion=42.7.4
 
 quartzVersion=2.5.0
 


### PR DESCRIPTION
#### Rationale
Turns out the latest version of the postgres driver has some significant performance issues, so instead of updating, we'll suppress [CVE-2025-49146](https://ossindex.sonatype.org/vulnerability/CVE-2025-49146?component-type=maven&component-name=org.postgresql%2Fpostgresql&utm_source=dependency-check&utm_medium=integration&utm_content=12.1.1) since we are not at risk from it

#### Related Pull Requests
* #1092

#### Changes
* Add suppression