### PR TITLE
Update hooks path to use $CLAUDE_PROJECT_DIR

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"$(git rev-parse --show-toplevel)\" && if command -v python3 >/dev/null 2>&1; then python3 .claude/hooks/check-dangerous-commands.py; else python .claude/hooks/check-dangerous-commands.py; fi"
+            "command": "cd \"$CLAUDE_PROJECT_DIR\" && if command -v python3 >/dev/null 2>&1; then python3 .claude/hooks/check-dangerous-commands.py; else python .claude/hooks/check-dangerous-commands.py; fi"
           }
         ]
       },
@@ -15,7 +15,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"$(git rev-parse --show-toplevel)\" && if command -v python3 >/dev/null 2>&1; then python3 .claude/hooks/check-secrets-file.py; else python .claude/hooks/check-secrets-file.py; fi"
+            "command": "cd \"$CLAUDE_PROJECT_DIR\" && if command -v python3 >/dev/null 2>&1; then python3 .claude/hooks/check-secrets-file.py; else python .claude/hooks/check-secrets-file.py; fi"
           }
         ]
       }


### PR DESCRIPTION
#### Rationale
Some claude functionality unnecessarily blocked when claude task navigates to sub-repos.

#### Changes
* pretooluse hooks to use $CLAUDE_PROJECT_DIR for python directory