### PR TITLE
Upgrade Rhino to 1.9.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -288,6 +288,8 @@ reflectionsVersion=0.10.2
 
 rforgeVersion=0.6-8.1
 
+rhinoVersion=1.9.1
+
 # sync with Tika version
 romeVersion=2.1.0
 


### PR DESCRIPTION
#### Rationale
Our current Rhino version (1.7R3) is almost 15 years old and lacks support for modern JavaScript. https://github.com/LabKey/internal-issues/issues/724

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/7658