### PR TITLE
Latest Spring AI milestone release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -294,7 +294,7 @@ snappyJavaVersion=1.1.10.8
 springBootVersion=4.0.6
 # This usually matches the Spring Framework version dictated by springBootVersion
 springVersion=7.0.7
-springAiVersion=2.0.0-M6
+springAiVersion=2.0.0-M8
 
 sqliteJdbcVersion=3.51.1.0
 


### PR DESCRIPTION
#### Rationale
Getting closer to GA

Pulls in `mcp-2.0.0-M8`, which does not fix the issue we reported