### PR TITLE
Suppress more noisy POI & FontBox classes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -195,6 +195,7 @@ intellijKotlinVersion=1.9.10
 
 # Update all Jackson dependency versions below in tandem, unless one gets a patch release out-of-sync with the others
 jacksonVersion=2.20.0
+# Note the inconsistent version numbering for "annotations"
 jacksonAnnotationsVersion=2.20
 jacksonDatabindVersion=2.20.0
 jacksonJaxrsBaseVersion=2.20.0

--- a/server/embedded/src/main/resources/log4j2.xml
+++ b/server/embedded/src/main/resources/log4j2.xml
@@ -235,6 +235,7 @@
         <Logger name="org.apache.poi.hwpf.model.FileInformationBlock" level="error"/>
         <Logger name="org.apache.poi.hwpf.model.ListLevel" level="error"/>
         <Logger name="org.apache.poi.hwpf.model.PAPBinTable" level="error"/>
+        <Logger name="org.apache.poi.ooxml.POIXMLDocumentPart" level="error"/>
         <Logger name="org.apache.poi.xssf.usermodel.XSSFDrawing" level="error"/>
 
         <!-- this is a very verbose logger for security/permissions checking -->

--- a/server/embedded/src/main/resources/log4j2.xml
+++ b/server/embedded/src/main/resources/log4j2.xml
@@ -222,13 +222,19 @@
         <!-- Suppress POI's PackageRelationshipCollection's "Cannot convert {} in a valid relationship URI" URISyntaxExceptions, Issue 51960 -->
         <Logger name="org.apache.poi.openxml4j.opc.PackageRelationshipCollection" level="fatal"/>
 
-        <!-- Suppress some other noisy POI classes that log warnings during document text extraction -->
+        <!-- Suppress some noisy FontBox and POI classes that log warnings during document text extraction -->
+        <Logger name="org.apache.fontbox.ttf.CmapSubtable" level="error"/>
+        <Logger name="org.apache.fontbox.ttf.PostScriptTable" level="error"/>
         <Logger name="org.apache.poi.hdgf.chunks.Chunk" level="error"/>
         <Logger name="org.apache.poi.hpsf.CodePageString" level="error"/>
         <Logger name="org.apache.poi.hslf.model.textproperties.BitMaskTextProp" level="error"/>
         <Logger name="org.apache.poi.hslf.record.Record" level="error"/>
         <Logger name="org.apache.poi.hslf.usermodel.HSLFTextParagraph" level="error"/>
+        <Logger name="org.apache.poi.hsmf.datatypes.PropertiesChunk" level="error"/>
+        <Logger name="org.apache.poi.hwmf.record.HwmfText" level="error"/>
         <Logger name="org.apache.poi.hwpf.model.FileInformationBlock" level="error"/>
+        <Logger name="org.apache.poi.hwpf.model.ListLevel" level="error"/>
+        <Logger name="org.apache.poi.hwpf.model.PAPBinTable" level="error"/>
         <Logger name="org.apache.poi.xssf.usermodel.XSSFDrawing" level="error"/>
 
         <!-- this is a very verbose logger for security/permissions checking -->


### PR DESCRIPTION
#### Rationale
Warnings from these classes at document indexing time are getting logged on staging.labkey.org. They are not actionable or helpful, so let's suppress them.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/1162