### PR TITLE
Update to latest version of owaspDependencyChecker and add properties for oss authentication

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,6 @@ plugins {
 allprojects {
     if (project.hasProperty('enableOwaspDependencyCheck'))
     {
-        // Comment in to enable the tasks for owasp dependency checking
         apply plugin: 'org.owasp.dependencycheck'
         dependencyCheck {
             outputDirectory = project.rootProject.layout.buildDirectory.file("reports/dependencyCheck/${project.path.replaceAll(':', '_').substring(1)}").get().asFile
@@ -31,6 +30,15 @@ allprojects {
                 retirejs {
                     enabled = false
                 }
+            }
+            if (project.hasProperty('ossIndexUsername') && project.hasProperty('ossIndexPassword'))
+            {
+                analyzers.ossIndex.username = project.property('ossIndexUsername')
+                analyzers.ossIndex.password = project.property('ossIndexPassword');
+            }
+            else
+            {
+                analyzers.ossIndex.enabled = false
             }
             formats = ['HTML', 'JUNIT']
             skipConfigurations = ['dedupe', 'gwtCompileClasspath', 'gwtRuntimeClasspath', 'developmentOnly']

--- a/gradle.properties
+++ b/gradle.properties
@@ -289,7 +289,7 @@ snappyJavaVersion=1.1.10.7
 # Also, update apacheTomcatVersion above to match Spring Boot's Tomcat dependency version
 springBootVersion=3.5.3
 # This usually matches the Spring Framework version dictated by springBootVersion
-springVersion=6.2.10
+springVersion=6.2.11
 
 sqliteJdbcVersion=3.50.3.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -247,7 +247,7 @@ luceneVersion=9.12.2
 mssqlJdbcVersion=12.10.1.jre11
 
 # force for docker
-nettyVersion=4.2.2.Final
+nettyVersion=4.2.5.Final
 
 objenesisVersion=1.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -60,7 +60,7 @@ windowsProteomicsBinariesVersion=1.0
 artifactoryPluginVersion=5.2.5
 gradleNodePluginVersion=7.1.0
 gradlePluginsVersion=6.3.0
-owaspDependencyCheckPluginVersion=12.1.5
+owaspDependencyCheckPluginVersion=12.1.6
 versioningPluginVersion=1.1.2
 
 # Versions of node and npm to use during the build. If set, these versions

--- a/gradle.properties
+++ b/gradle.properties
@@ -60,7 +60,7 @@ windowsProteomicsBinariesVersion=1.0
 artifactoryPluginVersion=5.2.5
 gradleNodePluginVersion=7.1.0
 gradlePluginsVersion=6.3.0
-owaspDependencyCheckPluginVersion=12.1.3
+owaspDependencyCheckPluginVersion=12.1.5
 versioningPluginVersion=1.1.2
 
 # Versions of node and npm to use during the build. If set, these versions


### PR DESCRIPTION
#### Rationale
On September 22, Sonatype started requiring authentication to get its OSS Index reports. Fortunately, the owaspDependencyChecker developers also [released a plugin update](https://github.com/dependency-check/DependencyCheck/blob/main/CHANGELOG.md#change-log) to get these properties included.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Update plugin version
* Add properties for ossIndex credentials
