### PR TITLE
GitHub Issue 692: Stop using CBC in HTTPS ciphers

### DIFF
--- a/server/bootstrap/src/org/labkey/bootstrap/ModuleArchive.java
+++ b/server/bootstrap/src/org/labkey/bootstrap/ModuleArchive.java
@@ -267,7 +267,7 @@ public class ModuleArchive
 
     public File extractEntry(JarFile jar, JarEntry entry, File targetDirectory) throws IOException
     {
-        @SuppressWarnings("SSBasedInspection") File destFile = new File(targetDirectory, entry.getName());
+        @SuppressWarnings({"SSBasedInspection", "JvmTaintAnalysis"}) File destFile = new File(targetDirectory, entry.getName());
         ensureChild(targetDirectory, destFile);
 
         File entryParent = destFile.getParentFile();

--- a/server/configs/application.properties
+++ b/server/configs/application.properties
@@ -6,14 +6,11 @@ server.port=@@serverPort@@
 ## To use ssl, update the properties below for your local installation
 
 #server.ssl.enabled=true
-#server.ssl.enabled-protocols=TLSv1.3,TLSv1.2
-#server.ssl.protocol=TLS
 #server.ssl.key-alias=tomcat
 #server.ssl.key-store=@@keyStore@@
 #server.ssl.key-store-password=@@keyStorePassword@@
 ## Typically either PKCS12 or JKS
 #server.ssl.key-store-type=PKCS12
-#server.ssl.ciphers=HIGH:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!kRSA:!EDH:!DHE:!DH:!CAMELLIA:!ARIA:!AESCCM:!SHA:!CHACHA20
 
 ## HTTP-only port for servers that need to handle both HTTPS (configure via server.port and server.ssl above) and HTTP
 #context.httpPort=8080

--- a/server/configs/webapps/embedded/config/application.properties
+++ b/server/configs/webapps/embedded/config/application.properties
@@ -41,15 +41,12 @@ context.encryptionKey=@@encryptionKey@@
 server.port=80
 
 ## To use HTTPS, update and uncomment the necessary properties below.
-##   Learn more here: https://www.labkey.org/Documentation/wiki-page.view?name=labkeyssl
+##   Learn more here: https://www.labkey.org/Documentation/wiki-page.view?name=labkeyHTTPS
 #server.ssl.enabled=true
-#server.ssl.enabled-protocols=TLSv1.3,TLSv1.2
-#server.ssl.protocol=TLS
 #server.ssl.key-alias=tomcat
 #server.ssl.key-store=@@keyStore@@
 #server.ssl.key-store-password=@@keyStorePassword@@
 #server.ssl.key-store-type=PKCS12
-#server.ssl.ciphers=HIGH:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!kRSA:!EDH:!DHE:!DH:!CAMELLIA:!ARIA:!AESCCM:!SHA:!CHACHA20
 
 server.error.include-stacktrace=always
 server.error.include-message=always

--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -113,6 +113,30 @@ public class LabKeyServer
 
                  put("csp.enforce", enforceCsp);
                  put("csp.report", reportCsp);
+
+                 // GitHub Issue 692: Stop using CBC in HTTPS ciphers
+                 // These settings configure HTTPS. Admins must opt in with additional settings
+                 // in application.properties, like the key store. Without those other settings,
+                 // HTTP-only startup fails unless "server.ssl.enabled" is explicitly set to false here
+                 put("server.ssl.enabled", "false");
+                 put("server.ssl.enabled-protocols", "TLSv1.3,TLSv1.2");
+                 // Use explicit JSSE cipher suite names to avoid CBC-mode suites
+                 put("server.ssl.ciphers",
+                     String.join(",",
+                         // TLS 1.3
+                         "TLS_AES_256_GCM_SHA384",
+                         "TLS_AES_128_GCM_SHA256",
+                         "TLS_CHACHA20_POLY1305_SHA256",
+                         // TLS 1.2 (AEAD only, no CBC)
+                         "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+                         "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+                         "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+                         "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+                         "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+                         "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"
+                     )
+                 );
+                 put("server.ssl.use-cipher-suites-order", "true");
              }}
         );
         application.setBannerMode(Banner.Mode.OFF);

--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -119,6 +119,7 @@ public class LabKeyServer
                  // in application.properties, like the key store. Without those other settings,
                  // HTTP-only startup fails unless "server.ssl.enabled" is explicitly set to false here
                  put("server.ssl.enabled", "false");
+                 put("#server.ssl.protocol", "TLS");
                  put("server.ssl.enabled-protocols", "TLSv1.3,TLSv1.2");
                  // Use explicit JSSE cipher suite names to avoid CBC-mode suites
                  put("server.ssl.ciphers",


### PR DESCRIPTION
#### Rationale
CBC ciphers are now considered weak.

#### Changes
* Set the default cipher list and TLS protocol versions in Java code, sparing admins from needing to update application.properties