### PR TITLE
Remediate CVE-2026-54399/54428 in httpcore5-h2; suppress 4.x false positive

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -248,6 +248,8 @@ allprojects {
                     // force version for cloud, docker, fileTransfer, googledrive, tcrb, wnprc_ehr
                     force "org.apache.httpcomponents:httpcore:${httpcoreVersion}"
                     force "org.apache.httpcomponents.core5:httpcore5:${httpcore5Version}"
+                    // align httpcore5-h2 with httpcore5; the transitive 5.3.6 is exposed to CVE-2026-54399/CVE-2026-54428 (fixed in 5.4.3)
+                    force "org.apache.httpcomponents.core5:httpcore5-h2:${httpcore5Version}"
                     // force version for cloud, docker, fileTransfer, googledrive, tcrb, wnprc_ehr
                     force "org.apache.httpcomponents:httpclient:${httpclientVersion}"
                     force "org.apache.httpcomponents.client5:httpclient5:${httpclient5Version}"

--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -438,14 +438,15 @@
         <cve>CVE-2025-15104</cve>
     </suppress>
     <!--
-    CVE-2026-54399 is scoped to Apache HttpComponents Core 5.x only. The classic httpcore 4.x line (org.apache.httpcomponents:httpcore) is EOL, is not listed as affected, and has no fixed 4.4.x release. False positive for the 4.x artifact.
+    CVE-2026-54399 (httpcore5 HTTP/1.1 parser) and CVE-2026-54428 (httpcore5-h2 HTTP/2 HPACK decoder) are both scoped to Apache HttpComponents Core 5.x only. The classic httpcore 4.x line (org.apache.httpcomponents:httpcore) is EOL, has no HTTP/2 module, is not listed as affected, and has no fixed 4.4.x release. False positives for the 4.x artifact.
     -->
     <suppress>
         <notes><![CDATA[
-    file name: httpcore-4.4.16.jar (classic 4.x, not affected by the 5.x-scoped CVE)
+    file name: httpcore-4.4.16.jar (classic 4.x, not affected by the 5.x-scoped CVEs)
     ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.apache\.httpcomponents/httpcore@.*$</packageUrl>
         <cve>CVE-2026-54399</cve>
+        <cve>CVE-2026-54428</cve>
     </suppress>
     <!--
     CVE-2026-53914 is in the Kotlin compiler's build-cache deserialization. We don't compile Kotlin or use the Kotlin build


### PR DESCRIPTION
## Rationale
OWASP dependency-check flagged CVE-2026-54399 (HTTP/1.1 parser DoS) and CVE-2026-54428 (HTTP/2 HPACK decoder DoS), both scoped to Apache HttpComponents Core "up to and including 5.4.2". Two things were needed: the classic httpcore 4.x artifact is not affected (4.x has no HTTP/2 module and no fixed 4.4.x release exists for these 5.x-scoped CVEs), so it is suppressed as a false positive; and the real exposure is httpcore5-h2, which was resolving transitively to 5.3.6 because the resolutionStrategy force block pinned httpcore5 and httpclient5 but not httpcore5-h2.

## Related Pull Requests
- https://github.com/LabKey/server/pull/1440

## Changes
- Force `org.apache.httpcomponents.core5:httpcore5-h2` to `httpcore5Version` (5.4.3), upgrading the transitive 5.3.6 past the vulnerable 5.4.2 ceiling and clearing both CVEs. Verified via `:server:modules:platform:api:dependencies` (`5.3.6 -> 5.4.3`).
- Suppress false positive CVE-2026-54428 on the classic httpcore 4.x artifact.

## Note on shaded copies
Shaded copies of these http5 libraries originate from labkey-api-jdbc (`:remoteapi:labkey-api-jdbc`, only wired into the build under the `all` settings/module set) and are being addressed separately. They do not appear in a `-PmoduleSet=community` scan because that project is out of scope there.

<!-- list of standard tasks (remove this comment to enable)
## Tasks 📍
- [ ] Claude Code Review
- [ ] Manual Testing
- [ ] Test Automation
- [ ] Verify Fix
-->
