### PR TITLE
Remove unnecessary version force for `io.netty`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -334,20 +334,6 @@ allprojects {
                     force "org.bouncycastle:bcprov-jdk18on:${bouncycastleVersion}"
                     // force consistency in docker and connectors and saml
                     force "org.bouncycastle:bcpkix-jdk18on:${bouncycastleVersion}"
-                    // docker dependency: force to mitigate CVEs in 4.1.46
-                    force "io.netty:netty-resolver:${nettyVersion}"
-                    force "io.netty:netty-resolver-dns:${nettyVersion}"
-                    force "io.netty:netty-handler:${nettyVersion}"
-                    force "io.netty:netty-handler-proxy:${nettyVersion}"
-                    force "io.netty:netty-buffer:${nettyVersion}"
-                    force "io.netty:netty-transport:${nettyVersion}"
-                    force "io.netty:netty-codec-socks:${nettyVersion}"
-                    force "io.netty:netty-codec:${nettyVersion}"
-                    force "io.netty:netty-common:${nettyVersion}"
-                    force "io.netty:netty-codec-http:${nettyVersion}"
-                    force "io.netty:netty-codec-http2:${nettyVersion}"
-                    force "io.netty:netty-transport-native-epoll:${nettyVersion}"
-                    force "io.netty:netty-transport-native-kqueue:${nettyVersion}"
 
                     // Force consistency for dependencies from pipeline and query
                     force "org.dom4j:dom4j:${dom4jVersion}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -247,9 +247,6 @@ luceneVersion=9.12.3
 
 mssqlJdbcVersion=13.2.1.jre11
 
-# force for docker
-nettyVersion=4.2.7.Final
-
 objenesisVersion=1.0
 
 opencsvVersion=2.3


### PR DESCRIPTION
#### Rationale
We no longer pull in netty as a transitive dependency.

#### Related Pull Requests
* https://github.com/LabKey/premiumModules/pull/436

#### Changes
* Remove unnecessary version force for `io.netty`
