### PR TITLE
GitHub Issue 796: JSON logging stopped after Tomcat/Spring update

### DIFF
--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -92,6 +92,32 @@ public class LabKeyServer
 
         application.setDefaultProperties(new HashMap<>()
              {{
+                // GitHub Issue 796: JSON logging stopped after Tomcat/Spring update
+                 // Propagate log4j configuration to Spring Boot config, which is necessary with Spring Boot 4.x
+                 String log4JConfig = System.getProperty("log4j.configurationFile");
+                 if (log4JConfig != null)
+                 {
+                     String[] log4JConfigParts = log4JConfig.split(",");
+                     if (log4JConfigParts.length > 0)
+                     {
+                         if ("log4j2.xml".equals(log4JConfigParts[0]))
+                         {
+                             // Assume this is the one packaged with our embedded build and on the classpath
+                             put("logging.config", "classpath:log4j2.xml");
+                         }
+                         else
+                         {
+                             put("logging.config", log4JConfigParts[0]);
+                         }
+                         if (log4JConfigParts.length == 2)
+                         {
+                            put("logging.log4j2.config.override", log4JConfigParts[1]);
+                         }
+                         else
+                             throw new IllegalArgumentException("log4j.configurationFile must be in the form log4j2.xml[,secondaryFile]");
+                     }
+                 }
+
                  put("server.tomcat.basedir", ".");
                  put("server.tomcat.accesslog.directory", logHome);
 

--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -15,6 +15,7 @@ import org.springframework.validation.annotation.Validated;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -111,15 +112,7 @@ public class LabKeyServer
                          }
                          if (log4JConfigParts.length > 1)
                          {
-                             StringBuilder sb = new StringBuilder();
-                             String separator = "";
-                             for (int i = 1; i < log4JConfigParts.length; i++)
-                             {
-                                 sb.append(separator);
-                                 separator = ",";
-                                 sb.append(log4JConfigParts[i]);
-                             }
-                            put("logging.log4j2.config.override", sb.toString());
+                            put("logging.log4j2.config.override", String.join(",", Arrays.asList(log4JConfigParts).subList(1, log4JConfigParts.length)));
                          }
                          else
                              throw new IllegalArgumentException("log4j.configurationFile must be in the form log4j2.xml[,secondaryFile]");

--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -109,9 +109,17 @@ public class LabKeyServer
                          {
                              put("logging.config", log4JConfigParts[0]);
                          }
-                         if (log4JConfigParts.length == 2)
+                         if (log4JConfigParts.length > 1)
                          {
-                            put("logging.log4j2.config.override", log4JConfigParts[1]);
+                             StringBuilder sb = new StringBuilder();
+                             String separator = "";
+                             for (int i = 1; i < log4JConfigParts.length; i++)
+                             {
+                                 sb.append(separator);
+                                 separator = ",";
+                                 sb.append(log4JConfigParts[i]);
+                             }
+                            put("logging.log4j2.config.override", sb.toString());
                          }
                          else
                              throw new IllegalArgumentException("log4j.configurationFile must be in the form log4j2.xml[,secondaryFile]");


### PR DESCRIPTION
#### Rationale
We configure JSON-based Log4J logging via an override file in our cloud instances. This stopped working as of the upgrade to Spring Boot 4.

#### Changes
* Propagate from the Log4J-preferred config to the Spring Boot-preferred config so they stop squabbling over the setup