### PR TITLE
Use mirrored NVD datafeed for dependency check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,11 +44,9 @@ allprojects {
             formats = ['HTML', 'JUNIT']
             skipConfigurations = ['dedupe', 'gwtCompileClasspath', 'gwtRuntimeClasspath', 'developmentOnly']
             skipProjects = [':server:testAutomation']
-            if (project.hasProperty('nvdApiKey'))
-            {
-                nvd {
-                    apiKey = "${project.property('nvdApiKey')}"
-                }
+
+            nvd {
+                datafeedUrl = 'https://dependency-check.github.io/DependencyCheck_Builder/nvd_cache/nvdcve-{0}.json.gz'
             }
         }
     }


### PR DESCRIPTION
#### Rationale
The OWASP check is timing out regularly trying to download the NVE CVE database.
This datafeed is used by the dependency-check GitHub action so I feel that it's likely to be pretty stable.

#### Related Pull Requests
* N/A

#### Changes
* Use mirrored NVD datafeed for dependency check 
