### PR TITLE
Address OWASP dependency-check CVEs in Jackson and Kotlin

### DIFF
--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -316,4 +316,16 @@
         <cve>CVE-2025-15104</cve>
     </suppress>
 
+    <!--
+    CVE-2026-53914 is in the Kotlin compiler's build-cache deserialization. We don't compile Kotlin or use the Kotlin build
+    cache; these jars are only transitive runtime dependencies of OkHttp (via the Duo SDK in mfa, and TCRdb). Not applicable.
+    -->
+    <suppress>
+        <notes><![CDATA[
+   file names: kotlin-reflect, kotlin-stdlib, kotlin-stdlib-jdk7, kotlin-stdlib-jdk8
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/.*@.*$</packageUrl>
+        <cve>CVE-2026-53914</cve>
+    </suppress>
+
 </suppressions>

--- a/gradle.properties
+++ b/gradle.properties
@@ -195,15 +195,15 @@ httpcoreVersion=4.4.16
 intellijKotlinVersion=2.3.10
 
 # Update the three Jackson dependency versions below in tandem, unless one gets a patch release out-of-sync with the others
-jacksonVersion=2.21.0
-jacksonDatabindVersion=2.21.0
-jacksonJaxrsBaseVersion=2.21.0
+jacksonVersion=2.21.4
+jacksonDatabindVersion=2.21.4
+jacksonJaxrsBaseVersion=2.21.4
 
 # Note the inconsistent version numbering for "annotations"... it no longer matches the above
 jacksonAnnotationsVersion=2.21
 
 # Spring Boot brings in a transitive dependency on Jackson 3.x. It has changed package names and can coexist with Jackson 2.x.
-jackson3Version=3.1.0
+jackson3Version=3.1.4
 
 # The Jakarta Activation API version that Angus Activation implements. Keep in sync with angusActivationVersion (above).
 jakartaActivationApiVersion=2.1.4


### PR DESCRIPTION
## Rationale

The 26.3 OWASP Dependency Check build flagged 18 findings: seven CVEs (CVE-2026-54512 through CVE-2026-54518) against each of Jackson 2.x (com.fasterxml.jackson.core:jackson-databind 2.21.0) and Jackson 3.x (tools.jackson.core:jackson-databind 3.1.0), plus CVE-2026-53914 against the transitive Kotlin jars.

## Related Pull Requests

None.

## Changes

- Bump Jackson 2.x (jacksonVersion, jacksonDatabindVersion, jacksonJaxrsBaseVersion) to 2.21.4 and jackson3Version to 3.1.4.
- Suppress CVE-2026-53914 for the transitive Kotlin jars (not applicable: LabKey compiles no Kotlin; the jars are transitive OkHttp runtime deps).