### PR TITLE
Suppress Rhino complaint for now

### DIFF
--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -251,7 +251,7 @@
     
     <!--
     Rhino 1.7R3 is getting flagged with a potential DoS issue when toFixed() is called on very small floating point numbers.
-    Upgading to a fix version is not trivial. See https://github.com/LabKey/internal-issues/issues/724 for details.
+    Upgrading to a fixed version is not trivial. See https://github.com/LabKey/internal-issues/issues/724 for details.
     -->
     <suppress>
        <notes><![CDATA[

--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -248,4 +248,16 @@
        <packageUrl regex="true">^pkg:maven/com\.google\.code\.gson/gson@.*$</packageUrl>
        <vulnerabilityName>CVE-2025-53864</vulnerabilityName>
     </suppress>
+    
+    <!--
+    Rhino 1.7R3 is getting flagged with a potential DoS issue when toFixed() is called on very small floating point numbers.
+    Upgading to a fix version is not trivial. See https://github.com/LabKey/internal-issues/issues/724 for details.
+    -->
+    <suppress>
+       <notes><![CDATA[
+       file name: rhino-1.7R3.jar
+       ]]></notes>
+       <packageUrl regex="true">^pkg:maven/org\.mozilla/rhino@.*$</packageUrl>
+       <vulnerabilityName>CVE-2025-66453</vulnerabilityName>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
#### Rationale
Upgrading Rhino will be a challenge and the reported DoS CVE doesn't seem critical.