### PR TITLE
Bump nettyVersion to 4.2.16.Final

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -260,8 +260,8 @@ microsoftGraphVersion=6.65.0
 
 mssqlJdbcVersion=13.4.0.jre11
 
-# Netty - transitive dependency via azure-core-http-netty; force for CVE-2026-33871, CVE-2026-33870, plus CVE-2026-45674 and CVE-2026-47691 (and 20 related) fixed in 4.2.15.Final
-nettyVersion=4.2.15.Final
+# Netty - transitive dependency via azure-core-http-netty; force for CVE-2026-33871, CVE-2026-33870, CVE-2026-45674, CVE-2026-47691 (and 20 related) fixed in 4.2.15.Final, plus CVE-2026-44891, CVE-2026-55831, CVE-2026-55833 fixed in 4.2.16.Final
+nettyVersion=4.2.16.Final
 # Reactor - transitive dependency via azure-core; force for version consistency across modules
 reactorCoreVersion=3.8.1
 


### PR DESCRIPTION
Fixes CVE-2026-44891, CVE-2026-55831, CVE-2026-55833 flagged in TeamCity build LabKey_267Release_Premium_GitExtraPostgres/4106377.

## Rationale
TeamCity build LabKey_267Release_Premium_GitExtraPostgres/4106377 flagged netty-buffer 4.2.15.Final for CVE-2026-44891, CVE-2026-55831, and CVE-2026-55833 (all HIGH, CVSS 7.5). Fixed upstream in netty 4.2.16.Final.

## Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

## Changes
- Bump `nettyVersion` from 4.2.15.Final to 4.2.16.Final in `gradle.properties`
- OWASP dependency-check build run locally, confirmed clean


<!-- list of standard tasks (remove this comment to enable)
## Tasks 📍
- [ ] Claude Code Review
- [ ] Manual Testing
- [ ] Test Automation
- [ ] Verify Fix
-->