### PR TITLE
restore top level audit logging in server default log4j

### DIFF
--- a/server/embedded/src/main/resources/log4j2.xml
+++ b/server/embedded/src/main/resources/log4j2.xml
@@ -300,7 +300,7 @@
             <AppenderRef ref="QUERY_STATS"/>
         </Logger>
 
-        <Logger name="org.labkey.audit.event" level="INFO">
+        <Logger name="org.labkey.audit.event" level="OFF">
             <AppenderRef ref="LABKEY_AUDIT"/>
         </Logger>
 

--- a/server/embedded/src/main/resources/log4j2.xml
+++ b/server/embedded/src/main/resources/log4j2.xml
@@ -300,9 +300,9 @@
             <AppenderRef ref="QUERY_STATS"/>
         </Logger>
 
-        <!-- <Logger name="org.labkey.audit.event" level="INFO">
+        <Logger name="org.labkey.audit.event" level="INFO">
             <AppenderRef ref="LABKEY_AUDIT"/>
-        </Logger> -->
+        </Logger>
 
         <!--
           Other audit event types include, but are not limited to:


### PR DESCRIPTION
#### Rationale
previous PR https://github.com/LabKey/server/pull/1113 results in audit logs going to main labkey.log by default, which is not great, and also caused certain tests to fail. This restores just the top level audit log config to send those logs to the audit log, as before.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/1113

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
