### PR TITLE
Issue 771: Update gradle plugins to fix snapshot distribution naming

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -59,7 +59,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=5.2.5
 gradleNodePluginVersion=7.1.0
-gradlePluginsVersion=7.2.1
+gradlePluginsVersion=7.3.0-versionFixes-SNAPSHOT
 owaspDependencyCheckPluginVersion=12.1.9
 
 # Versions of node and npm to use during the build. If set, these versions

--- a/gradle.properties
+++ b/gradle.properties
@@ -59,7 +59,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=5.2.5
 gradleNodePluginVersion=7.1.0
-gradlePluginsVersion=7.3.0-versionFixes-SNAPSHOT
+gradlePluginsVersion=7.3.0
 owaspDependencyCheckPluginVersion=12.1.9
 
 # Versions of node and npm to use during the build. If set, these versions


### PR DESCRIPTION
#### Rationale
Issue [771](https://github.com/LabKey/internal-issues/issues/771) When we removed the usage of the versioning plugin, we missed a dependency on that plugin that was used for determining the names of our distribution files.

See related PR for more details

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/240

#### Changes
* gradlePluginsVersion update
