### PR TITLE
Update gradle plugins version to eliminate VcsTag in module.xml file

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -59,7 +59,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=5.2.5
 gradleNodePluginVersion=7.1.0
-gradlePluginsVersion=7.4.0-dependencySub-SNAPSHOT
+gradlePluginsVersion=8.0.0
 owaspDependencyCheckPluginVersion=12.2.0
 
 # Versions of node and npm to use during the build. If set, these versions

--- a/gradle.properties
+++ b/gradle.properties
@@ -59,7 +59,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=5.2.5
 gradleNodePluginVersion=7.1.0
-gradlePluginsVersion=7.3.1
+gradlePluginsVersion=7.4.0-dependencySub-SNAPSHOT
 owaspDependencyCheckPluginVersion=12.2.0
 
 # Versions of node and npm to use during the build. If set, these versions


### PR DESCRIPTION
#### Rationale
When we switched from the Gradle VCS plugin to using plain git commands for populating VCS info, the VCS Tag property stopped getting populated. Since we don't check out tags when creating our artifacts, there is never anything to put into this property. In the related PR, we are switching to report the Release Version in the VcsTag mothership property (for backward compatibility) and thus no longer need this property (which is always blank or "Unknown" anyway).

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/7542

#### Changes
* Gradle plugins version update
