### PR TITLE
netty version bump for CVE-2025-58057

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -247,7 +247,7 @@ luceneVersion=9.12.2
 mssqlJdbcVersion=12.10.1.jre11
 
 # force for docker
-nettyVersion=4.2.2.Final
+nettyVersion=4.2.5.Final
 
 objenesisVersion=1.0
 


### PR DESCRIPTION
#### Rationale
bump Netty from 4.2.2.Final to 4.2.5.Final for CVE-2025-58057

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
