### PR TITLE
Remove use of versioning plugin and update gradle plugins version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 import org.apache.commons.lang3.SystemUtils
 import org.labkey.gradle.plugin.NpmRun
 import org.labkey.gradle.task.PurgeNpmAlphaVersions
+import org.labkey.gradle.task.PurgeNpmVersions
 import org.labkey.gradle.task.ShowDiscrepancies
 import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.GroupNames
@@ -11,7 +12,6 @@ plugins {
     id "org.owasp.dependencycheck" version "${owaspDependencyCheckPluginVersion}" apply false
 //    id "com.github.ben-manes.versions" version "0.39.0"
     id "org.labkey.build.multiGit"
-    id 'org.labkey.versioning' apply false // Need this for our 'base' plugin to get the version specified in settings.gradle
 }
 
 allprojects {
@@ -560,5 +560,12 @@ project.tasks.register('purgeNpmAlphaVersions', PurgeNpmAlphaVersions) {
     group = GroupNames.NPM_RUN
     description = "Given an alpha version prefix for npm packages via the property -P${PurgeNpmAlphaVersions.ALPHA_PREFIX_PROPERTY}=yourPrefix, " +
             "removes all packages with versions that match that prefix from Artifactory (e.g., @labkey/components-1.2.3-yourPrefix.0 and @labkey/premium-0.3.4-yourPrefix.1). " +
+            " Use -PdryRun to see what versions would be deleted without actually doing the deletion."
+}
+
+project.tasks.register('purgeNpmVersions', PurgeNpmVersions) {
+    group = GroupNames.NPM_RUN
+    description = "Given an package name via -P${PurgeNpmVersions.PACKAGE_NAME_PROP}=component (without the @labkey prefix) and a version list via -P${PurgeNpmVersions.VERSION_LIST_PROP}=fileName for npm package, " +
+            "removes the versions specified from Artifactory. " +
             " Use -PdryRun to see what versions would be deleted without actually doing the deletion."
 }

--- a/build.gradle
+++ b/build.gradle
@@ -565,7 +565,7 @@ project.tasks.register('purgeNpmAlphaVersions', PurgeNpmAlphaVersions) {
 
 project.tasks.register('purgeNpmVersions', PurgeNpmVersions) {
     group = GroupNames.NPM_RUN
-    description = "Given an package name via -P${PurgeNpmVersions.PACKAGE_NAME_PROP}=component (without the @labkey prefix) and a version list via -P${PurgeNpmVersions.VERSION_LIST_PROP}=fileName for npm package, " +
+    description = "Given a package name via -P${PurgeNpmVersions.PACKAGE_NAME_PROP}=name (without the @labkey prefix) and a version list via -P${PurgeNpmVersions.VERSION_LIST_PROP}=fileName for npm package, " +
             "removes the versions specified from Artifactory. " +
             " Use -PdryRun to see what versions would be deleted without actually doing the deletion."
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -59,9 +59,8 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=5.2.5
 gradleNodePluginVersion=7.1.0
-gradlePluginsVersion=7.1.0
+gradlePluginsVersion=7.2.0-miscCleaning-SNAPSHOT
 owaspDependencyCheckPluginVersion=12.1.9
-versioningPluginVersion=1.1.3
 
 # Versions of node and npm to use during the build. If set, these versions
 # will be downloaded and used. If not set, the existing local installations will be used

--- a/gradle.properties
+++ b/gradle.properties
@@ -59,7 +59,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=5.2.5
 gradleNodePluginVersion=7.1.0
-gradlePluginsVersion=7.2.0-miscCleaning-SNAPSHOT
+gradlePluginsVersion=7.2.0
 owaspDependencyCheckPluginVersion=12.1.9
 
 # Versions of node and npm to use during the build. If set, these versions

--- a/gradle/settings/all.gradle
+++ b/gradle/settings/all.gradle
@@ -17,7 +17,6 @@ buildscript {
             }
             content {
                 includeGroup "org.labkey.build"
-                includeGroup "org.labkey.versioning"
             }
         }
         if (gradlePluginsVersion.contains("SNAPSHOT"))
@@ -30,7 +29,6 @@ buildscript {
                 }
                 content {
                     includeGroup "org.labkey.build"
-                    includeGroup "org.labkey.versioning"
                 }
             }
 

--- a/gradle/settings/distributions.gradle
+++ b/gradle/settings/distributions.gradle
@@ -13,7 +13,6 @@ buildscript {
             }
             content {
                 includeGroup "org.labkey.build"
-                includeGroup "org.labkey.versioning"
             }
         }
         if (gradlePluginsVersion.contains("SNAPSHOT"))
@@ -26,7 +25,6 @@ buildscript {
                 }
                 content {
                     includeGroup "org.labkey.build"
-                    includeGroup "org.labkey.versioning"
                 }
             }
 

--- a/gradle/settings/ehr.gradle
+++ b/gradle/settings/ehr.gradle
@@ -13,7 +13,6 @@ buildscript {
             }
             content {
                 includeGroup "org.labkey.build"
-                includeGroup "org.labkey.versioning"
             }
         }
         if (gradlePluginsVersion.contains("SNAPSHOT"))
@@ -26,7 +25,6 @@ buildscript {
                 }
                 content {
                     includeGroup "org.labkey.build"
-                    includeGroup "org.labkey.versioning"
                 }
             }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,10 +14,9 @@ pluginManagement {
             }
             content {
                 includeGroup "org.labkey.build"
-                includeGroup "org.labkey.versioning"
             }
         }
-        if (gradlePluginsVersion.contains("SNAPSHOT") || versioningPluginVersion.contains("SNAPSHOT"))
+        if (gradlePluginsVersion.contains("SNAPSHOT"))
         {
             mavenLocal()
             maven {
@@ -27,19 +26,13 @@ pluginManagement {
                 }
                 content {
                     includeGroup "org.labkey.build"
-                    includeGroup "org.labkey.versioning"
                 }
             }
         }
     }
     resolutionStrategy {
         eachPlugin {
-            if (requested.id.id == 'org.labkey.versioning')
-            {
-                // Versioning isn't published with plugin markers
-                useModule("org.labkey.build:versioning:${versioningPluginVersion}")
-            }
-            else if (requested.id.namespace == 'org.labkey.build')
+            if (requested.id.namespace == 'org.labkey.build')
             {
                 // This doesn't really do anything. The jar on the classpath will take precedence
                 useVersion("${gradlePluginsVersion}")


### PR DESCRIPTION
#### Rationale
- We no longer need to assure ourselves that we are using the intended version of XMLBeans
- A more general task for purging NPM versions from Artifactory helps to keep things tidy
- We can get the Git data we need for the `module.xml` file without the (dying) versioning plugin

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/238

#### Changes
* Add `purgeNpmVersions` task
* Update gradlePlugins version
* Remove use of `versioning` plugin
