### PR TITLE
Add clientAPIs directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ remoteapi/
 server/modules/ 
 server/testAutomation/
 tools/
+clientAPIs/*
+!clientAPIs/README.md
 
 # Include the remoteapi README -- this line will override previous exclusion
 !remoteapi/README.md

--- a/clientAPIs/README.md
+++ b/clientAPIs/README.md
@@ -1,0 +1,5 @@
+### Client API Checkout Directory
+
+Clone client API repositories (e.g. `labkey-api-js`) into this directory. If you are using
+[labkey-workspaces](https://github.com/LabKey/labkey-workspaces) it will assume all client API repositories are in this
+directory when executing commands.


### PR DESCRIPTION
#### Rationale
This PR updates the .gitignore to assume there will be a clientAPIs directory where all client API repos are checked out.

#### Related Pull Requests
* https://github.com/LabKey/labkey-workspaces/pull/3
* https://github.com/LabKey/server/pull/1302

#### Changes
* Add `clientAPIs/README.md`
* Add `clientAPIs/* to .gitignore`
