### PR TITLE
Improved setup for XML parsing

### DIFF
--- a/server/bootstrap/src/org/labkey/bootstrap/ModuleArchive.java
+++ b/server/bootstrap/src/org/labkey/bootstrap/ModuleArchive.java
@@ -72,7 +72,7 @@ public class ModuleArchive
 
         try
         {
-            // Keep this in sync with config on XmlBeanUtil.SAX_PARSER_FACTORY. See motiviations in comments there.
+            // Keep this in sync with config on XmlBeansUtil.SAX_PARSER_FACTORY. See motiviations in comments there.
             SAXParserFactory factory = SAXParserFactory.newDefaultInstance();
             factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
             factory.setFeature("http://xml.org/sax/features/external-general-entities", false);

--- a/server/bootstrap/src/org/labkey/bootstrap/ModuleArchive.java
+++ b/server/bootstrap/src/org/labkey/bootstrap/ModuleArchive.java
@@ -71,7 +71,12 @@ public class ModuleArchive
 
         try
         {
-            SAXParser parser = SAXParserFactory.newDefaultInstance().newSAXParser();
+            SAXParserFactory factory = SAXParserFactory.newDefaultInstance();
+            factory.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            SAXParser parser = factory.newSAXParser();
             parser.parse(is, new DefaultHandler()
             {
                 final ArrayList<String> elementStack = new ArrayList<>();

--- a/server/bootstrap/src/org/labkey/bootstrap/ModuleArchive.java
+++ b/server/bootstrap/src/org/labkey/bootstrap/ModuleArchive.java
@@ -19,6 +19,7 @@ import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
@@ -71,11 +72,13 @@ public class ModuleArchive
 
         try
         {
+            // Keep this in sync with config on XmlBeanUtil.SAX_PARSER_FACTORY. See motiviations in comments there.
             SAXParserFactory factory = SAXParserFactory.newDefaultInstance();
-            factory.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true);
             factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
             factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
             factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+
             SAXParser parser = factory.newSAXParser();
             parser.parse(is, new DefaultHandler()
             {


### PR DESCRIPTION
#### Rationale
We should configure XML parsers consistently. Code in this repo can't leverage XmlBeanUtil so do it manually.

#### Changes
* Apply standard settings to the SAX parser