### PR TITLE
Support report-to CSP directive and Reporting-Endpoints header (#1269)

### DIFF
--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -80,15 +80,15 @@ public class LabKeyServer
                 base-uri 'self' ;
                 frame-src 'self' ${FRAME.SOURCES} ;
             """;
-        // Add upgrade_insecure_requests substitution, frame-ancestors, and e12 version for enforce CSP
+        // Add upgrade_insecure_requests substitution, frame-ancestors, and e13 version for enforce CSP
         String enforceCsp = baseCsp + """
                 ${UPGRADE.INSECURE.REQUESTS}
                 frame-ancestors 'self' ;
-                report-uri ${context.contextPath:}/admin-contentSecurityPolicyReport.api?cspVersion=e12&${CSP.REPORT.PARAMS} ;
+                report-uri ${context.contextPath:}/admin-contentSecurityPolicyReport.api?cspVersion=e13&${CSP.REPORT.PARAMS} ;
             """;
         // Leave out upgrade_insecure_requests and frame-ancestors directives, since they produce warnings on some browsers
         String reportCsp = baseCsp + """
-                report-uri ${context.contextPath:}/admin-contentSecurityPolicyReport.api?cspVersion=r12&${CSP.REPORT.PARAMS} ;
+                report-uri ${context.contextPath:}/admin-contentSecurityPolicyReport.api?cspVersion=r13&${CSP.REPORT.PARAMS} ;
             """;
 
         application.setDefaultProperties(new HashMap<>()


### PR DESCRIPTION
#### Rationale
Back port to support report-to CSP directive in 26.2