### PR TITLE
Update Netty

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -262,11 +262,9 @@ microsoftGraphVersion=6.59.0
 mssqlJdbcVersion=13.4.0.jre11
 
 # Netty - transitive dependency via azure-core-http-netty; force for CVE-2026-33871, CVE-2026-33870
-nettyVersion=4.2.12.Final
+nettyVersion=4.2.13.Final
 # Reactor - transitive dependency via azure-core; force for version consistency across modules
 reactorCoreVersion=3.8.1
-
-mssqlJdbcVersion=13.2.1.jre11
 
 objenesisVersion=1.0
 


### PR DESCRIPTION
#### Rationale
Most recent Netty version. Note: this dependency is not present in 26.3 (it's a graphMailTransport dependency, new for 26.4), hence the merge to 26.5.

Also, remove errant duplicate `mssqlJdbc` property.