### PR TITLE
Issue 54138: Update versioning plugin to latest Gradle version

### DIFF
--- a/.idea/codeInsightSettings.xml
+++ b/.idea/codeInsightSettings.xml
@@ -36,6 +36,8 @@
       <name>org.jspecify.annotations.NotNull</name>
       <name>io.micrometer.common.lang.NonNull</name>
       <name>io.micrometer.common.lang.Nullable</name>
+      <name>edu.umd.cs.findbugs.annotations.Nullable</name>
+      <name>org.apache.poi.hpsf.GUID</name>
     </excluded-names>
   </component>
 </project>

--- a/gradle.properties
+++ b/gradle.properties
@@ -61,7 +61,7 @@ artifactoryPluginVersion=5.2.5
 gradleNodePluginVersion=7.1.0
 gradlePluginsVersion=7.1.0
 owaspDependencyCheckPluginVersion=12.1.8
-versioningPluginVersion=1.1.3-gradle9-SNAPSHOT
+versioningPluginVersion=1.1.3
 
 # Versions of node and npm to use during the build. If set, these versions
 # will be downloaded and used. If not set, the existing local installations will be used

--- a/gradle.properties
+++ b/gradle.properties
@@ -61,7 +61,7 @@ artifactoryPluginVersion=5.2.5
 gradleNodePluginVersion=7.1.0
 gradlePluginsVersion=7.1.0
 owaspDependencyCheckPluginVersion=12.1.8
-versioningPluginVersion=1.1.2
+versioningPluginVersion=1.1.3-gradle9-SNAPSHOT
 
 # Versions of node and npm to use during the build. If set, these versions
 # will be downloaded and used. If not set, the existing local installations will be used


### PR DESCRIPTION
#### Rationale
Issue [54138](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=54138) We upgraded to Gradle 9, which brings with it a new version of Groovy. Upgrading the versioning plugin seems warranted as well.

#### Related Pull Requests
* https://github.com/LabKey/versioning/pull/7

#### Changes
* Update versioning plugin version
* Add some classes to ignore in `codeInsightSettings.xml`
