### PR TITLE
Update to netty version 4.2.12.Final to address CVEs

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -266,8 +266,8 @@ modelContextProtocolVersion=1.1.1
 
 mssqlJdbcVersion=13.2.1.jre11
 
-# Netty - transitive dependency via azure-core-http-netty; force for CVE-2025-67735
-nettyVersion=4.2.8.Final
+# Netty - transitive dependency via azure-core-http-netty; force for CVE-2025-67735, CVE-2026-33871, CVE-2026-33870
+nettyVersion=4.2.12.Final
 # Reactor - transitive dependency via azure-core; force for version consistency across modules
 reactorCoreVersion=3.8.1
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -266,7 +266,7 @@ modelContextProtocolVersion=1.1.1
 
 mssqlJdbcVersion=13.2.1.jre11
 
-# Netty - transitive dependency via azure-core-http-netty; force for CVE-2025-67735, CVE-2026-33871, CVE-2026-33870
+# Netty - transitive dependency via azure-core-http-netty; force for CVE-2026-33871, CVE-2026-33870
 nettyVersion=4.2.12.Final
 # Reactor - transitive dependency via azure-core; force for version consistency across modules
 reactorCoreVersion=3.8.1


### PR DESCRIPTION
#### Rationale
We've got some CVE reports coming from an older netty version

#### Changes
* Update to the latest version of netty
