### PR TITLE
Include contextPath in CSP 'report-uri'

### DIFF
--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -83,11 +83,11 @@ public class LabKeyServer
         String enforceCsp = baseCsp + """
                 ${UPGRADE.INSECURE.REQUESTS}
                 frame-ancestors 'self' ;
-                report-uri /admin-contentSecurityPolicyReport.api?cspVersion=e12&${CSP.REPORT.PARAMS} ;
+                report-uri ${context.contextPath:}/admin-contentSecurityPolicyReport.api?cspVersion=e12&${CSP.REPORT.PARAMS} ;
             """;
         // Leave out upgrade_insecure_requests and frame-ancestors directives, since they produce warnings on some browsers
         String reportCsp = baseCsp + """
-                report-uri /admin-contentSecurityPolicyReport.api?cspVersion=r12&${CSP.REPORT.PARAMS} ;
+                report-uri ${context.contextPath:}/admin-contentSecurityPolicyReport.api?cspVersion=r12&${CSP.REPORT.PARAMS} ;
             """;
         application.setDefaultProperties(Map.of(
             "server.tomcat.basedir", ".",


### PR DESCRIPTION
#### Rationale
[CSP reports don't get written to the csp-report.log if using a contextPath](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53319)

#### Related Pull Requests
* 25.3: https://github.com/LabKey/server/pull/1101

#### Changes
* Include contextPath in CSP 'report-uri'
