### PR TITLE
Suppress bzip2 CVE false positives

### DIFF
--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -164,4 +164,22 @@
         <packageUrl regex="true">^pkg:maven/org\.labkey\.api/labkey-api-jdbc@.*$</packageUrl>
         <cpe>cpe:/a:labkey:labkey_server</cpe>
     </suppress>
+
+    <!--
+    False positives from CVEs in the bzip2 Debian package
+    -->
+    <suppress>
+        <notes><![CDATA[
+        file name: bzip2-0.9.1.jar
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.itadaki/bzip2@.*$</packageUrl>
+        <cpe>cpe:/a:bzip:bzip2</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        file name: bzip2-0.9.1.jar
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.itadaki/bzip2@.*$</packageUrl>
+        <cpe>cpe:/a:bzip2_project:bzip2</cpe>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
#### Rationale
The following CVEs are for the Debian bzip2 package, not the [jbzip2 package](https://code.google.com/archive/p/jbzip2/) imported by the [SequenceAnalysis module](https://github.com/LabKey/DiscvrLabKeyModules/blob/b5baa8383999e93015dbfae2c2d94c3704e6ce80/SequenceAnalysis/build.gradle#L88).
https://nvd.nist.gov/vuln/detail/CVE-2005-1260
https://nvd.nist.gov/vuln/detail/CVE-2010-0405
https://nvd.nist.gov/vuln/detail/CVE-2011-4089
https://nvd.nist.gov/vuln/detail/CVE-2019-12900

#### Related Pull Requests
* N/A

#### Changes
* Suppress bzip2 CVE false positives
