### PR TITLE
Update tomcat, log4j2, and grpc versions to address CVEs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,8 @@ allprojects {
             if (project.hasProperty('ossIndexUsername') && project.hasProperty('ossIndexPassword'))
             {
                 analyzers.ossIndex.username = project.property('ossIndexUsername')
-                analyzers.ossIndex.password = project.property('ossIndexPassword');
+                analyzers.ossIndex.password = project.property('ossIndexPassword')
+                analyzers.ossIndex.url = "https://api.guide.sonatype.com"
             }
             else
             {

--- a/gradle.properties
+++ b/gradle.properties
@@ -100,7 +100,7 @@ apacheDirectoryVersion=2.1.7
 apacheMinaVersion=2.2.5
 
 # Usually matches the version specified as a Spring Boot dependency (see springBootVersion below)
-apacheTomcatVersion=11.0.20
+apacheTomcatVersion=11.0.21
 
 # (mothership) -> json-path -> json-smart -> accessor-smart
 # (core) -> graalvm
@@ -169,7 +169,7 @@ googleProtocolBufVersion=3.25.8
 # "java.lang.NoSuchMethodError: 'void com.google.gson.internal.ConstructorConstructor.<init>(java.util.Map)'" errors
 gsonVersion=2.8.9
 
-grpcVersion=1.78.0
+grpcVersion=1.80.0
 
 guavaVersion=33.5.0-jre
 
@@ -246,7 +246,7 @@ jxlVersion=2.6.3
 
 kaptchaVersion=2.3
 
-log4j2Version=2.25.3
+log4j2Version=2.25.4
 
 lombokVersion=1.18.42
 


### PR DESCRIPTION
#### Rationale
New CVEs have surfaced in some of our dependencies

Update URL for oss analyzer per recommendations in [this issue](https://github.com/dependency-check/DependencyCheck/issues/8336) for the plugin to follow updates from Sonatype OSS Index to Sonatype Guide API.

#### Changes
* Update tomcat version
* Update log4j2 version
* Update grpc version
* Update `ossIndex.url`
