### PR TITLE
Suppress CVE-2024-7254

### DIFF
--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -248,4 +248,13 @@
        <packageUrl regex="true">^pkg:maven/com\.google\.code\.gson/gson@.*$</packageUrl>
        <vulnerabilityName>CVE-2025-53864</vulnerabilityName>
     </suppress>
+
+    <suppress>
+        <notes><![CDATA[
+       file name: protobuf-java-util-3.23.2.jar
+       ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.google\.protobuf/protobuf-java-util@.*$</packageUrl>
+        <cpe>cpe:/a:google:protobuf</cpe>
+    </suppress>
+
 </suppressions>

--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -249,6 +249,7 @@
        <vulnerabilityName>CVE-2025-53864</vulnerabilityName>
     </suppress>
 
+    <!-- Old version of protobuf brought in as a transitive dependency in Sequence Analysis module. Currently no way to force upgrade.   -->
     <suppress>
         <notes><![CDATA[
        file name: protobuf-java-util-3.23.2.jar

--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -252,10 +252,10 @@
     <!-- Old version of protobuf brought in as a transitive dependency in Sequence Analysis module. Currently no way to force upgrade.   -->
     <suppress>
         <notes><![CDATA[
-       file name: protobuf-java-util-3.23.2.jar
-       ]]></notes>
+        file name: protobuf-java-util-3.23.2.jar
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.google\.protobuf/protobuf-java-util@.*$</packageUrl>
-        <cpe>cpe:/a:google:protobuf</cpe>
+        <cve>CVE-2024-7254</cve>
     </suppress>
 
 </suppressions>


### PR DESCRIPTION
#### Rationale
This is not a risk outside of one client specific module which is waiting on a package update using this version as a transitive dependency.

#### Changes
* Suppress cve
