### PR TITLE
Add nbriEHRModules to EHR test build module list

### DIFF
--- a/gradle/settings/ehr.gradle
+++ b/gradle/settings/ehr.gradle
@@ -47,6 +47,7 @@ import org.labkey.gradle.util.BuildUtils
 
 List<String> ehrModulesDirs = [
         "server/modules/johnsHopkinsEHRModules",
+        "server/modules/nbriEHRModules",
         "server/modules/nircEHRModules",
         "server/modules/onprcEHRModules",
         "server/modules/ehrModules",


### PR DESCRIPTION
## Rationale

The new nbriEHRModules repository needs to be included in the EHR TeamCity test distribution so its nbri_ehr module is built and tested.

## Related Pull Requests

- [LabKey/nbriEHRModules#1](https://github.com/LabKey/nbriEHRModules/pull/1)

## Changes

- Added server/modules/nbriEHRModules to the ehrModulesDirs list in gradle/settings/ehr.gradle.