### PR TITLE
Suppress PDFBox CVE

### DIFF
--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -194,4 +194,37 @@
        <packageUrl regex="true">^pkg:maven/org\.mozilla/rhino@.*$</packageUrl>
        <vulnerabilityName>CVE-2025-66453</vulnerabilityName>
     </suppress>
+
+    <!--
+    Some PDFBox example code (ExtractEmbeddedFiles) contains a path traversal vulnerability. The example code isn't
+    packaged in any jars and we already have checks in place to prevent path traversal vulnerabilities.
+    -->
+    <suppress>
+        <notes><![CDATA[
+       file name: pdfbox-3.0.4.jar
+       ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.pdfbox/pdfbox@.*$</packageUrl>
+        <cve>CVE-2026-23907</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+       file name: pdfbox-debugger-3.0.4.jar
+       ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.pdfbox/pdfbox-debugger@.*$</packageUrl>
+        <cve>CVE-2026-23907</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+       file name: pdfbox-io-3.0.4.jar
+       ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.pdfbox/pdfbox-io@.*$</packageUrl>
+        <cve>CVE-2026-23907</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+       file name: pdfbox-tools-3.0.4.jar
+       ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.pdfbox/pdfbox-tools@.*$</packageUrl>
+        <cve>CVE-2026-23907</cve>
+    </suppress>
 </suppressions>

--- a/gradle.properties
+++ b/gradle.properties
@@ -257,7 +257,7 @@ opencsvVersion=2.3
 openTracingVersion=0.33.0
 
 # sync with version Tika ships
-pdfboxVersion=3.0.7
+pdfboxVersion=3.0.4
 
 # sync with version Tika ships
 poiVersion=5.4.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -257,7 +257,7 @@ opencsvVersion=2.3
 openTracingVersion=0.33.0
 
 # sync with version Tika ships
-pdfboxVersion=3.0.4
+pdfboxVersion=3.0.7
 
 # sync with version Tika ships
 poiVersion=5.4.0


### PR DESCRIPTION
#### Rationale
Suppress PDFBox CVE: https://nvd.nist.gov/vuln/detail/CVE-2026-23907
This seems like more of a PSA than an actual vulnerability. There's a path-traversal issue in some example code that isn't actually packaged in any of the flagged the jars.
There's no fix available yet, so I'm going to suppress the warning.

#### Related Pull Requests
* N/A

#### Changes
* Suppress PDFBox CVE
