### PR TITLE
Update to latest version of owaspDependencyChecker and add properties for oss authentication

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,6 @@ plugins {
 allprojects {
     if (project.hasProperty('enableOwaspDependencyCheck'))
     {
-        // Comment in to enable the tasks for owasp dependency checking
         apply plugin: 'org.owasp.dependencycheck'
         dependencyCheck {
             outputDirectory = project.rootProject.layout.buildDirectory.file("reports/dependencyCheck/${project.path.replaceAll(':', '_').substring(1)}").get().asFile
@@ -31,6 +30,15 @@ allprojects {
                 retirejs {
                     enabled = false
                 }
+            }
+            if (project.hasProperty('ossIndexUsername') && project.hasProperty('ossIndexPassword'))
+            {
+                analyzers.ossIndex.username = project.property('ossIndexUsername')
+                analyzers.ossIndex.password = project.property('ossIndexPassword');
+            }
+            else
+            {
+                analyzers.ossIndex.enabled = false
             }
             formats = ['HTML', 'JUNIT']
             skipConfigurations = ['dedupe', 'gwtCompileClasspath', 'gwtRuntimeClasspath', 'developmentOnly']

--- a/gradle.properties
+++ b/gradle.properties
@@ -60,7 +60,7 @@ windowsProteomicsBinariesVersion=1.0
 artifactoryPluginVersion=5.2.5
 gradleNodePluginVersion=7.1.0
 gradlePluginsVersion=7.0.0
-owaspDependencyCheckPluginVersion=12.1.5
+owaspDependencyCheckPluginVersion=12.1.6
 versioningPluginVersion=1.1.2
 
 # Versions of node and npm to use during the build. If set, these versions

--- a/gradle.properties
+++ b/gradle.properties
@@ -60,7 +60,7 @@ windowsProteomicsBinariesVersion=1.0
 artifactoryPluginVersion=5.2.5
 gradleNodePluginVersion=7.1.0
 gradlePluginsVersion=7.0.0
-owaspDependencyCheckPluginVersion=12.1.3
+owaspDependencyCheckPluginVersion=12.1.5
 versioningPluginVersion=1.1.2
 
 # Versions of node and npm to use during the build. If set, these versions


### PR DESCRIPTION
#### Rationale
On September 22, Sonatype started requiring authentication to get its OSS Index reports. Fortunately, the owaspDependencyChecker developers also [released a plugin update](https://github.com/dependency-check/DependencyCheck/blob/main/CHANGELOG.md#change-log) to get these properties included.

#### Related Pull Requests
* https://github.com/LabKey/test_secure/pull/27

#### Changes
* Update to owaspDependencyChecker version 12.1.6 and add properties for the user name and password for getting data from ossIndex
