### PR TITLE
Revert tomcat v10.1.42 update

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -99,7 +99,7 @@ apacheDirectoryVersion=2.1.7
 apacheMinaVersion=2.2.4
 
 # Usually matches the version specified as a Spring Boot dependency (see springBootVersion below)
-apacheTomcatVersion=10.1.42
+apacheTomcatVersion=10.1.41
 
 # (mothership) -> json-path -> json-smart -> accessor-smart
 # (core) -> graalvm

--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -65,11 +65,6 @@ context.encryptionKey=@@encryptionKey@@
 #context.bypass2FA=true
 #context.workDirLocation=/path/to/desired/workDir
 
-## Tomcat v10.1.42 lowered the default for part count from 1000 to 10. Our default is now 500, but can be overridden here.
-## Header size default changed from 10Kb to 512, which is also our default.
-#context.maxConnectorPartCount=500
-#context.maxConnectorPartHeaderSize=512
-
 ## SMTP configuration
 mail.smtpHost=@@smtpHost@@
 mail.smtpPort=@@smtpPort@@

--- a/server/configs/webapps/embedded/config/application.properties
+++ b/server/configs/webapps/embedded/config/application.properties
@@ -103,11 +103,6 @@ mail.smtpUser=Anonymous
 #context.bypass2FA=true
 #context.workDirLocation=@@/path/to/desired/workDir@@
 
-## Tomcat v10.1.42 lowered the default for part count from 1000 to 10. Our default is now 500, but can be overridden here.
-## Header size default changed from 10Kb to 512, which is also our default.
-#context.maxConnectorPartCount=500
-#context.maxConnectorPartHeaderSize=512
-
 ## Other webapps to be deployed, most commonly to deliver a set of static files. The context path to deploy into is the
 ## property name after the "context.additionalWebapps." prefix, and the value is the location of the webapp on disk
 #context.additionalWebapps.firstContextPath=@@/my/webapp/path@@

--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -149,14 +149,6 @@ public class LabKeyServer
     }
 
     @Bean
-    TomcatConnectorCustomizer connectorCustomizer() {
-        return (connector) -> {
-            connector.setMaxPartCount(contextSource().getMaxConnectorPartCount());
-            connector.setMaxPartHeaderSize(contextSource().getMaxConnectorPartHeaderSize());
-        };
-    }
-
-    @Bean
     public TomcatServletWebServerFactory servletContainerFactory()
     {
         var result = new LabKeyTomcatServletWebServerFactory(this);
@@ -168,7 +160,6 @@ public class LabKeyServer
             Connector httpConnector = new Connector();
             httpConnector.setScheme("http");
             httpConnector.setPort(contextProperties.getHttpPort());
-            result.getTomcatConnectorCustomizers().forEach(customizer -> customizer.customize(httpConnector));
             result.addAdditionalTomcatConnectors(httpConnector);
         }
 
@@ -466,9 +457,6 @@ public class LabKeyServer
         private Map<String, Map<String, Map<String, String>>> resources;
         private Map<String, String> additionalWebapps;
 
-        private Integer maxConnectorPartCount = 500;
-        private Integer maxConnectorPartHeaderSize = 512;
-
         public List<String> getDataSourceName()
         {
             return dataSourceName;
@@ -730,26 +718,6 @@ public class LabKeyServer
         public void setAdditionalWebapps(Map<String, String> additionalWebapps)
         {
             this.additionalWebapps = additionalWebapps;
-        }
-
-        public Integer getMaxConnectorPartCount()
-        {
-            return maxConnectorPartCount;
-        }
-
-        public void setMaxConnectorPartCount(Integer maxConnectorPartCount)
-        {
-            this.maxConnectorPartCount = maxConnectorPartCount;
-        }
-
-        public Integer getMaxConnectorPartHeaderSize()
-        {
-            return maxConnectorPartHeaderSize;
-        }
-
-        public void setMaxConnectorPartHeaderSize(Integer maxConnectorPartHeaderSize)
-        {
-            this.maxConnectorPartHeaderSize = maxConnectorPartHeaderSize;
         }
     }
 

--- a/server/embedded/src/org/labkey/embedded/LabKeyTomcatServletWebServerFactory.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyTomcatServletWebServerFactory.java
@@ -38,7 +38,6 @@ class LabKeyTomcatServletWebServerFactory extends TomcatServletWebServerFactory
 
         addConnectorCustomizers(connector -> {
             LabKeyServer.TomcatProperties props = _server.tomcatProperties();
-            _server.connectorCustomizer().customize(connector);
 
             if (props.getUseBodyEncodingForURI() != null)
             {


### PR DESCRIPTION
#### Rationale
Not finding an appropriate default setting for the maxPartCount setting, we've opted to revert the version update for Tomcat for this release.

#### Related Pull Requests
* #1100 

#### Changes
* Revert changes related to update to v10.1.42
