### PR TITLE
Force consistent version of log4j-slf4j-impl

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -221,6 +221,8 @@ allprojects {
                     force "org.apache.logging.log4j:log4j-core:${log4j2Version}"
                     force "org.apache.logging.log4j:log4j-api:${log4j2Version}"
                     force "org.apache.logging.log4j:log4j-1.2-api:${log4j2Version}"
+                    // brought in by SequenceAnalysis, jbrowse
+                    force "org.apache.logging.log4j:log4j-slf4j2-impl:${log4j2Version}"
                     force "org.apache.commons:commons-vfs2:${commonsVfs2Version}"
                     // force version for consistency with saml, query, LDK, and pipeline
                     force "commons-lang:commons-lang:${commonsLangVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -222,7 +222,7 @@ allprojects {
                     force "org.apache.logging.log4j:log4j-api:${log4j2Version}"
                     force "org.apache.logging.log4j:log4j-1.2-api:${log4j2Version}"
                     // brought in by SequenceAnalysis, jbrowse
-                    force "org.apache.logging.log4j:log4j-slf4j2-impl:${log4j2Version}"
+                    force "org.apache.logging.log4j:log4j-slf4j-impl:${log4j2Version}"
                     force "org.apache.commons:commons-vfs2:${commonsVfs2Version}"
                     // force version for consistency with saml, query, LDK, and pipeline
                     force "commons-lang:commons-lang:${commonsLangVersion}"


### PR DESCRIPTION
#### Rationale
biojava (SequenceAnalysis dependency) pulls in an old version of log4j-slf4j-impl