### PR TITLE
Update tomcat and springboot versions and don't register purge tasks without atrifactory properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -563,16 +563,19 @@ project.tasks.register('ijConfigure') {
         task.dependsOn(project.tasks.ijRunConfigurationsSetup)
 }
 
-project.tasks.register('purgeNpmAlphaVersions', PurgeNpmAlphaVersions) {
-    group = GroupNames.NPM_RUN
-    description = "Given an alpha version prefix for npm packages via the property -P${PurgeNpmAlphaVersions.ALPHA_PREFIX_PROPERTY}=yourPrefix, " +
-            "removes all packages with versions that match that prefix from Artifactory (e.g., @labkey/components-1.2.3-yourPrefix.0 and @labkey/premium-0.3.4-yourPrefix.1). " +
-            " Use -PdryRun to see what versions would be deleted without actually doing the deletion."
-}
+if (project.hasProperty('artifactory_contextUrl') && project.hasProperty('artifactory_user') && project.hasProperty('artifactory_password'))
+{
+    project.tasks.register('purgeNpmAlphaVersions', PurgeNpmAlphaVersions) {
+        group = GroupNames.NPM_RUN
+        description = "Given an alpha version prefix for npm packages via the property -P${PurgeNpmAlphaVersions.ALPHA_PREFIX_PROPERTY}=yourPrefix, " +
+                "removes all packages with versions that match that prefix from Artifactory (e.g., @labkey/components-1.2.3-yourPrefix.0 and @labkey/premium-0.3.4-yourPrefix.1). " +
+                " Use -PdryRun to see what versions would be deleted without actually doing the deletion."
+    }
 
-project.tasks.register('purgeNpmVersions', PurgeNpmVersions) {
-    group = GroupNames.NPM_RUN
-    description = "Given a package name via -P${PurgeNpmVersions.PACKAGE_NAME_PROP}=name (without the @labkey prefix) and a version list via -P${PurgeNpmVersions.VERSION_LIST_PROP}=fileName for npm package, " +
-            "removes the versions specified from Artifactory. " +
-            " Use -PdryRun to see what versions would be deleted without actually doing the deletion."
+    project.tasks.register('purgeNpmVersions', PurgeNpmVersions) {
+        group = GroupNames.NPM_RUN
+        description = "Given a package name via -P${PurgeNpmVersions.PACKAGE_NAME_PROP}=name (without the @labkey prefix) and a version list via -P${PurgeNpmVersions.VERSION_LIST_PROP}=fileName for npm package, " +
+                "removes the versions specified from Artifactory. " +
+                " Use -PdryRun to see what versions would be deleted without actually doing the deletion."
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -100,7 +100,7 @@ apacheDirectoryVersion=2.1.7
 apacheMinaVersion=2.2.5
 
 # Usually matches the version specified as a Spring Boot dependency (see springBootVersion below)
-apacheTomcatVersion=11.0.18
+apacheTomcatVersion=11.0.20
 
 # (mothership) -> json-path -> json-smart -> accessor-smart
 # (core) -> graalvm
@@ -294,7 +294,7 @@ slf4jLog4jApiVersion=2.0.17
 snappyJavaVersion=1.1.10.8
 
 # Also, update apacheTomcatVersion above to match Spring Boot's Tomcat dependency version
-springBootVersion=4.0.4
+springBootVersion=4.0.5
 # This usually matches the Spring Framework version dictated by springBootVersion
 springVersion=7.0.6
 springAiVersion=2.0.0-M4


### PR DESCRIPTION
#### Rationale

- Adjust versions for a minor CVE related to the tomcat version
- Gradle plugins version 7.2.0 adjusted the `PurgeX` tasks to be more compatible with Gradle best practices, but that introduced a reliance on the artifactory authentication properties those tasks depend on. Since those tasks do require the user name, password, and contextURL, we check for the existence of all those properties before registering the purge tasks.

#### Changes
* Tomcat and springBoot version updates
* update to `build.gradle` to conditionalize the registration of the `PurgeX` tasks.
