### PR TITLE
Update IDE issue navigation links

### DIFF
--- a/.idea/configTemplates/vcs.xml
+++ b/.idea/configTemplates/vcs.xml
@@ -18,6 +18,14 @@
           <option name="linkRegexp" value="https://www.labkey.org/issues/home/Developer/issues/details.view?issueId=$3" />
         </IssueNavigationLink>
         <IssueNavigationLink>
+          <option name="issueRegexp" value="(Epic|Story|Item)( +#?)([0-9]+)" />
+          <option name="linkRegexp" value="https://www.scrumwise.com/scrum/#/backlog-item/$3" />
+        </IssueNavigationLink>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="^([0-9]+) ?:" />
+          <option name="linkRegexp" value="https://www.labkey.org/issues/home/Developer/issues/details.view?issueId=$1" />
+        </IssueNavigationLink>
+        <IssueNavigationLink>
           <option name="issueRegexp" value="(GitHub Issue|GH Issue)( +#?)([0-9]+)" />
           <option name="linkRegexp" value="https://github.com/LabKey/internal-issues/issues/$3" />
         </IssueNavigationLink>

--- a/.idea/configTemplates/vcs.xml
+++ b/.idea/configTemplates/vcs.xml
@@ -18,16 +18,8 @@
           <option name="linkRegexp" value="https://www.labkey.org/issues/home/Developer/issues/details.view?issueId=$3" />
         </IssueNavigationLink>
         <IssueNavigationLink>
-          <option name="issueRegexp" value="(Epic|Story|Item)( +#?)([0-9]+)" />
-          <option name="linkRegexp" value="https://www.scrumwise.com/scrum/#/backlog-item/$3" />
-        </IssueNavigationLink>
-        <IssueNavigationLink>
-          <option name="issueRegexp" value="^([0-9]+) ?:" />
-          <option name="linkRegexp" value="https://www.labkey.org/issues/home/Developer/issues/details.view?issueId=$1" />
-        </IssueNavigationLink>
-        <IssueNavigationLink>
           <option name="issueRegexp" value="(GitHub Issue|GH Issue)( +#?)([0-9]+)" />
-          <option name="linkRegexp" value="https://github.com/LabKey/kanban/issues/$3" />
+          <option name="linkRegexp" value="https://github.com/LabKey/internal-issues/issues/$3" />
         </IssueNavigationLink>
       </list>
     </option>


### PR DESCRIPTION
#### Rationale
25.11 is going to be relatively active for a couple of months. We should have issue links point to the correct repository. A couple of the existing link definitions are no longer (or never were) valid; they should be removed.

#### Related Pull Requests
* #1217 

#### Changes
* Update our issue navigation link to use the new location
* Remove invalid issue navigation links
