### PR TITLE
Force version of Jackson 3.x

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -202,6 +202,9 @@ jacksonJaxrsBaseVersion=2.21.0
 # Note the inconsistent version numbering for "annotations"... it no longer matches the above
 jacksonAnnotationsVersion=2.21
 
+# Spring Boot brings in a transitive dependency on Jackson 3.x. It has changed package names and can coexist with Jackson 2.x.
+jackson3Version=3.1.0
+
 # The Jakarta Activation API version that Angus Activation implements. Keep in sync with angusActivationVersion (above).
 jakartaActivationApiVersion=2.1.4
 

--- a/server/embedded/build.gradle
+++ b/server/embedded/build.gradle
@@ -41,9 +41,25 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-annotations:${jacksonAnnotationsVersion}"
 
     implementation("org.springframework.boot:spring-boot-starter-web:${springBootVersion}") {
-        exclude group: "org.springframework.boot", module: "spring-boot-starter-json" // Not used (?) and pulls in an old version of Jackson
         exclude group: "jakarta.annotation", module: "jakarta.annotation-api" // Already present in tomcat-annotations-api
         exclude group: "org.apache.tomcat.embed", module: "tomcat-embed-core" // We want to force apacheTomcatVersion
+    }
+
+    // Allows forcing a Jackson version that differs from spring-boot's version (e.g., to address CVEs)
+    implementation('tools.jackson.core:jackson-databind') {
+        version {
+            strictly "${jackson3Version}"
+        }
+    }
+    implementation('tools.jackson.core:jackson-core') {
+        version {
+            strictly "${jackson3Version}"
+        }
+    }
+    implementation('tools.jackson:jackson-bom') {
+        version {
+            strictly "${jackson3Version}"
+        }
     }
 
     // Allows forcing a Spring Framework version that differs from spring-boot's version (e.g., to address CVEs)


### PR DESCRIPTION
#### Rationale
Force new version of Jackson.
https://github.com/FasterXML/jackson-core/security/advisories/GHSA-6v53-7c9g-w56r

#### Related Pull Requests
* N/A

#### Changes
* Force version of Jackson 3.x
* Remove obsolete dependency exclusion of `org.springframework.boot:spring-boot-starter-json`