### PR TITLE
Update StartLabKey and StopLabKey tasks

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -59,7 +59,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=5.2.5
 gradleNodePluginVersion=7.1.0
-gradlePluginsVersion=7.0.0
+gradlePluginsVersion=7.1.0-updateStartAndStopTasks-SNAPSHOT
 owaspDependencyCheckPluginVersion=12.1.6
 versioningPluginVersion=1.1.2
 


### PR DESCRIPTION
#### Rationale
[Issue 53792: Capture heap dumps when a test causes an OutOfMemoryError on TeamCity](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53792)
[Issue 53244: Update 'stopTomcat' Gradle task to work without Spring's shutdown endpoint](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53244)

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/235

#### Changes
- Capture heap dumps when a test causes an OutOfMemoryError on TeamCity
- Update 'stopTomcat' Gradle task to work without Spring's shutdown endpoint