### PR TITLE
Issue 1090: Gradle plugins built with plugin validation.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
     id "com.jfrog.artifactory" version "${artifactoryPluginVersion}" apply false
     id "com.github.node-gradle.node" version "${gradleNodePluginVersion}" apply false
     id "org.owasp.dependencycheck" version "${owaspDependencyCheckPluginVersion}" apply false
-//    id "com.github.ben-manes.versions" version "0.39.0"
+    id "com.github.ben-manes.versions" version "0.54.0"
     id "org.labkey.build.multiGit"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -586,7 +586,7 @@ project.tasks.register('ijConfigure') {
         task.dependsOn(project.tasks.ijRunConfigurationsSetup)
 }
 
-if (project.hasProperty('artifactory_contextUrl') && project.hasProperty('artifactory_user') && project.hasProperty('artifactory_password'))
+if (BuildUtils.hasArtifactoryProperties(project as Project))
 {
     project.tasks.register('purgeNpmAlphaVersions', PurgeNpmAlphaVersions) {
         group = GroupNames.NPM_RUN

--- a/gradle.properties
+++ b/gradle.properties
@@ -56,7 +56,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=5.2.5
 gradleNodePluginVersion=7.1.0
-gradlePluginsVersion=8.2.0-pluginValidation-SNAPSHOT
+gradlePluginsVersion=8.2.0
 owaspDependencyCheckPluginVersion=12.2.2
 
 # Versions of node and npm to use during the build. If set, these versions

--- a/gradle.properties
+++ b/gradle.properties
@@ -56,7 +56,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=5.2.5
 gradleNodePluginVersion=7.1.0
-gradlePluginsVersion=8.1.0
+gradlePluginsVersion=8.2.0-pluginValidation-SNAPSHOT
 owaspDependencyCheckPluginVersion=12.2.2
 
 # Versions of node and npm to use during the build. If set, these versions


### PR DESCRIPTION
#### Rationale
Issue [1090](https://github.com/LabKey/internal-issues/issues/1090)

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/244

#### Changes
* Gradle plugin version update
* Use new `BuildUtils` method
* Enable and update the versions plugin. (It seems to run in less than infinite time now.)
