### PR TITLE
Update Java client API version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -45,7 +45,7 @@ buildFromSource=true
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
 labkeyVersion=25.8-SNAPSHOT
-labkeyClientApiVersion=6.4.0-QuerySaveRowsCommand-SNAPSHOT
+labkeyClientApiVersion=7.0.0-SNAPSHOT
 
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.

--- a/gradle.properties
+++ b/gradle.properties
@@ -45,7 +45,7 @@ buildFromSource=true
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
 labkeyVersion=25.8-SNAPSHOT
-labkeyClientApiVersion=6.3.0
+labkeyClientApiVersion=6.4.0-QuerySaveRowsCommand-SNAPSHOT
 
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.


### PR DESCRIPTION
#### Rationale
See https://github.com/LabKey/labkey-api-java/pull/83 for rationale.

#### Related Pull Requests
- https://github.com/LabKey/labkey-api-java/pull/83
- https://github.com/LabKey/server/pull/1132
- https://github.com/LabKey/testAutomation/pull/2568

#### Changes
* Bump `labkeyClientApiVersion` to latest version
