### PR TITLE
Bump Netty to 4.2.15.Final to patch DNS cache-poisoning CVEs

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -259,8 +259,8 @@ microsoftGraphVersion=6.65.0
 
 mssqlJdbcVersion=13.4.0.jre11
 
-# Netty - transitive dependency via azure-core-http-netty; force for CVE-2026-33871, CVE-2026-33870
-nettyVersion=4.2.14.Final
+# Netty - transitive dependency via azure-core-http-netty; force for CVE-2026-33871, CVE-2026-33870, plus CVE-2026-45674 and CVE-2026-47691 (and 20 related) fixed in 4.2.15.Final
+nettyVersion=4.2.15.Final
 # Reactor - transitive dependency via azure-core; force for version consistency across modules
 reactorCoreVersion=3.8.1
 


### PR DESCRIPTION
## Rationale

The OWASP dependency-check report flagged Netty 4.2.14.Final (pulled in transitively via azure-core-http-netty) with 22 active CVEs, including two CRITICAL (CVSS 10.0) DNS cache-poisoning issues in `io.netty.resolver.dns.DnsResolveContext` — CVE-2026-45674 (CNAME bailiwick validation) and CVE-2026-47691 (NS record bailiwick validation) — plus 20 related HIGH/MEDIUM advisories (Redis/HAProxy memory leaks, HTTP/3 and QUIC issues, IPv6 subnet-filter bypass). All are fixed in Netty 4.2.15.Final.

## Related Pull Requests

None.

## Changes

- Bump `nettyVersion` from 4.2.14.Final to 4.2.15.Final in `gradle.properties`; the root `build.gradle` resolutionStrategy interpolates this property, so all forced Netty submodules move to the patched release.