### PR TITLE
Update moduleSet gradle settings files

### DIFF
--- a/gradle/settings/all.gradle
+++ b/gradle/settings/all.gradle
@@ -58,16 +58,13 @@ if (hasProperty('gradleExcludeModuleDirs'))
 if (hasProperty('excludedModules'))
     exclusions.addAll("${excludedModules}".split(","))
 
-// Include ':server:embedded' unless explicitly excluded
-if (!exclusions.contains("embedded"))
-{
-    include BuildUtils.getEmbeddedProjectPath(gradle)
-}
-
 BuildUtils.includeModules(this.settings, rootDir, ["server/modules"], exclusions, true)
 
-// include the test distribution, which is used to create an artifact for TeamCity to pass around to the agents
-include "${BuildUtils.getTestProjectPath(this.settings.gradle)}:distributions:teamcity"
+if (new File(getRootDir(), BuildUtils.convertPathToRelativeDir(BuildUtils.getTestProjectPath(gradle))).exists())
+{
+    // include the test distribution, which is used to create an artifact for TeamCity to pass around to the agents
+    include "${BuildUtils.getTestProjectPath(this.settings.gradle)}:distributions:teamcity"
+}
 
 if (new File(getRootDir(), BuildUtils.convertPathToRelativeDir(BuildUtils.getJdbcApiProjectPath(gradle))).exists())
 {

--- a/gradle/settings/ehr.gradle
+++ b/gradle/settings/ehr.gradle
@@ -66,10 +66,15 @@ if (hasProperty('excludedModules'))
 BuildUtils.includeModules(this.settings, rootDir, [BuildUtils.PLATFORM_MODULES_DIR, BuildUtils.COMMON_ASSAYS_MODULES_DIR], excludedModules)
 BuildUtils.includeModules(this.settings, rootDir, ehrModulesDirs, excludedModules)
 
-include ":server:modules:snd"
-include ":server:modules:premiumModules:dataintegration"
-include ":server:modules:premiumModules:premium"
-include ":server:modules:premiumModules:ldap"
+if (new File(getRootDir(), BuildUtils.convertPathToRelativeDir(":server:modules:premiumModules")).exists())
+{
+    include ":server:modules:premiumModules:dataintegration"
+    include ":server:modules:premiumModules:premium"
+    include ":server:modules:premiumModules:ldap"
+}
 
-// include the test distribution, which is used to create an artifact for TeamCity to pass around to the agents
-include "${BuildUtils.getTestProjectPath(this.settings.gradle)}:distributions:teamcity"
+if (new File(getRootDir(), BuildUtils.convertPathToRelativeDir(BuildUtils.getTestProjectPath(gradle))).exists())
+{
+    // include the test distribution, which is used to create an artifact for TeamCity to pass around to the agents
+    include "${BuildUtils.getTestProjectPath(this.settings.gradle)}:distributions:teamcity"
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -171,13 +171,13 @@ else
     // The line below includes all modules in the server/modules, server/modules/platform, server/modules/commonAssays, and server/modules/customModules directories
     //BuildUtils.includeModules(this.settings, rootDir, BuildUtils.SERVER_MODULE_DIRS, excludedModules)
 
-    // The line below includes a set of individual modules (in this case, some EHR related modules)
-    //BuildUtils.includeModules(this.settings, [":server:modules:tnprc_ehr",
-    //                                         ":server:modules:tnprc_billing",
-    //                                         ":server:modules:snd"])
+    // The line below includes a set of individual modules (in this case, some assay modules)
+    //BuildUtils.includeModules(this.settings, [":server:modules:commonAssays:elisa",
+    //                                         ":server:modules:commonAssays:flow",
+    //                                         ":server:modules:commonAssays:ms2"])
 
     // The line below is an example of how to include a single module
-    //include ":server:modules:workflow"
+    //include ":server:modules:commonAssays:ms2"
 }
 
 if (hasProperty('extraIncludes'))


### PR DESCRIPTION
#### Rationale
[[Issue](https://www.labkey.org/home/issues-details.view?issueId=54047)]

Gradle 9 is more strict about including non-existent projects.

#### Related Pull Requests
* #1182 

#### Changes
* Update moduleSet gradle settings files to account for missing projects
* Update obsolete gradle project references
