### PR TITLE
Use new version of labkeyClientApi for commands used in API tests for moving jobs

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -45,7 +45,7 @@ buildFromSource=true
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
 labkeyVersion=26.1-SNAPSHOT
-labkeyClientApiVersion=7.0.0
+labkeyClientApiVersion=7.0.0-moveJobs-SNAPSHOT
 
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.

--- a/gradle.properties
+++ b/gradle.properties
@@ -45,7 +45,7 @@ buildFromSource=true
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
 labkeyVersion=26.1-SNAPSHOT
-labkeyClientApiVersion=7.0.0-moveJobs-SNAPSHOT
+labkeyClientApiVersion=7.1.0
 
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.


### PR DESCRIPTION
#### Rationale
When importing an assay run, we sometimes will associate a workflow task id with the run. This PR updates the `labkeyClientApi` version to a version that allows specifying the taskId when importing assay run data.

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-java/pull/85

#### Changes
* Update `labkeyClientApi`
