### PR TITLE
Add some instructions for Claude regarding accessibility reviews

### DIFF
--- a/.claude/commands/review-local.md
+++ b/.claude/commands/review-local.md
@@ -56,6 +56,11 @@ Compare what the code *actually does* (from Phase 2) against what it *should do*
 - Are there other places in the codebase that should have been updated alongside this change?
 - Are tests updated to cover the new behavior?
 
+## Phase 6: Accessibility
+
+- Are there missing labels, empty buttons, missing alt text, missing or inappropriate tab indexes, or other problems that make the new functionality 
+not accessible to all users and prevent us from being WCAG 2.2 A and AA compliant?
+
 ---
 
 ## Output Format

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -47,6 +47,11 @@ Compare what the code *actually does* (from Phase 2) against what it *should do*
 - Are there other places in the codebase that should have been updated alongside this change?
 - Are tests updated to cover the new behavior?
 
+## Phase 6: Accessibility 
+
+- Are there missing labels, empty buttons, missing alt text, missing or inappropriate tab indexes, or other problems that make the new functionality
+  not accessible to all users and prevent us from being WCAG 2.2 A and AA compliant?
+
 ---
 
 ## Output Format

--- a/.claude/skills/wcag-compliance/wcag-22-checklist.md
+++ b/.claude/skills/wcag-compliance/wcag-22-checklist.md
@@ -193,6 +193,7 @@ These patterns are common in the LabKey codebase and deserve extra attention:
 - Check `Modal`/`ModalDialog` components trap focus and are dismissible via Escape.
 - Ensure `Grid`/`QueryGrid` table components use proper `<table>` semantics with headers.
 - Check custom dropdown/select components for keyboard navigation (arrow keys, Escape, Enter).
+- Ensure tags other than buttons that have an `onClick` include an `onKeyDown` handler
 
 ### JSP Pages
 - Verify `<labkey:form>` and `<labkey:input>` render with proper label associations.


### PR DESCRIPTION
#### Rationale
Having gone through a round of fixing up various accessibility issues in our apps. we want Claude to review new functionality for accessibility impact, so we add some general instructions in the review commands. I've not tried this on a branch that wasn't specifically for addressing accessibility issues.

@labkey-jeckels This may be made obsolete by the changes in your other branch, in which case I can close this. 

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Update review commands with an Accessibility phase.
* Update wcag checklist with specifics about callbacks.
