### PR TITLE
Remove application properties for configuring management endpoints

### DIFF
--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -114,15 +114,6 @@ mail.smtpUser=@@smtpUser@@
 # HTTP session timeout for users - defaults to 30 minutes
 #server.servlet.session.timeout=30m
 
-## Enable shutdown endpoint
-management.endpoint.shutdown.enabled=true
-## turn off other endpoints
-management.endpoints.enabled-by-default=false
-## allow access via http
-management.endpoints.web.exposure.include=*
-## Use a separate port for management endpoints. Required if LabKey is using default (ROOT) context path
-management.server.port=@@shutdownPort@@
-
 ## Turn on JSON-formatted HTTP access logging to stdout. See issue 48565
 ## https://tomcat.apache.org/tomcat-9.0-doc/config/valve.html#JSON_Access_Log_Valve
 #jsonaccesslog.enabled=true


### PR DESCRIPTION
#### Rationale
[Issue 53244: Unable to stop server via Spring Boot shutdown endpoint](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53244)

We've decided it's ok to stop supporting this functionality.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/937

#### Changes
* Remove dev properties for configuring management endpoints
