### PR TITLE
Move default Tomcat request properties into code

### DIFF
--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -46,12 +46,12 @@ context.encryptionKey=@@encryptionKey@@
 
 ## By default, we serve LabKey at the root context path (e.g. http://localhost:8080)
 ## You may customize the context path if you wish (e.g. http://localhost:8080/labkey)
-## Context path value must start with a slash
+## The context path value must start with a slash
 #context.contextPath=/labkey
 
 ## Using a legacy context path provides backwards compatibility with old deployments. A typical use case would be to
 ## deploy to the root context (the default) and configure /labkey as the legacy path. GETs will be redirected.
-## All other methods (POSTs, PUTs, etc) will be handled server-side via a servlet forward.
+## All other methods (POSTs, PUTs, etc.) will be handled server-side via a servlet forward.
 #context.legacyContextPath=/labkey
 
 ## Other webapps to be deployed, most commonly to deliver a set of static files. The context path to deploy into is the
@@ -68,11 +68,12 @@ context.encryptionKey=@@encryptionKey@@
 
 ## Tomcat v10.1.42 lowered the default for part count from 1000 to 10. Our default is now 500.
 ## Tomcat also lowered the header size default from 10Kb to 512, which is also our default.
-## We lower max connections from default 8192 to 250, providing ample concurrent requests for LabKey Server scenarios.
-## These settings can be overridden if needed, but reasonable limits reduce your server's vulnerability to DoS attacks.
-server.tomcat.max-part-count=500
-server.tomcat.max-part-header-size=512
-server.tomcat.max-connections=250
+## We lowered max connections from default 8192 to 250, providing ample concurrent requests for LabKey Server scenarios.
+## These default values are set via the server code (LabKeyServer.java), but they can be overridden below, if needed.
+## However, note that reasonable limits reduce your server's vulnerability to DoS attacks.
+#server.tomcat.max-part-count=500
+#server.tomcat.max-part-header-size=512
+#server.tomcat.max-connections=250
 
 ## SMTP configuration
 mail.smtpHost=@@smtpHost@@

--- a/server/configs/webapps/embedded/config/application.properties
+++ b/server/configs/webapps/embedded/config/application.properties
@@ -58,15 +58,15 @@ server.error.include-message=always
 ##   This must not be the same as the server.port set above.
 #context.httpPort=80
 
-## We strongly recommend deploying LabKey at the root context path (e.g. http://localhost:8080)
+## We strongly recommend deploying LabKey at the root context path (e.g., http://localhost:8080)
 ## If your previous configuration file was named "ROOT.xml", you were already deployed at the root.
-## If you previously used a different context path, such as "/labkey" (i.e. with a configuration
+## If you previously used a different context path, such as "/labkey" (i.e., with a configuration
 ## file named "labkey.xml"), set a legacy context path for backwards compatibility.
 ## Previous URLs, GETs, etc. will be redirected or handled server-side via a servlet forward.
 #context.legacyContextPath=/labkey
 
-## We do not recommend deploying to a non-root context path (e.g. http://localhost:8080/labkey)
-## If you do set this property, do not set a legacyContextPath.
+## We do not recommend deploying to a non-root context path (e.g., http://localhost:8080/labkey)
+## If you do set this property, do not set a legacyContextPath. And the context path value must start with a slash.
 #context.contextPath=/labkey
 
 ####################################################################################
@@ -105,11 +105,12 @@ mail.smtpUser=Anonymous
 
 ## Tomcat v10.1.42 lowered the default for part count from 1000 to 10. Our default is now 500.
 ## Tomcat also lowered the header size default from 10Kb to 512, which is also our default.
-## We lower max connections from default 8192 to 250, providing ample concurrent requests for LabKey Server scenarios.
-## These settings can be overridden if needed, but reasonable limits reduce your server's vulnerability to DoS attacks.
-server.tomcat.max-part-count=500
-server.tomcat.max-part-header-size=512
-server.tomcat.max-connections=250
+## We lowered max connections from default 8192 to 250, providing ample concurrent requests for LabKey Server scenarios.
+## These default values are set via the server code (LabKeyServer.java), but they can be overridden below, if needed.
+## However, note that reasonable limits reduce your server's vulnerability to DoS attacks.
+#server.tomcat.max-part-count=500
+#server.tomcat.max-part-header-size=512
+#server.tomcat.max-connections=250
 
 ## Other webapps to be deployed, most commonly to deliver a set of static files. The context path to deploy into is the
 ## property name after the "context.additionalWebapps." prefix, and the value is the location of the webapp on disk

--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -15,6 +15,7 @@ import org.springframework.validation.annotation.Validated;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -66,36 +67,43 @@ public class LabKeyServer
 
         SpringApplication application = new SpringApplication(LabKeyServer.class);
         application.addListeners(new ApplicationPidFileWriter("./labkey.pid"));
-        application.setDefaultProperties(Map.of(
-                "server.tomcat.basedir", ".",
-                "server.tomcat.accesslog.directory", logHome,
+        application.setDefaultProperties(new HashMap<>()
+             {{
+                 put("server.tomcat.basedir", ".");
+                 put("server.tomcat.accesslog.directory", logHome);
 
-                // Enable HTTP compression for response content
-                "server.compression.enabled", "true",
+                 // Boost limits imposed by Tomcat v10.1.42
+                 put("server.tomcat.max-part-count", 500);
+                 put("server.tomcat.max-part-header-size", 512);
+                 put("server.tomcat.max-connections", 250);
 
-                "server.tomcat.accesslog.enabled", "true",
-                "server.tomcat.accesslog.pattern", "%h %l %u %t \"%r\" %s %b %D %S %I \"%{Referer}i\" \"%{User-Agent}i\" %{LABKEY.username}s %{X-Forwarded-For}i",
-                "jsonaccesslog.pattern", "%h %t %m %U %s %b %D %S \"%{Referer}i\" \"%{User-Agent}i\" %{LABKEY.username}s %{X-Forwarded-For}i",
+                 // Enable HTTP compression for response content
+                 put("server.compression.enabled", "true");
 
-                // Issue 52415: Omit stack traces from Tomcat error pages by default, but propagate error messages
-                "server.error.include-stacktrace", "never",
-                "server.error.include-message", "always",
+                 put("server.tomcat.accesslog.enabled", "true");
+                 put("server.tomcat.accesslog.pattern", "%h %l %u %t \"%r\" %s %b %D %S %I \"%{Referer}i\" \"%{User-Agent}i\" %{LABKEY.username}s %{X-Forwarded-For}i");
+                 put("jsonaccesslog.pattern", "%h %t %m %U %s %b %D %S \"%{Referer}i\" \"%{User-Agent}i\" %{LABKEY.username}s %{X-Forwarded-For}i");
 
-                // A strong report-only Content Security Policy that reports violations to this server
-                "csp.report", """
-                        default-src 'self' ;
-                        connect-src 'self' ${CONNECTION.SOURCES} ;
-                        object-src 'none' ;
-                        style-src 'self' 'unsafe-inline' ${STYLE.SOURCES} ;
-                        img-src 'self' data: ${IMAGE.SOURCES} ;
-                        font-src 'self' data: ${FONT.SOURCES} ;
-                        script-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ;
-                        base-uri 'self' ;
-                        frame-ancestors 'self' ;
-                        frame-src 'self' ${FRAME.SOURCES} ;
-                        report-uri ${context.contextPath:}/admin-contentSecurityPolicyReport.api?cspVersion=r11&${CSP.REPORT.PARAMS}
-                    """
-        ));
+                 // Issue 52415: Omit stack traces from Tomcat error pages by default, but propagate error messages
+                 put("server.error.include-stacktrace", "never");
+                 put("server.error.include-message", "always");
+
+                 // A strong report-only Content Security Policy that reports violations to this server
+                 put("csp.report", """
+                             default-src 'self' ;
+                             connect-src 'self' ${CONNECTION.SOURCES} ;
+                             object-src 'none' ;
+                             style-src 'self' 'unsafe-inline' ${STYLE.SOURCES} ;
+                             img-src 'self' data: ${IMAGE.SOURCES} ;
+                             font-src 'self' data: ${FONT.SOURCES} ;
+                             script-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ;
+                             base-uri 'self' ;
+                             frame-ancestors 'self' ;
+                             frame-src 'self' ${FRAME.SOURCES} ;
+                             report-uri ${context.contextPath:}/admin-contentSecurityPolicyReport.api?cspVersion=r11&${CSP.REPORT.PARAMS}
+                         """);
+             }}
+        );
         application.setBannerMode(Banner.Mode.OFF);
         application.run(args);
     }


### PR DESCRIPTION
#### Rationale
Moving these default values into code means they don't have to be provided in `application.properties`

#### Related Pull Requests
* https://github.com/LabKey/server/pull/1104