### PR TITLE
Restore limit of 10,000 HTTP parameters to fix flow tests

### DIFF
--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -99,6 +99,8 @@ public class LabKeyServer
                  put("server.tomcat.max-part-count", 500);
                  put("server.tomcat.max-part-header-size", 1024);  // GitHub Issue 161: LKS insert forms can't handle long file field names
                  put("server.tomcat.max-connections", 250);
+                // Boost limit back to Tomcat 10 level
+                 put("server.tomcat.max-parameter-count", 10_000);
 
                  // Enable HTTP compression for response content
                  put("server.compression.enabled", "true");


### PR DESCRIPTION
#### Rationale
Tomcat 11 switched the default maximum HTTP parameters per request from 10,000 to 1,000. We have scenarios that use more than 1,000 parameters.

#### Changes
* Reset back to 10,000
