### PR TITLE
Adopt Tika 3.2.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -299,7 +299,7 @@ stax2ApiVersion=4.2.2
 thumbnailatorVersion=0.4.20
 
 # used for tika-core in API and tika-parsers in search
-tikaVersion=3.2.1
+tikaVersion=3.2.2
 
 # sync with Tika
 tukaaniXZVersion=1.10


### PR DESCRIPTION
#### Rationale
CVE-2025-54988

#### Changes
* Bump to recommended version
