### PR TITLE
Upgrade Spring Boot and set reasonable request limits

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -290,7 +290,7 @@ slf4jLog4jApiVersion=2.0.16
 snappyJavaVersion=1.1.10.7
 
 # Also, update apacheTomcatVersion above to match Spring Boot's Tomcat dependency version
-springBootVersion=3.5.2
+springBootVersion=3.5.3
 # This usually matches the Spring Framework version dictated by springBootVersion
 springVersion=6.2.8
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -60,7 +60,7 @@ windowsProteomicsBinariesVersion=1.0
 artifactoryPluginVersion=5.2.5
 gradleNodePluginVersion=7.1.0
 gradlePluginsVersion=6.1.0
-owaspDependencyCheckPluginVersion=12.1.0
+owaspDependencyCheckPluginVersion=12.1.3
 versioningPluginVersion=1.1.2
 
 # Versions of node and npm to use during the build. If set, these versions

--- a/gradle.properties
+++ b/gradle.properties
@@ -290,7 +290,7 @@ slf4jLog4jApiVersion=2.0.16
 snappyJavaVersion=1.1.10.7
 
 # Also, update apacheTomcatVersion above to match Spring Boot's Tomcat dependency version
-springBootVersion=3.4.5
+springBootVersion=3.5.2
 # This usually matches the Spring Framework version dictated by springBootVersion
 springVersion=6.2.8
 

--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -66,10 +66,13 @@ context.encryptionKey=@@encryptionKey@@
 #context.bypass2FA=true
 #context.workDirLocation=/path/to/desired/workDir
 
-## Tomcat v10.1.42 lowered the default for part count from 1000 to 10. Our default is now 500, but can be overridden here.
-## Header size default changed from 10Kb to 512, which is also our default.
-#context.maxConnectorPartCount=500
-#context.maxConnectorPartHeaderSize=512
+## Tomcat v10.1.42 lowered the default for part count from 1000 to 10. Our default is now 500.
+## Tomcat also lowered the header size default from 10Kb to 512, which is also our default.
+## We lower max connections from default 8192 to 250, providing ample concurrent requests for LabKey Server scenarios.
+## These settings can be overridden if needed, but reasonable limits reduce your server's vulnerability to DoS attacks.
+server.tomcat.max-part-count=500
+server.tomcat.max-part-header-size=512
+server.tomcat.max-connections=250
 
 ## SMTP configuration
 mail.smtpHost=@@smtpHost@@

--- a/server/configs/webapps/embedded/config/application.properties
+++ b/server/configs/webapps/embedded/config/application.properties
@@ -103,10 +103,13 @@ mail.smtpUser=Anonymous
 #context.bypass2FA=true
 #context.workDirLocation=@@/path/to/desired/workDir@@
 
-## Tomcat v10.1.42 lowered the default for part count from 1000 to 10. Our default is now 500, but can be overridden here.
-## Header size default changed from 10Kb to 512, which is also our default.
-#context.maxConnectorPartCount=500
-#context.maxConnectorPartHeaderSize=512
+## Tomcat v10.1.42 lowered the default for part count from 1000 to 10. Our default is now 500.
+## Tomcat also lowered the header size default from 10Kb to 512, which is also our default.
+## We lower max connections from default 8192 to 250, providing ample concurrent requests for LabKey Server scenarios.
+## These settings can be overridden if needed, but reasonable limits reduce your server's vulnerability to DoS attacks.
+server.tomcat.max-part-count=500
+server.tomcat.max-part-header-size=512
+server.tomcat.max-connections=250
 
 ## Other webapps to be deployed, most commonly to deliver a set of static files. The context path to deploy into is the
 ## property name after the "context.additionalWebapps." prefix, and the value is the location of the webapp on disk

--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -7,7 +7,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.ApplicationPidFileWriter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.web.embedded.tomcat.TomcatConnectorCustomizer;
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
 import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.context.annotation.Bean;
@@ -139,14 +138,6 @@ public class LabKeyServer
     }
 
     @Bean
-    TomcatConnectorCustomizer connectorCustomizer() {
-        return (connector) -> {
-            connector.setMaxPartCount(contextSource().getMaxConnectorPartCount());
-            connector.setMaxPartHeaderSize(contextSource().getMaxConnectorPartHeaderSize());
-        };
-    }
-
-    @Bean
     public TomcatServletWebServerFactory servletContainerFactory()
     {
         var result = new LabKeyTomcatServletWebServerFactory(this);
@@ -158,7 +149,6 @@ public class LabKeyServer
             Connector httpConnector = new Connector();
             httpConnector.setScheme("http");
             httpConnector.setPort(contextProperties.getHttpPort());
-            result.getTomcatConnectorCustomizers().forEach(customizer -> customizer.customize(httpConnector));
             result.addAdditionalTomcatConnectors(httpConnector);
         }
 
@@ -456,9 +446,6 @@ public class LabKeyServer
         private Map<String, Map<String, Map<String, String>>> resources;
         private Map<String, String> additionalWebapps;
 
-        private Integer maxConnectorPartCount = 500;
-        private Integer maxConnectorPartHeaderSize = 512;
-
         public List<String> getDataSourceName()
         {
             return dataSourceName;
@@ -720,26 +707,6 @@ public class LabKeyServer
         public void setAdditionalWebapps(Map<String, String> additionalWebapps)
         {
             this.additionalWebapps = additionalWebapps;
-        }
-
-        public Integer getMaxConnectorPartCount()
-        {
-            return maxConnectorPartCount;
-        }
-
-        public void setMaxConnectorPartCount(Integer maxConnectorPartCount)
-        {
-            this.maxConnectorPartCount = maxConnectorPartCount;
-        }
-
-        public Integer getMaxConnectorPartHeaderSize()
-        {
-            return maxConnectorPartHeaderSize;
-        }
-
-        public void setMaxConnectorPartHeaderSize(Integer maxConnectorPartHeaderSize)
-        {
-            this.maxConnectorPartHeaderSize = maxConnectorPartHeaderSize;
         }
     }
 

--- a/server/embedded/src/org/labkey/embedded/LabKeyTomcatServletWebServerFactory.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyTomcatServletWebServerFactory.java
@@ -38,7 +38,6 @@ class LabKeyTomcatServletWebServerFactory extends TomcatServletWebServerFactory
 
         addConnectorCustomizers(connector -> {
             LabKeyServer.TomcatProperties props = _server.tomcatProperties();
-            _server.connectorCustomizer().customize(connector);
 
             if (props.getUseBodyEncodingForURI() != null)
             {


### PR DESCRIPTION
#### Rationale
Upgrade Spring Boot to 3.5.3, a version that directly handles the new (as of Tomcat 10.1.42) `maxPartCount` and `maxHeaderSize` settings. Set these and `maxConnections` to reasonable values. Revert previous handling of limit settings in favor of using the Spring Boot standard properties.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/1099
* https://github.com/LabKey/commonAssays/pull/896