### PR TITLE
Add Jackson Annotations dependency to Spring Boot classpath

### DIFF
--- a/server/embedded/build.gradle
+++ b/server/embedded/build.gradle
@@ -38,6 +38,7 @@ configurations.configureEach {
 dependencies {
     // Needed to support composite Log4j2 plugins using JSONLayout elements
     implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}"
+    implementation "com.fasterxml.jackson.core:jackson-annotations:${jacksonAnnotationsVersion}"
 
     implementation("org.springframework.boot:spring-boot-starter-web:${springBootVersion}") {
         exclude group: "org.springframework.boot", module: "spring-boot-starter-json" // Not used (?) and pulls in an old version of Jackson


### PR DESCRIPTION
#### Rationale
The upgrade to Jackson 2.21 means that we need `jackson-annotations` on the Spring Boot class path to support JSON logging via Log4J.

#### Changes
* Add the annotations as a direct dependency
