### PR TITLE
Remove errant MSSQL JDBC property

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -266,8 +266,6 @@ nettyVersion=4.2.12.Final
 # Reactor - transitive dependency via azure-core; force for version consistency across modules
 reactorCoreVersion=3.8.1
 
-mssqlJdbcVersion=13.2.1.jre11
-
 objenesisVersion=1.0
 
 opencsvVersion=2.3


### PR DESCRIPTION
#### Rationale
Looks like yesterday's merge forward brought in a duplicate, older `mssqlJdbcVersion` property

#### Related Pull Requests
* https://github.com/LabKey/server/pull/1364