### PR TITLE
Add new Issue pattern to reference Kanban issues

### DIFF
--- a/.idea/configTemplates/vcs.xml
+++ b/.idea/configTemplates/vcs.xml
@@ -29,6 +29,10 @@
           <option name="issueRegexp" value="(GitHub Issue|GH Issue)( +#?)([0-9]+)" />
           <option name="linkRegexp" value="https://github.com/LabKey/internal-issues/issues/$3" />
         </IssueNavigationLink>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="(Kanban|Kanban Issue)( +#)([0-9]+)" />
+          <option name="linkRegexp" value="https://github.com/LabKey/kanban/issues/$3" />
+        </IssueNavigationLink>
       </list>
     </option>
   </component>


### PR DESCRIPTION
#### Rationale
To help give more context for issue-level stories that are worked on without an issue in the GH Issues list, it's handy to be able to autolink to the kanban issue.

#### Changes
* Update the template for `vcs.xml` to add a new pattern to link to the kanban issues as appropriate.
