### PR TITLE
restore auditlog top level

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -44,7 +44,7 @@ buildFromSource=true
 
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
-labkeyVersion=25.7-SNAPSHOT
+labkeyVersion=25.8-SNAPSHOT
 labkeyClientApiVersion=6.3.0
 
 # Version numbers for the various binary artifacts that are included when

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ org.gradle.parallel=true
 # (this could be memory-intensive)
 org.gradle.workers.max=3
 # Default to using 2GB of memory for the JVM.
-org.gradle.jvmargs=-Xmx2048m -XX:+UseParallelGC
+org.gradle.jvmargs=-Xmx2048m -XX:+UseParallelGC -Dfile.encoding=UTF-8
 # Uncomment to restrict the number of concurrent npm build tasks. Useful for systems with limited resources.
 #npmRunLimit=2
 
@@ -59,7 +59,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=5.2.5
 gradleNodePluginVersion=7.1.0
-gradlePluginsVersion=6.2.0
+gradlePluginsVersion=6.3.0
 owaspDependencyCheckPluginVersion=12.1.3
 versioningPluginVersion=1.1.2
 

--- a/gradle/settings/all.gradle
+++ b/gradle/settings/all.gradle
@@ -24,7 +24,7 @@ buildscript {
         {
             mavenLocal()
             maven {
-                url "${artifactory_contextUrl}/plugins-snapshot-local"
+                url = "${artifactory_contextUrl}/plugins-snapshot-local"
                 mavenContent {
                     snapshotsOnly()
                 }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -191,6 +191,7 @@ project.tasks.register("reportVersionToTeamCity", DefaultTask) {
             println "##teamcity[setParameter name='labkey.version' value='${labkeyVersion}']"
         })
 }
+
 if (project.hasProperty("teamcity"))
 {
     project.tasks.named('stageApp').configure { dependsOn(project.tasks.named('reportVersionToTeamCity')) }
@@ -210,14 +211,11 @@ else
             task.description = "Copy dependencies required for JSP dynamic compiling"
             task.into project.rootProject.layout.buildDirectory.dir("jspRecompiling")
             task.from project.configurations.recompilingJsp
-            task.mustRunAfter(cleanJspRecompileSetup)
+            task.dependsOn(cleanJspRecompileSetup)
             if (project.hasProperty('apacheTomcatVersion'))
                 task.inputs.property 'apacheTomcatVersion', project.property('apacheTomcatVersion')
             else
                 task.outputs.cacheIf { false } // Just don't cache if we can't be sure of the Jasper version
-            task.doFirst {
-                project.delete project.rootProject.layout.buildDirectory.dir("jspRecompiling")
-            }
     }
 
     project.tasks.named('deployApp').configure {

--- a/server/embedded/src/main/resources/log4j2.xml
+++ b/server/embedded/src/main/resources/log4j2.xml
@@ -300,9 +300,9 @@
             <AppenderRef ref="QUERY_STATS"/>
         </Logger>
 
-        <!-- <Logger name="org.labkey.audit.event" level="INFO">
+        <Logger name="org.labkey.audit.event" level="INFO">
             <AppenderRef ref="LABKEY_AUDIT"/>
-        </Logger> -->
+        </Logger>
 
         <!--
           Other audit event types include, but are not limited to:


### PR DESCRIPTION
#### Rationale
previous PR https://github.com/LabKey/server/pull/1113 results in audit logs going to main labkey.log by default, which is not great, and also caused certain tests to fail. This restores just the top level audit log config to send those logs to the audit log, as before.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/1113

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
