### PR TITLE
New gradle plugins version to fix `purgeNpmAlphaVersions` task

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -59,7 +59,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=5.2.5
 gradleNodePluginVersion=7.1.0
-gradlePluginsVersion=7.3.0-fixNpmPurge-SNAPSHOT
+gradlePluginsVersion=7.2.1
 owaspDependencyCheckPluginVersion=12.1.9
 
 # Versions of node and npm to use during the build. If set, these versions

--- a/gradle.properties
+++ b/gradle.properties
@@ -59,7 +59,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=5.2.5
 gradleNodePluginVersion=7.1.0
-gradlePluginsVersion=7.2.0
+gradlePluginsVersion=7.3.0-SNAPSHOT
 owaspDependencyCheckPluginVersion=12.1.9
 
 # Versions of node and npm to use during the build. If set, these versions

--- a/gradle.properties
+++ b/gradle.properties
@@ -59,7 +59,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=5.2.5
 gradleNodePluginVersion=7.1.0
-gradlePluginsVersion=7.3.0-SNAPSHOT
+gradlePluginsVersion=7.3.0-fixNpmPurge-SNAPSHOT
 owaspDependencyCheckPluginVersion=12.1.9
 
 # Versions of node and npm to use during the build. If set, these versions


### PR DESCRIPTION
#### Rationale
The addition of the `PurgeNpmVersion` task as a base class for `PurgeNpmAlphaVersions` inadvertently made the former require properties used by the latter. Marking those properties as optional since we have internal logic to verify they are provided.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/239

#### Changes
* new gradlePluginsVersion
