### PR TITLE
Update spring to 6.2.8 for CVE-2025-41234

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -292,7 +292,7 @@ snappyJavaVersion=1.1.10.7
 # Also, update apacheTomcatVersion above to match Spring Boot's Tomcat dependency version
 springBootVersion=3.4.5
 # This usually matches the Spring Framework version dictated by springBootVersion
-springVersion=6.2.7
+springVersion=6.2.8
 
 sqliteJdbcVersion=3.49.1.0
 


### PR DESCRIPTION
#### Rationale
[CVE-2025-41234](https://ossindex.sonatype.org/vulnerability/CVE-2025-41234) is a vulnerability for spring-web we are not subject to that is present in supported version before 6.2.8.

#### Changes
* Update to `springVersion` 6.2.8
