### PR TITLE
Update NodeJS/NPM

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -62,8 +62,8 @@ owaspDependencyCheckPluginVersion=12.2.2
 # Versions of node and npm to use during the build. If set, these versions
 # will be downloaded and used. If not set, the existing local installations will be used
 # The version of npm corresponds to the given version of node
-npmVersion=11.13.0
-nodeVersion=24.16.0
+npmVersion=11.17.0
+nodeVersion=26.5.0
 nodeRepo=https://nodejs.org/dist
 # Directory in a project's build directory where the node binary will be placed
 nodeWorkDirectory=.node

--- a/gradle.properties
+++ b/gradle.properties
@@ -62,8 +62,8 @@ owaspDependencyCheckPluginVersion=12.2.2
 # Versions of node and npm to use during the build. If set, these versions
 # will be downloaded and used. If not set, the existing local installations will be used
 # The version of npm corresponds to the given version of node
-npmVersion=11.6.1
-nodeVersion=24.11.0
+npmVersion=11.13.0
+nodeVersion=24.16.0
 nodeRepo=https://nodejs.org/dist
 # Directory in a project's build directory where the node binary will be placed
 nodeWorkDirectory=.node

--- a/gradle.properties
+++ b/gradle.properties
@@ -63,7 +63,7 @@ owaspDependencyCheckPluginVersion=12.2.2
 # will be downloaded and used. If not set, the existing local installations will be used
 # The version of npm corresponds to the given version of node
 npmVersion=11.17.0
-nodeVersion=26.5.0
+nodeVersion=26.5.1
 nodeRepo=https://nodejs.org/dist
 # Directory in a project's build directory where the node binary will be placed
 nodeWorkDirectory=.node


### PR DESCRIPTION
#### Rationale
This updates NodeJS to the next LTS release. The following versions have been determined based on their pairing in [previous releases](https://nodejs.org/en/download/releases).

- NodeJS: `26.5.1`
- NPM: `11.17.0`

#### Previous Update
- #1213

#### Related Pull Requests
- https://github.com/LabKey/server/pull/1459
- https://github.com/LabKey/labkey-api-js/pull/223
- https://github.com/LabKey/labkey-ui-components/pull/2043
- https://github.com/LabKey/labkey-ui-premium/pull/1001
- https://github.com/LabKey/limsModules/pull/2368
- https://github.com/LabKey/platform/pull/7891
- https://github.com/LabKey/premiumModules/pull/679
- https://github.com/LabKey/clientModules/pull/131
- https://github.com/LabKey/commonAssays/pull/1047
- https://github.com/LabKey/wnprc-modules/pull/1000
- https://github.com/LabKey/snprcEHRModules/pull/972

#### Changes
- Update `gradle.properties` with the corresponding versions
