### PR TITLE
CSP reports don't get reported locally if using a contextPath

### DIFF
--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -140,7 +140,7 @@ management.server.port=@@shutdownPort@@
 #useLocalBuild#    base-uri 'self' ;                                                                       /* Limit the base tags to only source from current server */\
 #useLocalBuild#    frame-ancestors 'self' ;                                                                /* Limit iframe content destinations (who can load this server's content into an iframe) */\
 #useLocalBuild#    frame-src 'self' ${FRAME.SOURCES} ;                                                     /* Limit iframe content sources (from what servers can this server's iframe content be loaded) */\
-#useLocalBuild#    report-uri /admin-contentSecurityPolicyReport.api?cspVersion=e11&${CSP.REPORT.PARAMS} ; /* Report any encountered CSP violations to the supplied URL */
+#useLocalBuild#    report-uri admin-contentSecurityPolicyReport.api?cspVersion=e11&${CSP.REPORT.PARAMS} ; /* Report any encountered CSP violations to the supplied URL */
 ## END OF CSP ENFORCE BLOCK (DO NOT CHANGE THIS TEXT)
 
 ## START OF CSP REPORT BLOCK (DO NOT CHANGE THIS TEXT)
@@ -155,7 +155,7 @@ csp.report=\
     base-uri 'self' ;                                                                       /* Limit the base tags to only source from current server */\
     frame-ancestors 'self' ;                                                                /* Limit iframe content destinations (who can load this server's content into an iframe) */\
     frame-src 'self' ${FRAME.SOURCES} ;                                                     /* Limit iframe content sources (from what servers can this server's iframe content be loaded) */\
-    report-uri /admin-contentSecurityPolicyReport.api?cspVersion=r11&${CSP.REPORT.PARAMS} ; /* Report any encountered CSP violations to the supplied URL */
+    report-uri admin-contentSecurityPolicyReport.api?cspVersion=r11&${CSP.REPORT.PARAMS} ; /* Report any encountered CSP violations to the supplied URL */
 ## END OF CSP REPORT BLOCK (DO NOT CHANGE THIS TEXT)
 
 ## Use a custom logging configuration

--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -140,7 +140,7 @@ management.server.port=@@shutdownPort@@
 #useLocalBuild#    base-uri 'self' ;                                                                       /* Limit the base tags to only source from current server */\
 #useLocalBuild#    frame-ancestors 'self' ;                                                                /* Limit iframe content destinations (who can load this server's content into an iframe) */\
 #useLocalBuild#    frame-src 'self' ${FRAME.SOURCES} ;                                                     /* Limit iframe content sources (from what servers can this server's iframe content be loaded) */\
-#useLocalBuild#    report-uri admin-contentSecurityPolicyReport.api?cspVersion=e11&${CSP.REPORT.PARAMS} ; /* Report any encountered CSP violations to the supplied URL */
+#useLocalBuild#    report-uri admin-contentSecurityPolicyReport.api?cspVersion=e11&${CSP.REPORT.PARAMS} ;  /* Report any encountered CSP violations to the supplied URL */
 ## END OF CSP ENFORCE BLOCK (DO NOT CHANGE THIS TEXT)
 
 ## START OF CSP REPORT BLOCK (DO NOT CHANGE THIS TEXT)
@@ -155,7 +155,7 @@ csp.report=\
     base-uri 'self' ;                                                                       /* Limit the base tags to only source from current server */\
     frame-ancestors 'self' ;                                                                /* Limit iframe content destinations (who can load this server's content into an iframe) */\
     frame-src 'self' ${FRAME.SOURCES} ;                                                     /* Limit iframe content sources (from what servers can this server's iframe content be loaded) */\
-    report-uri admin-contentSecurityPolicyReport.api?cspVersion=r11&${CSP.REPORT.PARAMS} ; /* Report any encountered CSP violations to the supplied URL */
+    report-uri admin-contentSecurityPolicyReport.api?cspVersion=r11&${CSP.REPORT.PARAMS} ;  /* Report any encountered CSP violations to the supplied URL */
 ## END OF CSP REPORT BLOCK (DO NOT CHANGE THIS TEXT)
 
 ## Use a custom logging configuration

--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -46,6 +46,7 @@ context.encryptionKey=@@encryptionKey@@
 
 ## By default, we serve LabKey at the root context path (e.g. http://localhost:8080)
 ## You may customize the context path if you wish (e.g. http://localhost:8080/labkey)
+## Context path value must start with a slash
 #context.contextPath=/labkey
 
 ## Using a legacy context path provides backwards compatibility with old deployments. A typical use case would be to
@@ -140,7 +141,7 @@ management.server.port=@@shutdownPort@@
 #useLocalBuild#    base-uri 'self' ;                                                                       /* Limit the base tags to only source from current server */\
 #useLocalBuild#    frame-ancestors 'self' ;                                                                /* Limit iframe content destinations (who can load this server's content into an iframe) */\
 #useLocalBuild#    frame-src 'self' ${FRAME.SOURCES} ;                                                     /* Limit iframe content sources (from what servers can this server's iframe content be loaded) */\
-#useLocalBuild#    report-uri admin-contentSecurityPolicyReport.api?cspVersion=e11&${CSP.REPORT.PARAMS} ;  /* Report any encountered CSP violations to the supplied URL */
+#useLocalBuild#    report-uri /admin-contentSecurityPolicyReport.api?cspVersion=e11&${CSP.REPORT.PARAMS} ; /* Report any encountered CSP violations to the supplied URL */
 ## END OF CSP ENFORCE BLOCK (DO NOT CHANGE THIS TEXT)
 
 ## START OF CSP REPORT BLOCK (DO NOT CHANGE THIS TEXT)
@@ -155,7 +156,7 @@ csp.report=\
     base-uri 'self' ;                                                                       /* Limit the base tags to only source from current server */\
     frame-ancestors 'self' ;                                                                /* Limit iframe content destinations (who can load this server's content into an iframe) */\
     frame-src 'self' ${FRAME.SOURCES} ;                                                     /* Limit iframe content sources (from what servers can this server's iframe content be loaded) */\
-    report-uri admin-contentSecurityPolicyReport.api?cspVersion=r11&${CSP.REPORT.PARAMS} ;  /* Report any encountered CSP violations to the supplied URL */
+    report-uri /admin-contentSecurityPolicyReport.api?cspVersion=r11&${CSP.REPORT.PARAMS} ; /* Report any encountered CSP violations to the supplied URL */
 ## END OF CSP REPORT BLOCK (DO NOT CHANGE THIS TEXT)
 
 ## Use a custom logging configuration

--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -94,7 +94,7 @@ public class LabKeyServer
                         base-uri 'self' ;
                         frame-ancestors 'self' ;
                         frame-src 'self' ${FRAME.SOURCES} ;
-                        report-uri admin-contentSecurityPolicyReport.api?cspVersion=r11&${CSP.REPORT.PARAMS}
+                        report-uri ${context.contextPath:}/admin-contentSecurityPolicyReport.api?cspVersion=r11&${CSP.REPORT.PARAMS}
                     """
         ));
         application.setBannerMode(Banner.Mode.OFF);

--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -94,7 +94,7 @@ public class LabKeyServer
                         base-uri 'self' ;
                         frame-ancestors 'self' ;
                         frame-src 'self' ${FRAME.SOURCES} ;
-                        report-uri /admin-contentSecurityPolicyReport.api?cspVersion=r11&${CSP.REPORT.PARAMS}
+                        report-uri admin-contentSecurityPolicyReport.api?cspVersion=r11&${CSP.REPORT.PARAMS}
                     """
         ));
         application.setBannerMode(Banner.Mode.OFF);


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53319

Adding the context path to the `report-uri` does the trick -- tested both with and without a context path. Note: for this to work correctly, any provided `contextPath` value must start with a slash. Credit to @labkey-tchad for current approach.

#### Related Pull Requests
- https://github.com/LabKey/server/pull/1103