### PR TITLE
Update to Tomcat version 10.1.42

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -99,7 +99,7 @@ apacheDirectoryVersion=2.1.7
 apacheMinaVersion=2.2.4
 
 # Usually matches the version specified as a Spring Boot dependency (see springBootVersion below)
-apacheTomcatVersion=10.1.41
+apacheTomcatVersion=10.1.42
 
 # (mothership) -> json-path -> json-smart -> accessor-smart
 # (core) -> graalvm

--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -65,9 +65,9 @@ context.encryptionKey=@@encryptionKey@@
 #context.bypass2FA=true
 #context.workDirLocation=/path/to/desired/workDir
 
-## Tomcat v10.1.42 lowered the default for part count from 1000 to 10. Our default is now 100, but can be overridden here.
+## Tomcat v10.1.42 lowered the default for part count from 1000 to 10. Our default is now 500, but can be overridden here.
 ## Header size default changed from 10Kb to 512, which is also our default.
-#context.maxConnectorPartCount=100
+#context.maxConnectorPartCount=500
 #context.maxConnectorPartHeaderSize=512
 
 ## SMTP configuration

--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -65,9 +65,9 @@ context.encryptionKey=@@encryptionKey@@
 #context.bypass2FA=true
 #context.workDirLocation=/path/to/desired/workDir
 
-## Required as of Tomcat v10.1.42 to override significantly lower default for part count (10 vs. 1000)
-## Header size default changed from 10Kb to 512.
-context.maxConnectorPartCount=100
+## Tomcat v10.1.42 lowered the default for part count from 1000 to 10. Our default is now 100, but can be overridden here.
+## Header size default changed from 10Kb to 512, which is also our default.
+#context.maxConnectorPartCount=100
 #context.maxConnectorPartHeaderSize=512
 
 ## SMTP configuration

--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -65,6 +65,11 @@ context.encryptionKey=@@encryptionKey@@
 #context.bypass2FA=true
 #context.workDirLocation=/path/to/desired/workDir
 
+## Required as of Tomcat v10.1.42 to override significantly lower default for part count (10 vs. 1000)
+## Header size default changed from 10Kb to 512.
+context.maxConnectorPartCount=100
+#context.maxConnectorPartHeaderSize=512
+
 ## SMTP configuration
 mail.smtpHost=@@smtpHost@@
 mail.smtpPort=@@smtpPort@@

--- a/server/configs/webapps/embedded/config/application.properties
+++ b/server/configs/webapps/embedded/config/application.properties
@@ -103,9 +103,9 @@ mail.smtpUser=Anonymous
 #context.bypass2FA=true
 #context.workDirLocation=@@/path/to/desired/workDir@@
 
-## Required as of Tomcat v10.1.42 to override significantly lower default for part count (10 vs. 1000)
-## Header size default changed from 10Kb to 512.
-context.maxConnectorPartCount=100
+## Tomcat v10.1.42 lowered the default for part count from 1000 to 10. Our default is now 100, but can be overridden here.
+## Header size default changed from 10Kb to 512, which is also our default.
+#context.maxConnectorPartCount=100
 #context.maxConnectorPartHeaderSize=512
 
 ## Other webapps to be deployed, most commonly to deliver a set of static files. The context path to deploy into is the

--- a/server/configs/webapps/embedded/config/application.properties
+++ b/server/configs/webapps/embedded/config/application.properties
@@ -103,9 +103,9 @@ mail.smtpUser=Anonymous
 #context.bypass2FA=true
 #context.workDirLocation=@@/path/to/desired/workDir@@
 
-## Tomcat v10.1.42 lowered the default for part count from 1000 to 10. Our default is now 100, but can be overridden here.
+## Tomcat v10.1.42 lowered the default for part count from 1000 to 10. Our default is now 500, but can be overridden here.
 ## Header size default changed from 10Kb to 512, which is also our default.
-#context.maxConnectorPartCount=100
+#context.maxConnectorPartCount=500
 #context.maxConnectorPartHeaderSize=512
 
 ## Other webapps to be deployed, most commonly to deliver a set of static files. The context path to deploy into is the

--- a/server/configs/webapps/embedded/config/application.properties
+++ b/server/configs/webapps/embedded/config/application.properties
@@ -103,6 +103,11 @@ mail.smtpUser=Anonymous
 #context.bypass2FA=true
 #context.workDirLocation=@@/path/to/desired/workDir@@
 
+## Required as of Tomcat v10.1.42 to override significantly lower default for part count (10 vs. 1000)
+## Header size default changed from 10Kb to 512.
+context.maxConnectorPartCount=100
+#context.maxConnectorPartHeaderSize=512
+
 ## Other webapps to be deployed, most commonly to deliver a set of static files. The context path to deploy into is the
 ## property name after the "context.additionalWebapps." prefix, and the value is the location of the webapp on disk
 #context.additionalWebapps.firstContextPath=@@/my/webapp/path@@

--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -456,7 +456,7 @@ public class LabKeyServer
         private Map<String, Map<String, Map<String, String>>> resources;
         private Map<String, String> additionalWebapps;
 
-        private Integer maxConnectorPartCount = 100;
+        private Integer maxConnectorPartCount = 500;
         private Integer maxConnectorPartHeaderSize = 512;
 
         public List<String> getDataSourceName()

--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -7,6 +7,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.ApplicationPidFileWriter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.web.embedded.tomcat.TomcatConnectorCustomizer;
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
 import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.context.annotation.Bean;
@@ -138,6 +139,14 @@ public class LabKeyServer
     }
 
     @Bean
+    TomcatConnectorCustomizer connectorCustomizer() {
+        return (connector) -> {
+            connector.setMaxPartCount(contextSource().getMaxConnectorPartCount());
+            connector.setMaxPartHeaderSize(contextSource().getMaxConnectorPartHeaderSize());
+        };
+    }
+
+    @Bean
     public TomcatServletWebServerFactory servletContainerFactory()
     {
         var result = new LabKeyTomcatServletWebServerFactory(this);
@@ -149,6 +158,7 @@ public class LabKeyServer
             Connector httpConnector = new Connector();
             httpConnector.setScheme("http");
             httpConnector.setPort(contextProperties.getHttpPort());
+            result.getTomcatConnectorCustomizers().forEach(customizer -> customizer.customize(httpConnector));
             result.addAdditionalTomcatConnectors(httpConnector);
         }
 
@@ -446,6 +456,9 @@ public class LabKeyServer
         private Map<String, Map<String, Map<String, String>>> resources;
         private Map<String, String> additionalWebapps;
 
+        private Integer maxConnectorPartCount = 100;
+        private Integer maxConnectorPartHeaderSize = 512;
+
         public List<String> getDataSourceName()
         {
             return dataSourceName;
@@ -707,6 +720,26 @@ public class LabKeyServer
         public void setAdditionalWebapps(Map<String, String> additionalWebapps)
         {
             this.additionalWebapps = additionalWebapps;
+        }
+
+        public Integer getMaxConnectorPartCount()
+        {
+            return maxConnectorPartCount;
+        }
+
+        public void setMaxConnectorPartCount(Integer maxConnectorPartCount)
+        {
+            this.maxConnectorPartCount = maxConnectorPartCount;
+        }
+
+        public Integer getMaxConnectorPartHeaderSize()
+        {
+            return maxConnectorPartHeaderSize;
+        }
+
+        public void setMaxConnectorPartHeaderSize(Integer maxConnectorPartHeaderSize)
+        {
+            this.maxConnectorPartHeaderSize = maxConnectorPartHeaderSize;
         }
     }
 

--- a/server/embedded/src/org/labkey/embedded/LabKeyTomcatServletWebServerFactory.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyTomcatServletWebServerFactory.java
@@ -38,6 +38,7 @@ class LabKeyTomcatServletWebServerFactory extends TomcatServletWebServerFactory
 
         addConnectorCustomizers(connector -> {
             LabKeyServer.TomcatProperties props = _server.tomcatProperties();
+            _server.connectorCustomizer().customize(connector);
 
             if (props.getUseBodyEncodingForURI() != null)
             {


### PR DESCRIPTION
#### Rationale
- [CVE-2025-48988](https://ossindex.sonatype.org/vulnerability/CVE-2025-48988?component-type=maven&component-name=org.apache.tomcat%2Ftomcat-catalina&utm_source=dependency-check&utm_medium=integration&utm_content=12.1.1) (8.7)
- [CVE-2025-49125](https://ossindex.sonatype.org/vulnerability/CVE-2025-49125?component-type=maven&component-name=org.apache.tomcat%2Ftomcat-catalina&utm_source=dependency-check&utm_medium=integration&utm_content=12.1.1) (6.3)

#### Changes
* Update `apacheTomcatVersion` to 10.1.42
