### PR TITLE
Fast-forward for 26.7.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -45,7 +45,7 @@ buildFromSource=true
 # The default version for LabKey artifacts that are built or that we depend on.
 # override in an individual module's gradle.properties file as necessary 
 labkeyVersion=26.3-SNAPSHOT
-labkeyClientApiVersion=7.2.0
+labkeyClientApiVersion=7.3.0
 
 # Version numbers for the various binary artifacts that are included when
 # deploying via deployApp or deployDist and when creating distributions.
@@ -100,7 +100,7 @@ apacheDirectoryVersion=2.1.7
 apacheMinaVersion=2.2.7
 
 # Usually matches the version specified as a Spring Boot dependency (see springBootVersion below)
-apacheTomcatVersion=11.0.23
+apacheTomcatVersion=11.0.24
 
 # (mothership) -> json-path -> json-smart -> accessor-smart
 # (core) -> graalvm
@@ -246,7 +246,7 @@ jxlVersion=2.6.3
 
 kaptchaVersion=2.3
 
-log4j2Version=2.26.0
+log4j2Version=2.26.1
 
 lombokVersion=1.18.42
 


### PR DESCRIPTION
## Rationale
Automatic merge and version bump failed due to a merge conflict. Performing manually.