### PR TITLE
Port OWASP CVE remediations to 26.3: httpcore5-h2 5.4.3, pg driver 42.7.12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -245,6 +245,8 @@ allprojects {
                     // force version for cloud, docker, fileTransfer, googledrive, tcrb, wnprc_ehr
                     force "org.apache.httpcomponents:httpcore:${httpcoreVersion}"
                     force "org.apache.httpcomponents.core5:httpcore5:${httpcore5Version}"
+                    // align httpcore5-h2 with httpcore5; the transitive 5.3.6 is exposed to CVE-2026-54399/CVE-2026-54428 (fixed in 5.4.3)
+                    force "org.apache.httpcomponents.core5:httpcore5-h2:${httpcore5Version}"
                     // force version for cloud, docker, fileTransfer, googledrive, tcrb, wnprc_ehr
                     force "org.apache.httpcomponents:httpclient:${httpclientVersion}"
                     force "org.apache.httpcomponents.client5:httpclient5:${httpclient5Version}"

--- a/dependencyCheckSuppression.xml
+++ b/dependencyCheckSuppression.xml
@@ -328,14 +328,14 @@
         <cve>CVE-2026-53914</cve>
     </suppress>
     <!--
-    CVE-2026-54399 is scoped to Apache HttpComponents Core 5.x only. The classic httpcore 4.x line (org.apache.httpcomponents:httpcore) is EOL, is not listed as affected, and has no fixed 4.4.x release. False positive for the 4.x artifact.
-    -->
+    CVE-2026-54399 (httpcore5 HTTP/1.1 parser) and CVE-2026-54428 (httpcore5-h2 HTTP/2 HPACK decoder) are both scoped to Apache HttpComponents Core 5.x only. The classic httpcore 4.x line (org.apache.httpcomponents:httpcore) is EOL, has no HTTP/2 module, is not listed as affected, and has no fixed 4.4.x release. False positives for the 4.x artifact.    -->
     <suppress>
         <notes><![CDATA[
-    file name: httpcore-4.4.16.jar (classic 4.x, not affected by the 5.x-scoped CVE)
+    file name: httpcore-4.4.16.jar (classic 4.x, not affected by the 5.x-scoped CVEs)
     ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.apache\.httpcomponents/httpcore@.*$</packageUrl>
         <cve>CVE-2026-54399</cve>
+        <cve>CVE-2026-54428</cve>
     </suppress>
     <!--
     CVE-2026-53914 is an unsafe-deserialization flaw in Kotlin build-cache metadata (build tooling); JetBrains (the CNA) scores it 6.7 MEDIUM (AV:L/AC:H/PR:H), not NVD's auto-assigned 9.8, and the advisory names no runtime package. The shipped Kotlin runtime jars (kotlin-stdlib, kotlin-reflect, etc.) do not execute the affected code, and no stable fixed release exists yet (only 2.4.20-Beta1). False positive for the runtime artifacts.

--- a/gradle.properties
+++ b/gradle.properties
@@ -268,7 +268,7 @@ poiVersion=5.4.0
 
 pollingWatchVersion=0.2.0
 
-postgresqlDriverVersion=42.7.11
+postgresqlDriverVersion=42.7.12
 
 quartzVersion=2.5.2
 


### PR DESCRIPTION
## Rationale
Ports the OWASP dependency-check CVE remediations from develop (PR #1441, branch fb_owasp_cves_20260709) onto the 26.3 release branch. The 26.3 scan flagged CVE-2026-54399 / CVE-2026-54428 (httpcore5-h2 resolving transitively to 5.3.6) and additionally CVE-2026-54291 (postgresql JDBC driver pinned at 42.7.11 — a channel-binding downgrade fixed in 42.7.12; develop was already on 42.7.12).

## Related Pull Requests
- https://github.com/LabKey/server/pull/1441

## Changes
- Force `org.apache.httpcomponents.core5:httpcore5-h2` to `httpcore5Version` (5.4.3), upgrading the transitive 5.3.6 past the vulnerable 5.4.2 ceiling (CVE-2026-54399, CVE-2026-54428).
- Bump `postgresqlDriverVersion` 42.7.11 -> 42.7.12 (CVE-2026-54291).
- Suppress the CVE-2026-54428 false positive on the classic httpcore 4.x artifact.

## Note on shaded copies
Shaded copies of these http5 libraries originate from labkey-api-jdbc and are addressed separately.
