### PR TITLE
comment out audit log disabling blocks

### DIFF
--- a/server/embedded/src/main/resources/log4j2.xml
+++ b/server/embedded/src/main/resources/log4j2.xml
@@ -300,7 +300,7 @@
             <AppenderRef ref="QUERY_STATS"/>
         </Logger>
 
-        <!-- <Logger name="org.labkey.audit.event" level="OFF">
+        <!-- <Logger name="org.labkey.audit.event" level="INFO">
             <AppenderRef ref="LABKEY_AUDIT"/>
         </Logger> -->
 
@@ -332,7 +332,7 @@
          individual stanza like the one shown below, where you prefix the audit event type
          with 'org.labkey.audit.event'. Then set the level to INFO and specify the appenders.
         -->
-        <!-- <Logger name="org.labkey.audit.event.UserAuditEvent" additivity="false" level="OFF">
+        <!-- <Logger name="org.labkey.audit.event.UserAuditEvent" additivity="false" level="INFO">
             <AppenderRef ref="LABKEY_AUDIT"/>
             <AppenderRef ref="CONSOLE"/>
         </Logger> -->

--- a/server/embedded/src/main/resources/log4j2.xml
+++ b/server/embedded/src/main/resources/log4j2.xml
@@ -300,9 +300,9 @@
             <AppenderRef ref="QUERY_STATS"/>
         </Logger>
 
-        <Logger name="org.labkey.audit.event" level="OFF">
+        <!-- <Logger name="org.labkey.audit.event" level="OFF">
             <AppenderRef ref="LABKEY_AUDIT"/>
-        </Logger>
+        </Logger> -->
 
         <!--
           Other audit event types include, but are not limited to:
@@ -332,10 +332,10 @@
          individual stanza like the one shown below, where you prefix the audit event type
          with 'org.labkey.audit.event'. Then set the level to INFO and specify the appenders.
         -->
-        <Logger name="org.labkey.audit.event.UserAuditEvent" additivity="false" level="OFF">
+        <!-- <Logger name="org.labkey.audit.event.UserAuditEvent" additivity="false" level="OFF">
             <AppenderRef ref="LABKEY_AUDIT"/>
             <AppenderRef ref="CONSOLE"/>
-        </Logger>
+        </Logger> -->
 
         <Logger name="NoOpLogger" level="OFF" additivity="false"/>
     </Loggers>


### PR DESCRIPTION
#### Rationale
audit logging options change based on which environment we are deploying to, and these default "offs" are taking precedence over downstream overrides. Best to comment them out, but leave as an example.

#### Related Pull Requests
* https://github.com/LabKey/syseng-chef-server/pull/636

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
