### PR TITLE
Bump spring versions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -288,9 +288,9 @@ slf4jLog4jApiVersion=2.0.17
 snappyJavaVersion=1.1.10.8
 
 # Also, update apacheTomcatVersion above to match Spring Boot's Tomcat dependency version
-springBootVersion=4.0.2
+springBootVersion=4.0.3
 # This usually matches the Spring Framework version dictated by springBootVersion
-springVersion=7.0.3
+springVersion=7.0.5
 springAiVersion=2.0.0-M2
 
 sqliteJdbcVersion=3.51.1.0


### PR DESCRIPTION
#### Rationale
Bump Spring Boot and Spring Framework to the latest versions.

Note: The related platform PR fixes CVE-2026-24734 by excluding Spring-Boot (and therefore Tomcat-Embed).

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/7443
* https://github.com/LabKey/server/pull/1289