### PR TITLE
labkeyClientApiVersion=7.1.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -45,7 +45,7 @@ buildFromSource=true
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
 labkeyVersion=26.3-SNAPSHOT
-labkeyClientApiVersion=7.2.0-SNAPSHOT
+labkeyClientApiVersion=7.1.1
 
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.


### PR DESCRIPTION
#### Rationale
I messed up and committed the SNAPSHOT version to develop. Update this to refer to an actual release version.

#### Related Pull Requests
- #1281

#### Changes
- Update client API `v7.1.1`
