### PR TITLE
Update GWT to the latest version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -171,8 +171,8 @@ grpcVersion=1.73.0
 guavaVersion=33.4.8-jre
 
 # Note: You won't find usages in the product sources; this property is used by the gradle plugin.
-gwtVersion=2.11.0
-gwtServletJakartaVersion=2.11.0
+gwtVersion=2.12.2
+gwtServletJakartaVersion=2.12.2
 
 # force hadoop-hdfs-client for CVE-2021-37404, CVE-2022-25168, CVE-2022-26612, CVE-2021-25642, CVE-2021-33036, CVE-2023-26031,
 hadoopHdfsClientVersion=3.4.1


### PR DESCRIPTION
#### Rationale
Update to suppress two "new" CVE complaints related to a shaded version of protobuf bundled with GWT. As usual, detailed information is hard to come by, but I believe these are false positives because:

- One or both pertain to the C++ version
- The protobuf classes are internal only and not used at runtime

Nevertheless, suppressing the errors with a simple dependency update is always preferable

https://github.com/gwtproject/gwt/issues/9752
https://groups.google.com/g/google-web-toolkit/c/tr2d8-RhMPc?pli=1

Note: We're relying on the automated tests to flag any issues with the legacy plate designer (our last remaining GWT component).