### PR TITLE
Update Java client API version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -45,7 +45,7 @@ buildFromSource=true
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
 labkeyVersion=25.8-SNAPSHOT
-labkeyClientApiVersion=7.0.0-SNAPSHOT
+labkeyClientApiVersion=7.0.0
 
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.


### PR DESCRIPTION
#### Rationale
My previous PR #1132 updated to `SNAPSHOT`. We don't want to run with snapshot on develop. This updates to the latest published release.

#### Related Pull Requests
- #1132

#### Changes
- Update to `v7.0.0` for `labkeyClientApiVersion`
