### PR TITLE
Remove Scrumwise issue navigation link from IDE config template

### DIFF
--- a/.idea/configTemplates/vcs.xml
+++ b/.idea/configTemplates/vcs.xml
@@ -18,10 +18,6 @@
           <option name="linkRegexp" value="https://www.labkey.org/issues/home/Developer/issues/details.view?issueId=$3" />
         </IssueNavigationLink>
         <IssueNavigationLink>
-          <option name="issueRegexp" value="(Epic|Story|Item)( +#?)([0-9]+)" />
-          <option name="linkRegexp" value="https://www.scrumwise.com/scrum/#/backlog-item/$3" />
-        </IssueNavigationLink>
-        <IssueNavigationLink>
           <option name="issueRegexp" value="^([0-9]+) ?:" />
           <option name="linkRegexp" value="https://www.labkey.org/issues/home/Developer/issues/details.view?issueId=$1" />
         </IssueNavigationLink>


### PR DESCRIPTION
## Rationale

Pretty sure we're totally done with Scrumwise, so any of these links would just be broken. This removes the `Epic|Story|Item` `IssueNavigationLink` that pointed at scrumwise.com from the IDE-generated VCS config template.

## Related Pull Requests

None.

## Changes

- Drop the Scrumwise `IssueNavigationLink` from `.idea/configTemplates/vcs.xml`.