### PR TITLE
Compress TSV exports

### DIFF
--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -130,9 +130,9 @@ public class LabKeyServer
 
                  // Enable HTTP compression for response content
                  put("server.compression.enabled", "true");
-                 // Spring Boot compresses HTML, JSON and other types by default, but not TSV. We have to duplicate the
-                 // defaults and add text/tab-separated-values
-                 put("server.compression.mime-types", "text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json,application/xml,text/tab-separated-values");
+                 // Spring Boot compresses HTML, JSON and other types by default, but not TSV, CSV, or SVG. We have to
+                 // duplicate the defaults and add those types
+                 put("server.compression.mime-types", "text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json,application/xml,text/tab-separated-values,text/csv,image/svg+xml");
 
                  put("server.tomcat.accesslog.enabled", "true");
                  put("server.tomcat.accesslog.pattern", "%h %l %u %t \"%r\" %s %b %D %S %I \"%{Referer}i\" \"%{User-Agent}i\" %{LABKEY.username}s %{X-Forwarded-For}i");

--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -130,9 +130,9 @@ public class LabKeyServer
 
                  // Enable HTTP compression for response content
                  put("server.compression.enabled", "true");
-                 // Spring Boot compresses HTML, JSON and other types by default, but not TSV, CSV, SVG, or TTF fonts.
+                 // Spring Boot compresses HTML, JSON and other types by default, but not TSV, CSV, or SVG.
                  // We have to duplicate the defaults and add those types
-                 put("server.compression.mime-types", "text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json,application/xml,text/tab-separated-values,text/csv,image/svg+xml,font/ttf");
+                 put("server.compression.mime-types", "text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json,application/xml,text/tab-separated-values,text/csv,image/svg+xml");
 
                  put("server.tomcat.accesslog.enabled", "true");
                  put("server.tomcat.accesslog.pattern", "%h %l %u %t \"%r\" %s %b %D %S %I \"%{Referer}i\" \"%{User-Agent}i\" %{LABKEY.username}s %{X-Forwarded-For}i");

--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -130,9 +130,9 @@ public class LabKeyServer
 
                  // Enable HTTP compression for response content
                  put("server.compression.enabled", "true");
-                 // Spring Boot compresses HTML, JSON and other types by default, but not TSV, CSV, or SVG. We have to
-                 // duplicate the defaults and add those types
-                 put("server.compression.mime-types", "text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json,application/xml,text/tab-separated-values,text/csv,image/svg+xml");
+                 // Spring Boot compresses HTML, JSON and other types by default, but not TSV, CSV, SVG, or TTF fonts.
+                 // We have to duplicate the defaults and add those types
+                 put("server.compression.mime-types", "text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json,application/xml,text/tab-separated-values,text/csv,image/svg+xml,font/ttf");
 
                  put("server.tomcat.accesslog.enabled", "true");
                  put("server.tomcat.accesslog.pattern", "%h %l %u %t \"%r\" %s %b %D %S %I \"%{Referer}i\" \"%{User-Agent}i\" %{LABKEY.username}s %{X-Forwarded-For}i");

--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -130,6 +130,9 @@ public class LabKeyServer
 
                  // Enable HTTP compression for response content
                  put("server.compression.enabled", "true");
+                 // Spring Boot compresses HTML, JSON and other types by default, but not TSV. We have to duplicate the
+                 // defaults and add text/tab-separated-values
+                 put("server.compression.mime-types", "text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json,application/xml,text/tab-separated-values");
 
                  put("server.tomcat.accesslog.enabled", "true");
                  put("server.tomcat.accesslog.pattern", "%h %l %u %t \"%r\" %s %b %D %S %I \"%{Referer}i\" \"%{User-Agent}i\" %{LABKEY.username}s %{X-Forwarded-For}i");


### PR DESCRIPTION
#### Rationale
Spring Boot compresses many text HTTP responses by default. But not TSV.

#### Changes
* Add `text/tab-separated-values` to the default set of compressed MIME types

- [x] Code review @labkey-matthewb 
- [x] Manual test - confirm that HTML, JSON, JS, CSV, TTF, SVG, and TSV responses use gzip compression @labkey-tchad 