### PR TITLE
Test PostgreSQL JDBC SNAPSHOT driver

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -158,7 +158,7 @@ allprojects {
 
 // To build and test Tomcat versions that haven't been released yet, temporarily uncomment the block below and update
 // the four-digit number. The "VOTE" emails sent to the Tomcat dev email list include a staging repo URL. In addition
-// to updating the url to match, you'll also need to update apacheTomcatVersion in gradle.properties.
+// to updating the url to match, you'll need to update apacheTomcatVersion in gradle.properties.
 //                    maven {
 //                    	url "https://repository.apache.org/content/repositories/orgapachetomcat-1322/"
 //                    }

--- a/build.gradle
+++ b/build.gradle
@@ -156,15 +156,23 @@ allprojects {
                         }
                     }
 
-// Temporarily uncomment the block below and update the four-digit number to allow building with Tomcat versions that
-// haven't been released yet. The "VOTE" emails sent to the Tomcat dev email list include a staging repo URL. In
-// addition to updating the url to match, you'll also need to update apacheTomcatVersion in gradle.properties.
+// To build and test Tomcat versions that haven't been released yet, temporarily uncomment the block below and update
+// the four-digit number. The "VOTE" emails sent to the Tomcat dev email list include a staging repo URL. In addition
+// to updating the url to match, you'll also need to update apacheTomcatVersion in gradle.properties.
 //                    maven {
 //                    	url "https://repository.apache.org/content/repositories/orgapachetomcat-1322/"
 //                    }
-                    maven {
-                    	url "https://oss.sonatype.org/content/repositories/snapshots/"
-                    }
+
+// To test SNAPSHOT PostgreSQL JDBC drivers locally, temporarily uncomment the block below and update the
+// postgresqlDriverVersion property in gradle.properties to a SNAPSHOT version (e.g., 42.7.7-SNAPSHOT). Note that
+// the writeDependenciesList task does not support SNAPSHOT versions, so you'll need to build with something like:
+//
+//     ./gradlew deployApp -x writeDependenciesList
+//
+//                    maven {
+//                    	url "https://oss.sonatype.org/content/repositories/snapshots/"
+//                    }
+
                     maven {
                         // Mondrian dependencies are available via this repository. It's a direct dependency of the Query
                         // module but is declared here as many modules depend on Query and therefore need it as well.

--- a/build.gradle
+++ b/build.gradle
@@ -163,6 +163,9 @@ allprojects {
 //                    	url "https://repository.apache.org/content/repositories/orgapachetomcat-1322/"
 //                    }
                     maven {
+                    	url "https://oss.sonatype.org/content/repositories/snapshots/"
+                    }
+                    maven {
                         // Mondrian dependencies are available via this repository. It's a direct dependency of the Query
                         // module but is declared here as many modules depend on Query and therefore need it as well.
                         url = "https://repo.orl.eng.hitachivantara.com/artifactory/pnt-mvn"

--- a/gradle.properties
+++ b/gradle.properties
@@ -264,7 +264,7 @@ poiVersion=5.4.0
 pollingWatchVersion=0.2.0
 
 # Newer versions of the driver have a perf degradation that's important for us. https://github.com/pgjdbc/pgjdbc/issues/3505
-postgresqlDriverVersion=42.7.7-SNAPSHOT
+postgresqlDriverVersion=42.7.4
 
 quartzVersion=2.5.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -264,7 +264,7 @@ poiVersion=5.4.0
 pollingWatchVersion=0.2.0
 
 # Newer versions of the driver have a perf degradation that's important for us. https://github.com/pgjdbc/pgjdbc/issues/3505
-postgresqlDriverVersion=42.7.4
+postgresqlDriverVersion=42.7.7-SNAPSHOT
 
 quartzVersion=2.5.0
 

--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -7,7 +7,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.ApplicationPidFileWriter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.web.embedded.tomcat.TomcatConnectorCustomizer;
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
 import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.context.annotation.Bean;


### PR DESCRIPTION
#### Rationale
This PR was used to test if the latest SNAPSHOT driver addressed performance issues reported in https://github.com/pgjdbc/pgjdbc/issues/3505. The performance issues are greatly improved, but we need to wait for an official release before upgrading.

This PR now contains only a commented out maven URL and instructions for testing future SNAPSHOT versions of the PostgreSQL JDBC driver. 