### PR TITLE
Upgrade to Spring AI 2, allow concurrent Jackson 2 and 3

### DIFF
--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -194,4 +194,32 @@
        <packageUrl regex="true">^pkg:maven/org\.mozilla/rhino@.*$</packageUrl>
        <vulnerabilityName>CVE-2025-66453</vulnerabilityName>
     </suppress>
+
+    <!-- Lots of false positives for Spring AI 2.0 due to bad matches-->
+    <suppress>
+        <notes><![CDATA[
+   file name: spring-ai-autoconfigure-mcp-server-common-2.0.0-M2.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework\.ai/spring-ai-autoconfigure-mcp-server-common@.*$</packageUrl>
+        <cpe>cpe:/a:vmware:server</cpe>
+        <cpe>cpe:/a:vmware:vmware_server</cpe>
+    </suppress>
+
+    <suppress>
+        <notes><![CDATA[
+   file name: spring-ai-autoconfigure-mcp-server-webmvc-2.0.0-M2.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework\.ai/spring-ai-autoconfigure-mcp-server-webmvc@.*$</packageUrl>
+        <cpe>cpe:/a:vmware:server</cpe>
+        <cpe>cpe:/a:vmware:vmware_server</cpe>
+    </suppress>
+
+    <suppress>
+        <notes><![CDATA[
+   file name: spring-ai-starter-mcp-server-webmvc-2.0.0-M2.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework\.ai/spring-ai-starter-mcp-server-webmvc@.*$</packageUrl>
+        <cpe>cpe:/a:vmware:server</cpe>
+        <cpe>cpe:/a:vmware:vmware_server</cpe>
+    </suppress>
 </suppressions>

--- a/gradle.properties
+++ b/gradle.properties
@@ -199,10 +199,6 @@ jacksonVersion=2.21.0
 jacksonDatabindVersion=2.21.0
 jacksonJaxrsBaseVersion=2.21.0
 
-# We also need Jackson 3.x for Spring AI and new versions of Spring Boot and Spring Framework
-jacksonVersion3=3.0.4
-jacksonDatabindVersion3=3.0.4
-
 # Note the inconsistent version numbering for "annotations"... it no longer matches the above
 jacksonAnnotationsVersion=2.21
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -195,9 +195,10 @@ httpcoreVersion=4.4.16
 intellijKotlinVersion=1.9.10
 
 # Update the three Jackson dependency versions below in tandem, unless one gets a patch release out-of-sync with the others
-jacksonVersion=2.21.0
-jacksonDatabindVersion=2.21.0
-jacksonJaxrsBaseVersion=2.21.0
+jacksonVersion=3.0.3
+jacksonDatabindVersion=3.0.3
+jacksonJaxrsBaseVersion=3.0.3
+jacksonJsr310Version=3.0.0-rc2
 
 # Note the inconsistent version numbering for "annotations"... it no longer matches the above
 jacksonAnnotationsVersion=2.21
@@ -291,7 +292,7 @@ snappyJavaVersion=1.1.10.8
 springBootVersion=4.0.2
 # This usually matches the Spring Framework version dictated by springBootVersion
 springVersion=7.0.3
-springAiVersion=1.1.2
+springAiVersion=2.0.0-M2
 
 sqliteJdbcVersion=3.51.1.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -59,7 +59,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=5.2.5
 gradleNodePluginVersion=7.1.0
-gradlePluginsVersion=7.4.0-multiJackson-SNAPSHOT
+gradlePluginsVersion=7.3.1
 owaspDependencyCheckPluginVersion=12.2.0
 
 # Versions of node and npm to use during the build. If set, these versions

--- a/gradle.properties
+++ b/gradle.properties
@@ -195,10 +195,13 @@ httpcoreVersion=4.4.16
 intellijKotlinVersion=1.9.10
 
 # Update the three Jackson dependency versions below in tandem, unless one gets a patch release out-of-sync with the others
-jacksonVersion=3.0.3
-jacksonDatabindVersion=3.0.3
-jacksonJaxrsBaseVersion=3.0.3
-jacksonJsr310Version=3.0.0-rc2
+jacksonVersion=2.21.0
+jacksonDatabindVersion=2.21.0
+jacksonJaxrsBaseVersion=2.21.0
+
+# We also need Jackson 3.x for Spring AI and new versions of Spring Boot and Spring Framework
+jacksonVersion3=3.0.4
+jacksonDatabindVersion3=3.0.4
 
 # Note the inconsistent version numbering for "annotations"... it no longer matches the above
 jacksonAnnotationsVersion=2.21

--- a/gradle.properties
+++ b/gradle.properties
@@ -59,7 +59,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=5.2.5
 gradleNodePluginVersion=7.1.0
-gradlePluginsVersion=7.3.0
+gradlePluginsVersion=7.4.0-multiJackson-SNAPSHOT
 owaspDependencyCheckPluginVersion=12.2.0
 
 # Versions of node and npm to use during the build. If set, these versions


### PR DESCRIPTION
#### Rationale
We want to use the newest Spring AI versions. That requires Jackson 3, which is a major upgrade from Jackson 2. Fortunately, they can coexist

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/7409

#### Changes
* New Spring AI, Jackson, and Gradle plugin