### PR TITLE
Remove version force for ByteBuddy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -210,8 +210,6 @@ allprojects {
                     force "org.slf4j:slf4j-api:${slf4jLog4jApiVersion}"
                     // force some newer versions than are brought in by mondrian (et al.)
                     force "xerces:xercesImpl:${xercesImplVersion}"
-                    // Microsoft SQL Server JDBC driver and Duo SDK pull in different versions of byte-buddy
-                    force "net.bytebuddy:byte-buddy:${byteBuddyVersion}"
                     force "org.apache.logging.log4j:log4j-core:${log4j2Version}"
                     force "org.apache.logging.log4j:log4j-api:${log4j2Version}"
                     force "org.apache.logging.log4j:log4j-1.2-api:${log4j2Version}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -113,8 +113,6 @@ batikVersion=1.19
 bouncycastlePgpVersion=1.82
 bouncycastleVersion=1.82
 
-byteBuddyVersion=1.17.8
-
 cglibNodepVersion=2.2.3
 
 checkerQualVersion=3.31.0


### PR DESCRIPTION
#### Rationale
ByteBuddy is no longer included in MSSQL JDBC Driver: https://github.com/microsoft/mssql-jdbc/pull/2755
No need to force version to align Duo SDK

#### Related Pull Requests
* #1173 

#### Changes
* Remove version force for ByteBuddy
