### PR TITLE
Prefer File constructor argument to String argument

### DIFF
--- a/server/bootstrap/src/org/labkey/bootstrap/LabKeyBootstrapClassLoader.java
+++ b/server/bootstrap/src/org/labkey/bootstrap/LabKeyBootstrapClassLoader.java
@@ -210,7 +210,7 @@ public class LabKeyBootstrapClassLoader extends WebappClassLoader implements Exp
     @Override
     public Map.Entry<File,File> updateModule(File explodedModuleDirectory, File updateArchive, File existingArchive, File mvExistingArchive, boolean dryRun) throws IOException
     {
-        File updateArchiveNewHome = new File(existingArchive.getParent(), updateArchive.getName());
+        File updateArchiveNewHome = new File(existingArchive.getParentFile(), updateArchive.getName());
 
         validateReplaceArchive(explodedModuleDirectory, updateArchive, existingArchive);
 


### PR DESCRIPTION
#### Rationale
For code analysis purposes, it's better to use File as the argument instead of its String equivalent

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/7134

#### Changes
* Don't convert parent to a string