### PR TITLE
Update dependencies for 26.5

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -201,8 +201,8 @@ intellijKotlinVersion=2.3.10
 
 # Update the three Jackson dependency versions below in tandem, unless one gets a patch release out-of-sync with the others
 jacksonVersion=2.21.2
-jacksonDatabindVersion=2.21.0
-jacksonJaxrsBaseVersion=2.21.0
+jacksonDatabindVersion=2.21.2
+jacksonJaxrsBaseVersion=2.21.2
 
 # Note the inconsistent version numbering for "annotations"... it no longer matches the above
 jacksonAnnotationsVersion=2.21

--- a/gradle.properties
+++ b/gradle.properties
@@ -60,7 +60,7 @@ windowsProteomicsBinariesVersion=1.0
 artifactoryPluginVersion=5.2.5
 gradleNodePluginVersion=7.1.0
 gradlePluginsVersion=8.0.0
-owaspDependencyCheckPluginVersion=12.2.0
+owaspDependencyCheckPluginVersion=12.2.1
 
 # Versions of node and npm to use during the build. If set, these versions
 # will be downloaded and used. If not set, the existing local installations will be used
@@ -114,14 +114,14 @@ azureIdentityVersion=1.18.2
 batikVersion=1.19
 
 # sync with Tika version (or later)
-bouncycastlePgpVersion=1.83
-bouncycastleVersion=1.83
+bouncycastlePgpVersion=1.84
+bouncycastleVersion=1.84
 
 cglibNodepVersion=2.2.3
 
 checkerQualVersion=3.53.0
 
-commonmarkVersion=0.27.1
+commonmarkVersion=0.28.0
 
 # the beanutils version is not the default version brought from commons-validator and/or commons-digester
 # in the :server:api module but is required for some of our code to compile
@@ -143,7 +143,7 @@ commonsTextVersion=1.15.0
 commonsValidatorVersion=1.10.1
 commonsVfs2Version=2.10.0
 
-datadogVersion=1.60.1
+datadogVersion=1.61.0
 
 dom4jVersion=2.2.0
 
@@ -161,10 +161,10 @@ fopVersion=2.11
 googleApiVersion=2.47.0
 googleAuthVersion=1.40.0
 googleAutoValueAnnotationsVersion=1.10.4
-googleErrorProneAnnotationsVersion=2.48.0
+googleErrorProneAnnotationsVersion=2.49.0
 googleHttpClientVersion=2.1.0
 googleOauthClientVersion=1.39.0
-googleProtocolBufVersion=3.25.8
+googleProtocolBufVersion=3.25.9
 
 graphSupportVersion=1.5.2
 
@@ -176,7 +176,7 @@ gsonVersion=2.8.9
 
 grpcVersion=1.80.0
 
-guavaVersion=33.5.0-jre
+guavaVersion=33.6.0-jre
 
 # Note: You won't find usages in the product sources; this property is used by the gradle plugin.
 gwtVersion=2.13.0
@@ -191,7 +191,7 @@ hamcrestVersion=2.2
 htsjdkVersion=4.3.0
 
 httpclient5Version=5.5.2
-httpcore5Version=5.4.1
+httpcore5Version=5.4.2
 
 # Not used directly, but these are widely used transitive dependencies
 httpclientVersion=4.5.14
@@ -200,7 +200,7 @@ httpcoreVersion=4.4.16
 intellijKotlinVersion=2.3.10
 
 # Update the three Jackson dependency versions below in tandem, unless one gets a patch release out-of-sync with the others
-jacksonVersion=2.21.0
+jacksonVersion=2.21.2
 jacksonDatabindVersion=2.21.0
 jacksonJaxrsBaseVersion=2.21.0
 
@@ -208,7 +208,7 @@ jacksonJaxrsBaseVersion=2.21.0
 jacksonAnnotationsVersion=2.21
 
 # Spring Boot brings in a transitive dependency on Jackson 3.x. It has changed package names and can coexist with Jackson 2.x.
-jackson3Version=3.1.0
+jackson3Version=3.1.1
 
 # The Jakarta Activation API version that Angus Activation implements. Keep in sync with angusActivationVersion (above).
 jakartaActivationApiVersion=2.1.4
@@ -225,7 +225,7 @@ jaxbOldVersion=2.3.3
 
 # All other direct and indirect uses of JAXB use the current, jakarta-packaged versions
 jaxbApiVersion=4.0.5
-jaxbVersion=4.0.6
+jaxbVersion=4.0.7
 
 jaxrpcVersion=1.1
 
@@ -239,7 +239,7 @@ jmockVersion=2.6.0
 # Transitive dependency via azure-identity and docker; force for consistency
 jnaVersion=5.18.1
 
-jodaTimeVersion=2.14.0
+jodaTimeVersion=2.14.1
 
 # brought in transitively by Cloud, FileTransfer, SequenceAnalysis, etc. Need to resolve consistently
 jsr305Version=3.0.2
@@ -256,7 +256,7 @@ kaptchaVersion=2.3
 
 log4j2Version=2.25.4
 
-lombokVersion=1.18.42
+lombokVersion=1.18.44
 
 luceneVersion=10.4.0
 
@@ -266,7 +266,7 @@ microsoftGraphVersion=6.59.0
 # Spring-AI dependency that's showing a CVE
 modelContextProtocolVersion=1.1.1
 
-mssqlJdbcVersion=13.2.1.jre11
+mssqlJdbcVersion=13.4.0.jre11
 
 # Netty - transitive dependency via azure-core-http-netty; force to mitigate multiple CVEs in older versions
 nettyVersion=4.2.12.Final
@@ -280,7 +280,7 @@ opencsvVersion=2.3
 openTracingVersion=0.33.0
 
 # sync with version Tika ships
-pdfboxVersion=3.0.4
+pdfboxVersion=3.0.7
 
 # sync with version Tika ships
 poiVersion=5.5.1
@@ -315,7 +315,7 @@ springBootVersion=4.0.5
 springVersion=7.0.6
 springAiVersion=2.0.0-M4
 
-sqliteJdbcVersion=3.51.2.0
+sqliteJdbcVersion=3.53.0.0
 
 # NLP and SAML bring stax2-api in as a transitive dependency but with very different versions. We force the later version.
 stax2ApiVersion=4.2.2
@@ -323,7 +323,7 @@ stax2ApiVersion=4.2.2
 thumbnailatorVersion=0.4.21
 
 # used for tika-core in API and tika-parsers in search
-tikaVersion=3.2.3
+tikaVersion=3.3.0
 
 # sync with Tika
 tukaaniXZVersion=1.12


### PR DESCRIPTION
#### Rationale
Various dependencies have newer versions.

#### Changes
* Update various dependencies
