### PR TITLE
Add IssueNavigationLink for GitHub issues

### DIFF
--- a/.idea/configTemplates/vcs.xml
+++ b/.idea/configTemplates/vcs.xml
@@ -25,6 +25,10 @@
           <option name="issueRegexp" value="^([0-9]+) ?:" />
           <option name="linkRegexp" value="https://www.labkey.org/issues/home/Developer/issues/details.view?issueId=$1" />
         </IssueNavigationLink>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="(GitHub Issue|GH Issue)( +#?)([0-9]+)" />
+          <option name="linkRegexp" value="https://github.com/LabKey/kanban/issues/$3" />
+        </IssueNavigationLink>
       </list>
     </option>
   </component>

--- a/gradle.properties
+++ b/gradle.properties
@@ -45,7 +45,7 @@ buildFromSource=true
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
 labkeyVersion=25.7-SNAPSHOT
-labkeyClientApiVersion=6.3.0
+labkeyClientApiVersion=6.2.0
 
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.

--- a/gradle.properties
+++ b/gradle.properties
@@ -45,7 +45,7 @@ buildFromSource=true
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
 labkeyVersion=25.7-SNAPSHOT
-labkeyClientApiVersion=6.2.0
+labkeyClientApiVersion=6.3.0
 
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.


### PR DESCRIPTION
#### Rationale
We'll want to link to GitHub issues from our comments as we start tracking things there.

#### Changes
* Add new link configuration in `configTemplates/vcs.xml`
