### PR TITLE
Require Java 25

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -34,8 +34,8 @@ artifactory_contextUrl=https://labkey.jfrog.io/artifactory
 
 # The source and target versions of Java for compilation tasks
 # @JavaRuntimeVersion
-sourceCompatibility=17
-targetCompatibility=17
+sourceCompatibility=25
+targetCompatibility=25
 
 # indicates if we should use previously published artifacts or build from source
 # This setting applies to all projects unless overridden on command line or in a


### PR DESCRIPTION
#### Rationale
We're upgrading to require Java 25.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/7305

#### Changes
* Tell Gradle to use Java 25