### PR TITLE
Add Gradle buildscript dependency for LabKey plugins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,16 @@
 import org.apache.commons.lang3.SystemUtils
-import org.labkey.gradle.plugin.NpmRun
 import org.labkey.gradle.task.PurgeNpmAlphaVersions
 import org.labkey.gradle.task.PurgeNpmVersions
 import org.labkey.gradle.task.ShowDiscrepancies
 import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.GroupNames
+
+buildscript {
+    dependencies {
+        // Not necessary but makes IntelliJ able to resolve class imports from our plugins
+        classpath "org.labkey.build:gradlePlugins:${gradlePluginsVersion}"
+    }
+}
 
 plugins {
     id "com.jfrog.artifactory" version "${artifactoryPluginVersion}" apply false


### PR DESCRIPTION
#### Rationale
IntelliJ doesn't seem to recognize buildscript dependencies that come from `settings.gradle`. This causes class imports from our gradle plugin to show up as errors in the IDE.
With some experimentation, I discovered that adding the dependency to the root `build.gradle` makes IntelliJ recognize the imports throughout the project.
In addition to getting code assistance in our Gradle files, this will prevent IntelliJ's "Optimize Imports" from removing `org.labkey.gradle.util.ExternalDependency` from files that need it.

Before:
<img width="409" height="52" alt="image" src="https://github.com/user-attachments/assets/519b8a7f-6914-44ca-8172-9ac2528e1adf" />

After:
<img width="409" height="52" alt="image" src="https://github.com/user-attachments/assets/4394c0b9-1b1f-4ea0-b14b-1fafe00ce3b1" />

#### Related Pull Requests
* N/A

#### Changes
* Add Gradle buildscript dependency for LabKey plugins
