### PR TITLE
Remove default pull request template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,8 +1,0 @@
-#### Rationale
-<!-- Rationale describing why this pull request is needed, what behavior it's adding/changing/removing, etc. (replace this comment) -->
-
-#### Related Pull Requests
-* <!-- list of links to related pull requests (replace this comment) -->
-
-#### Changes
-* <!-- list of descriptions of changes that are worth noting (replace this comment) -->


### PR DESCRIPTION
### Rationale

Removes this repository's default pull request template (`pull_request_template.md`).

### Related Pull Requests

- LabKey/server, LabKey/nbconvert-service, LabKey/distributions, LabKey/targetedms — same change on branch `fb_remove_pr_template`.

### Changes

- Delete `pull_request_template.md`.