### PR TITLE
Update Bouncy Castle version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -110,8 +110,8 @@ asmVersion=9.8
 batikVersion=1.19
 
 # sync with Tika version (or later)
-bouncycastlePgpVersion=1.79
-bouncycastleVersion=1.79
+bouncycastlePgpVersion=1.81
+bouncycastleVersion=1.81
 
 cglibNodepVersion=2.2.3
 


### PR DESCRIPTION
#### Rationale
Latest is greatest. Update was previously blocked by an NLP test failure that we didn't want to spend time investigating. https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52712

#### Related Pull Requests
* https://github.com/LabKey/clientModules/pull/54