### PR TITLE
Upgrade to Spring AI 2.0.0-M5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -352,9 +352,6 @@ allprojects {
                     force "org.springframework:spring-messaging:${springVersion}"
                     force "org.springframework:spring-webflux:${springVersion}"
 
-                    // spring-ai dependency. Force to mitigate a CVE.
-                    force "io.modelcontextprotocol.sdk:mcp:${modelContextProtocolVersion}"
-
                     // Force consistency between pipeline's ActiveMQ and cloud's jClouds dependencies
                     force "javax.annotation:javax.annotation-api:${javaxAnnotationVersion}"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -291,9 +291,9 @@ slf4jLog4jApiVersion=2.0.17
 snappyJavaVersion=1.1.10.8
 
 # Also, update apacheTomcatVersion above to match Spring Boot's Tomcat dependency version
-springBootVersion=4.0.5
+springBootVersion=4.0.6
 # This usually matches the Spring Framework version dictated by springBootVersion
-springVersion=7.0.6
+springVersion=7.0.7
 springAiVersion=2.0.0-M5
 
 sqliteJdbcVersion=3.51.1.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -252,9 +252,6 @@ lombokVersion=1.18.42
 
 luceneVersion=10.3.2
 
-# Spring-AI dependency that's showing a CVE
-modelContextProtocolVersion=1.1.1
-
 mssqlJdbcVersion=13.2.1.jre11
 
 objenesisVersion=1.0
@@ -297,7 +294,7 @@ snappyJavaVersion=1.1.10.8
 springBootVersion=4.0.5
 # This usually matches the Spring Framework version dictated by springBootVersion
 springVersion=7.0.6
-springAiVersion=2.0.0-M4
+springAiVersion=2.0.0-M5
 
 sqliteJdbcVersion=3.51.1.0
 


### PR DESCRIPTION
#### Rationale
Latest

#### Related Pull Requests
* https://github.com/LabKey/premiumModules/pull/536

#### Changes
* Bump Spring AI to 2.0.0-M5
* Remove force for MCP library; accept the version that Spring AI pulls in.