### PR TITLE
Gradle 9.6.0 and gradlePluginsVersion update

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -56,7 +56,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=5.2.5
 gradleNodePluginVersion=7.1.0
-gradlePluginsVersion=9.0.0
+gradlePluginsVersion=9.1.0-gradle960-SNAPSHOT
 owaspDependencyCheckPluginVersion=12.2.2
 
 # Versions of node and npm to use during the build. If set, these versions

--- a/gradle.properties
+++ b/gradle.properties
@@ -56,7 +56,7 @@ windowsProteomicsBinariesVersion=1.0
 # The current version numbers for the gradle plugins.
 artifactoryPluginVersion=5.2.5
 gradleNodePluginVersion=7.1.0
-gradlePluginsVersion=9.1.0-gradle960-SNAPSHOT
+gradlePluginsVersion=9.1.0
 owaspDependencyCheckPluginVersion=12.2.2
 
 # Versions of node and npm to use during the build. If set, these versions

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500


### PR DESCRIPTION
#### Rationale
#### Rationale
[Gradle 9.6.0 ](https://docs.gradle.org/9.6.0/release-notes.html) is the latest and it comes with a [deprecation of certain patterns for getting properties](https://docs.gradle.org/9.6.0/release-notes.html#build-authoring-improvements)

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/247

#### Changes
* gradlePluginsVersion update
* Gradle version update
