### PR TITLE
Use report-to exclusively in CSPs

### DIFF
--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -94,18 +94,19 @@ public class LabKeyServer
                 script-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ${SCRIPT.SOURCES} ;
                 base-uri 'self' ;
                 frame-src 'self' ${FRAME.SOURCES} ;
-                report-uri ${context.contextPath:}/admin-contentSecurityPolicyReport.api ;
+                report-to csp-report ;
             """;
+        int cspVersion = 17;
         // Add upgrade_insecure_requests substitution, frame-ancestors, and enforce version
         String enforceCsp = baseCsp + """
                 ${UPGRADE.INSECURE.REQUESTS}
                 frame-ancestors 'self' ${FRAMEANCESTORS.SOURCES} ;
-                /* cspVersion=e16 */
-            """;
+                /* cspVersion=e%d */
+            """.formatted(cspVersion);
         // Leave out upgrade_insecure_requests and frame-ancestors directives, since they produce warnings on some browsers
         String reportCsp = baseCsp + """
-                /* cspVersion=r16 */
-            """;
+                /* cspVersion=r%d */
+            """.formatted(cspVersion);
 
         application.setDefaultProperties(new HashMap<>()
              {{

--- a/server/embedded/src/org/labkey/embedded/LabKeyServer.java
+++ b/server/embedded/src/org/labkey/embedded/LabKeyServer.java
@@ -96,17 +96,16 @@ public class LabKeyServer
                 frame-src 'self' ${FRAME.SOURCES} ;
                 report-to csp-report ;
             """;
-        int cspVersion = 17;
         // Add upgrade_insecure_requests substitution, frame-ancestors, and enforce version
         String enforceCsp = baseCsp + """
                 ${UPGRADE.INSECURE.REQUESTS}
                 frame-ancestors 'self' ${FRAMEANCESTORS.SOURCES} ;
-                /* cspVersion=e%d */
-            """.formatted(cspVersion);
+                /* cspVersion=e17 */
+            """;
         // Leave out upgrade_insecure_requests and frame-ancestors directives, since they produce warnings on some browsers
         String reportCsp = baseCsp + """
-                /* cspVersion=r%d */
-            """.formatted(cspVersion);
+                /* cspVersion=r17 */
+            """;
 
         application.setDefaultProperties(new HashMap<>()
              {{


### PR DESCRIPTION
## Rationale
https://github.com/LabKey/internal-issues/issues/900

## Related Pull Requests
- https://github.com/LabKey/platform/pull/7888

## Changes
- Remove deprecated `report-uri` directive. Add `report-to` unconditionally.