### PR TITLE
Update Tomcat, HttpCore5, Jackson for OWASP CVE remediation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -246,6 +246,8 @@ allprojects {
                     // force version for cloud, docker, fileTransfer, googledrive, tcrb, wnprc_ehr
                     force "org.apache.httpcomponents:httpcore:${httpcoreVersion}"
                     force "org.apache.httpcomponents.core5:httpcore5:${httpcore5Version}"
+                    // httpcore5-h2 arrives transitively (not pinned before); force to the fixed version for CVE-2026-54399
+                    force "org.apache.httpcomponents.core5:httpcore5-h2:${httpcore5Version}"
                     // force version for cloud, docker, fileTransfer, googledrive, tcrb, wnprc_ehr
                     force "org.apache.httpcomponents:httpclient:${httpclientVersion}"
                     force "org.apache.httpcomponents.client5:httpclient5:${httpclient5Version}"

--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -437,5 +437,25 @@
         <packageUrl regex="true">^pkg:maven/com\.networknt/json-schema-validator@.*$</packageUrl>
         <cve>CVE-2025-15104</cve>
     </suppress>
+    <!--
+    CVE-2026-54399 is scoped to Apache HttpComponents Core 5.x only. The classic httpcore 4.x line (org.apache.httpcomponents:httpcore) is EOL, is not listed as affected, and has no fixed 4.4.x release. False positive for the 4.x artifact.
+    -->
+    <suppress>
+        <notes><![CDATA[
+    file name: httpcore-4.4.16.jar (classic 4.x, not affected by the 5.x-scoped CVE)
+    ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.httpcomponents/httpcore@.*$</packageUrl>
+        <cve>CVE-2026-54399</cve>
+    </suppress>
+    <!--
+    CVE-2026-53914 is an unsafe-deserialization flaw in Kotlin build-cache metadata (build tooling); JetBrains (the CNA) scores it 6.7 MEDIUM (AV:L/AC:H/PR:H), not NVD's auto-assigned 9.8, and the advisory names no runtime package. The shipped Kotlin runtime jars (kotlin-stdlib, kotlin-reflect, etc.) do not execute the affected code, and no stable fixed release exists yet (only 2.4.20-Beta1). False positive for the runtime artifacts.
+    -->
+    <suppress>
+        <notes><![CDATA[
+    Kotlin runtime jars (kotlin-stdlib, kotlin-reflect, kotlin-stdlib-jdk7/jdk8) - build-tooling CVE, not applicable to runtime.
+    ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/.*@.*$</packageUrl>
+        <cve>CVE-2026-53914</cve>
+    </suppress>
 
 </suppressions>

--- a/gradle.properties
+++ b/gradle.properties
@@ -96,8 +96,8 @@ apacheDirectoryVersion=2.1.7
 #Transitive dependency of Apache directory
 apacheMinaVersion=2.2.7
 
-# Usually matches the version specified as a Spring Boot dependency (see springBootVersion below)
-apacheTomcatVersion=11.0.22
+# Intentionally held ahead of the Tomcat version Spring Boot manages (SB 4.0.6 -> 11.0.21, 4.0.7 -> 11.0.22, both affected by CVE-2026-53434/-55276 et al.). Keep at 11.0.23+ until a Spring Boot release ships a patched Tomcat. (see springBootVersion below)
+apacheTomcatVersion=11.0.23
 
 # (mothership) -> json-path -> json-smart -> accessor-smart
 # (core) -> graalvm
@@ -185,7 +185,7 @@ hamcrestVersion=2.2
 htsjdkVersion=4.3.0
 
 httpclient5Version=5.5.2
-httpcore5Version=5.4.2
+httpcore5Version=5.4.3
 
 # Not used directly, but these are widely used transitive dependencies
 httpclientVersion=4.5.14
@@ -194,9 +194,9 @@ httpcoreVersion=4.4.16
 intellijKotlinVersion=2.3.10
 
 # Update the three Jackson dependency versions below in tandem, unless one gets a patch release out-of-sync with the others
-jacksonVersion=2.21.4
-jacksonDatabindVersion=2.21.4
-jacksonJaxrsBaseVersion=2.21.4
+jacksonVersion=2.21.5
+jacksonDatabindVersion=2.21.5
+jacksonJaxrsBaseVersion=2.21.5
 
 # Note the inconsistent version numbering for "annotations"... it no longer matches the above
 jacksonAnnotationsVersion=2.21
@@ -300,7 +300,7 @@ slf4jLog4jApiVersion=2.0.18
 # This is a dependency for HTSJDK. Force version for CVE-2023-43642
 snappyJavaVersion=1.1.10.8
 
-# Also, update apacheTomcatVersion above to match Spring Boot's Tomcat dependency version
+# Note: apacheTomcatVersion above is intentionally held ahead of Spring Boot's managed Tomcat for CVE remediation (see the comment there)
 springBootVersion=4.0.6
 # This usually matches the Spring Framework version dictated by springBootVersion
 springVersion=7.0.7


### PR DESCRIPTION
#### Rationale

LabKey Server's OWASP Dependency Check build is failing on develop with 124 findings, the bulk of them from a handful of vulnerable third-party dependencies. This PR clears the findings that can be resolved by version bumps/forces and suppresses two verified false positives.

#### Related Pull Requests

- LabKey/platform#7822 - companion ActiveMQ 5.19.8 bump (same OWASP remediation)
- LabKey/labkey-api-java#93 - HttpCore5 5.4.3 root fix, first link in the release chain that will clear the labkey-api-jdbc shaded-httpcore5 findings

#### Changes

- Tomcat 11.0.22 -> 11.0.23: CVE-2026-53434 and CVE-2026-55276 (CRITICAL 9.1), plus CVE-2026-53404, CVE-2026-55955, CVE-2026-55956, CVE-2026-50229
- httpcore5 5.4.2 -> 5.4.3, and a new httpcore5-h2 force at 5.4.3 (previously transitive at 5.3.6): CVE-2026-54399
- Jackson 2.21.4 -> 2.21.5 (jacksonVersion, jacksonDatabindVersion, jacksonJaxrsBaseVersion): CVE-2026-54515
- Suppress classic httpcore 4.x for CVE-2026-54399 (the CVE is scoped to HttpComponents Core 5.x; the 4.x line is EOL and unaffected)
- Suppress Kotlin runtime jars for CVE-2026-53914 (a Kotlin build-cache-metadata deserialization flaw scored 6.7 MEDIUM by JetBrains, not applicable to the shipped stdlib/reflect runtime jars)
- Update comments to document that apacheTomcatVersion is intentionally held ahead of Spring Boot's managed Tomcat

#### Not included

- The two labkey-api-jdbc shaded httpcore5 5.2.4 findings: the vulnerable httpcore5 is shaded inside the published labkey-api-jdbc-3.1.0-all.jar and cannot be overridden via resolutionStrategy. These clear once the release chain lands (labkey-api-java 7.3.0 -> labkey-api-jdbc 3.2.0 -> bump labkeyJdbcVersion here).
