### PR TITLE
Stop failing when -Dlog4j.configurationFile has a single value

### DIFF
--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -114,8 +114,6 @@ public class LabKeyServer
                          {
                             put("logging.log4j2.config.override", String.join(",", Arrays.asList(log4JConfigParts).subList(1, log4JConfigParts.length)));
                          }
-                         else
-                             throw new IllegalArgumentException("log4j.configurationFile must be in the form log4j2.xml[,secondaryFile]");
                      }
                  }
 


### PR DESCRIPTION
#### Rationale
Work in https://github.com/LabKey/server/pull/1265 propagated config from `-Dlog4j.configurationFile` through Spring Boot's preferred `application.properties` settings. It is stricter than intended and is failing when there's only a single file specified.

#### Changes
* Support one or more file paths