### PR TITLE
Update tracked third-party dependency versions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -92,9 +92,9 @@ antVersion=1.10.17
 antlrST4Version=4.3.4
 
 #Unifying version used by DISCVR and Premium
-apacheDirectoryVersion=2.1.7
+apacheDirectoryVersion=2.1.8
 #Transitive dependency of Apache directory
-apacheMinaVersion=2.2.7
+apacheMinaVersion=2.2.9
 
 # Usually matches the version specified as a Spring Boot dependency (see springBootVersion below)
 apacheTomcatVersion=11.0.22
@@ -107,7 +107,7 @@ asmVersion=9.10
 awsSdkVersion=2.29.50
 
 # Microsoft library for sending OAuth2-authenticated notification emails via the Microsoft Graph API
-azureIdentityVersion=1.18.3
+azureIdentityVersion=1.18.4
 
 # Apache Batik -- Batik version needs to be compatible with Apache FOP, but we need to pull in batik-codec separately
 batikVersion=1.19
@@ -120,7 +120,7 @@ cglibNodepVersion=2.2.3
 
 checkerQualVersion=3.53.0
 
-commonmarkVersion=0.28.0
+commonmarkVersion=0.29.0
 
 # the beanutils version is not the default version brought from commons-validator and/or commons-digester
 # in the :server:api module but is required for some of our code to compile
@@ -135,14 +135,14 @@ commonsDiscoveryVersion=0.2
 commonsIoVersion=2.22.0
 commonsLang3Version=3.20.0
 commonsLangVersion=2.6
-commonsLoggingVersion=1.3.6
+commonsLoggingVersion=1.4.0
 commonsMath3Version=3.6.1
 commonsPoolVersion=1.6
 commonsTextVersion=1.15.0
 commonsValidatorVersion=1.10.1
 commonsVfs2Version=2.10.0
 
-datadogVersion=1.62.0
+datadogVersion=1.63.2
 
 dom4jVersion=2.2.0
 
@@ -160,13 +160,13 @@ fopVersion=2.11
 googleApiVersion=2.47.0
 googleAuthVersion=1.40.0
 googleAutoValueAnnotationsVersion=1.10.4
-googleErrorProneAnnotationsVersion=2.49.0
-googleHttpClientVersion=2.1.0
+googleErrorProneAnnotationsVersion=2.50.0
+googleHttpClientVersion=2.1.1
 googleOauthClientVersion=1.39.0
 googleProtocolBufVersion=3.25.9
 
 graphSupportVersion=1.5.2
-grpcVersion=1.81.0
+grpcVersion=1.82.1
 
 # Cloud and SequenceAnalysis bring gson in as a transitive dependency.
 # We resolve to the later version here to keep things consistent
@@ -185,7 +185,7 @@ hamcrestVersion=2.2
 htsjdkVersion=4.3.0
 
 httpclient5Version=5.5.2
-httpcore5Version=5.4.2
+httpcore5Version=5.4.3
 
 # Not used directly, but these are widely used transitive dependencies
 httpclientVersion=4.5.14
@@ -219,7 +219,7 @@ jaxbOldVersion=2.3.3
 
 # All other direct and indirect uses of JAXB use the current, jakarta-packaged versions
 jaxbApiVersion=4.0.5
-jaxbVersion=4.0.8
+jaxbVersion=4.0.9
 
 jaxrpcVersion=1.1
 
@@ -252,7 +252,7 @@ log4j2Version=2.26.0
 
 lombokVersion=1.18.46
 
-luceneVersion=10.4.0
+luceneVersion=10.5.0
 
 # Microsoft library for sending OAuth2-authenticated notification emails via the Microsoft Graph API
 microsoftGraphVersion=6.65.0
@@ -278,7 +278,7 @@ poiVersion=5.5.1
 
 pollingWatchVersion=0.2.0
 
-postgresqlDriverVersion=42.7.11
+postgresqlDriverVersion=42.7.12
 
 quartzVersion=2.5.2
 
@@ -306,7 +306,7 @@ springBootVersion=4.1.0
 springVersion=7.0.8
 springAiVersion=2.0.0
 
-sqliteJdbcVersion=3.53.1.0
+sqliteJdbcVersion=3.53.2.0
 
 # SAML brings stax2-api in as a transitive dependency. We force the latest version.
 stax2ApiVersion=4.2.2


### PR DESCRIPTION
## Rationale

Routine upkeep of the third-party dependency versions catalogued in the Core Infrastructure "Upgrade Dependencies" doc, keeping us current for security and bug fixes. Scope is limited to doc-tracked dependencies with clean, low-risk upgrades; forced-for-consistency transitives and caveated upgrades were deliberately excluded and left for separate, individually-tested changes.

## Related Pull Requests

None.

## Changes

- Bump 14 doc-tracked dependency versions in `gradle.properties`: apacheDirectory 2.1.7→2.1.8, apacheMina 2.2.7→2.2.9, azureIdentity 1.18.3→1.18.4, commonmark 0.28.0→0.29.0, commonsLogging 1.3.6→1.4.0, datadog 1.62.0→1.63.2, googleErrorProneAnnotations 2.49.0→2.50.0, googleHttpClient 2.1.0→2.1.1, grpc 1.81.0→1.82.1, httpcore5 5.4.2→5.4.3, jaxb 4.0.8→4.0.9, lucene 10.4.0→10.5.0, postgresqlDriver 42.7.11→42.7.12, sqliteJdbc 3.53.1.0→3.53.2.0.